### PR TITLE
Prevent TypeError when serializing objects with circular references

### DIFF
--- a/src/serializers/json.js
+++ b/src/serializers/json.js
@@ -33,7 +33,16 @@ class JSONSerializer extends BaseSerializer {
 	 * @memberof Serializer
 	 */
 	serialize(obj) {
-		return JSON.stringify(obj);
+		const cache = new WeakSet();
+		return JSON.stringify(obj, (key, value) => {
+			if (typeof value === "object" && value !== null) {
+				if (cache.has(value)) {
+					return "[Circular]";
+				}
+				cache.add(value);
+			}
+			return value;
+		});
 	}
 
 	/**

--- a/test/unit/serializers/json.spec.js
+++ b/test/unit/serializers/json.spec.js
@@ -35,4 +35,25 @@ describe("Test JSONSerializer", () => {
 		expect(res).toEqual(obj);
 	});
 
+	it("should serialize the data contains a circular reference", () => {
+		const data = {
+			a: 5,
+			b: "Test"
+		};
+		data.c = data;
+		const obj = {
+			ver: "3",
+			sender: "test-1",
+			event: "user.created",
+			data,
+			broadcast: true
+		};
+		const s = serializer.serialize(cloneDeep(obj), P.PACKET_EVENT);
+		expect(s.length).toBe(112);
+
+		// Deserializing can't be equal to the preserialized object due to replacements
+		const res = serializer.deserialize(s, P.PACKET_EVENT);
+		expect(res).not.toEqual(obj);
+	});
+
 });


### PR DESCRIPTION
Prevents issues like #191 by replacing circular references with a string when serializing requests and responses.