### PR TITLE
Measure Latency Upon Heartbeat + New Strategy Based on Latency

### DIFF
--- a/src/registry/node-catalog.js
+++ b/src/registry/node-catalog.js
@@ -44,6 +44,7 @@ class NodeCatalog {
 
 		this.broker.localBus.on("$transporter.connected", this.startHeartbeatTimers.bind(this));
 		this.broker.localBus.on("$transporter.disconnected", this.stopHeartbeatTimers.bind(this));
+		this.broker.localBus.on("$node.pong", this.updateLatency.bind(this));
 	}
 
 	/**
@@ -283,6 +284,20 @@ class NodeCatalog {
 		} else {
 			// Unknow node. Request an INFO from node
 			this.broker.transit.discoverNode(payload.sender);
+		}
+	}
+
+	/**
+	 * Update latency in local node registry
+	 *
+	 * @param {any} payload
+	 * @memberof NodeCatalog
+	 */
+	updateLatency(payload) {
+		const node = this.get(payload.nodeID);
+
+		if (node) {
+			node.updateLatency(payload);
 		}
 	}
 

--- a/src/registry/node.js
+++ b/src/registry/node.js
@@ -37,6 +37,9 @@ class Node {
 		this.rawInfo = null;
 		this.services = [];
 
+		this.historicLatency = [];
+		this.latency = 0;
+
 		this.cpu = null;
 		this.cpuSeq = null;
 
@@ -99,6 +102,21 @@ class Node {
 		this.cpuSeq = payload.cpuSeq || 1;
 
 		this.lastHeartbeatTime = Date.now();
+	}
+
+	/**
+	 * Update latency properties
+	 *
+	 * @param {any} payload
+	 * @memberof Node
+	 */
+	updateLatency(payload) {
+		if (this.historicLatency.length > 50) this.historicLatency.unshift();
+		this.historicLatency.push(payload.elapsedTime);
+
+		this.latency = this.historicLatency.reduce(function(total, latency) {
+			return total + latency;
+		}) / this.historicLatency.length;
 	}
 
 	/**

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -42,13 +42,13 @@ const defaultOptions = {
 	requestTimeout: 0 * 1000,
 	requestRetry: 0,
 	maxCallLevel: 0,
-	heartbeatInterval: 10,
-	heartbeatTimeout: 30,
+	heartbeatInterval: 5,
+	heartbeatTimeout: 15,
 
 	disableBalancer: false,
 
 	registry: {
-		strategy: "Latency",
+		strategy: "RoundRobin",
 		preferLocal: true
 	},
 

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -42,13 +42,13 @@ const defaultOptions = {
 	requestTimeout: 0 * 1000,
 	requestRetry: 0,
 	maxCallLevel: 0,
-	heartbeatInterval: 5,
-	heartbeatTimeout: 15,
+	heartbeatInterval: 10,
+	heartbeatTimeout: 30,
 
 	disableBalancer: false,
 
 	registry: {
-		strategy: "RoundRobin",
+		strategy: "Latency",
 		preferLocal: true
 	},
 

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -11,5 +11,5 @@ module.exports = {
 	RoundRobin: require("./round-robin"),
 	Random: require("./random"),
 	CpuUsage: require("./cpu-usage"),
-	Latency: require('./latency')
+	Latency: require("./latency")
 };

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -11,4 +11,5 @@ module.exports = {
 	RoundRobin: require("./round-robin"),
 	Random: require("./random"),
 	CpuUsage: require("./cpu-usage"),
+	Latency: require('./latency')
 };

--- a/src/strategies/latency.js
+++ b/src/strategies/latency.js
@@ -1,0 +1,86 @@
+/*
+ * moleculer
+ * Copyright (c) 2018 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const _ = require("lodash");
+
+const { random } = require("lodash");
+const BaseStrategy = require("./base");
+
+/**
+ * Lowest latency invocation strategy
+ *
+ * The endpoint list is not iterated completely because it can
+ * very large. We get `sampleCount` samples from the list
+ * and select the endpoint of the lowest latency.
+ * But if we found an endpoint which has lower latency
+ * than `lowLatency` we select it.
+ *
+ * These options can be configured in broker registry options:
+ *
+ * const broker = new ServiceBroker({
+ * 	logger: true,
+ * 	registry: {
+ * 		strategy: "Latency",
+ * 		strategyOptions: {
+ * 			sampleCount: 5,
+ * 			lowLatency: 10
+ * 		}
+ * 	}
+ * });
+ *
+ * @class LatencyStrategy
+ */
+class LatencyStrategy extends BaseStrategy {
+
+	constructor(registry, broker) {
+		super(registry, broker);
+
+		this.opts = _.defaultsDeep(registry.opts.strategyOptions, {
+			sampleCount: 3,
+			lowLatency: 10
+		});
+	}
+
+	select(list) {
+		let minEp = null;
+
+		const sampleCount = this.opts.sampleCount;
+		const count = sampleCount <= 0 || sampleCount > list.length ? list.length : sampleCount;
+		for (let i = 0; i < count; i++) {
+			let ep;
+			// Get random endpoint
+			if (count == list.length) {
+				ep = list[i];
+			} else {
+				ep = list[random(0, list.length - 1)];
+			}
+			const latency = ep.node.latency;
+
+			// Check latency of endpoint
+			if (latency != 0) {
+
+				if (latency < this.opts.lowLatency)
+					return ep;
+
+				if (!minEp || latency < minEp.node.latency) {
+					minEp = ep;
+				}
+			}
+		}
+
+		// Return the lowest latancy
+		if (minEp) {
+			return minEp;
+		}
+
+		// Return a random item (no latancy data)
+		return list[random(0, list.length - 1)];
+	}
+}
+
+module.exports = LatencyStrategy;

--- a/src/transit.js
+++ b/src/transit.js
@@ -645,11 +645,14 @@ class Transit {
 	}
 
 	/**
-	 * Send a node heartbeat. It will be called with timer
+	 * Send a node heartbeat + Ping other nodes. It will be called with timer
 	 *
 	 * @memberof Transit
 	 */
 	sendHeartbeat(localNode) {
+
+		this.sendPing();
+
 		return this.publish(new Packet(P.PACKET_HEARTBEAT, null, {
 			cpu: localNode.cpu
 		})).catch(err => this.logger.error("Unable to send HEARTBEAT packet.", err));

--- a/test/integration/broker-internal.spec.js
+++ b/test/integration/broker-internal.spec.js
@@ -69,10 +69,12 @@ describe("Test internal services", () => {
 				"config": {},
 				"cpu": null,
 				"cpuSeq": null,
+				"historicLatency": [],
 				"id": "node-master",
 				"ipList": localNode.ipList,
 				"hostname": hostname(),
 				"lastHeartbeatTime": localNode.lastHeartbeatTime,
+				"latency": 0,
 				"offlineSince": null,
 				"port": null,
 				"seq": localNode.seq,
@@ -457,4 +459,3 @@ describe("Test internal services", () => {
 	});
 
 });
-

--- a/test/unit/registry/node-catalog.spec.js
+++ b/test/unit/registry/node-catalog.spec.js
@@ -31,9 +31,10 @@ describe("Test NodeCatalog constructor", () => {
 		expect(catalog.localNode.available).toBe(true);
 		expect(catalog.nodes.size).toBe(1);
 
-		expect(broker.localBus.on).toHaveBeenCalledTimes(2);
+		expect(broker.localBus.on).toHaveBeenCalledTimes(3);
 		expect(broker.localBus.on).toHaveBeenCalledWith("$transporter.connected", jasmine.any(Function));
 		expect(broker.localBus.on).toHaveBeenCalledWith("$transporter.disconnected", jasmine.any(Function));
+		expect(broker.localBus.on).toHaveBeenCalledWith("$node.pong", jasmine.any(Function));
 	});
 
 	it("should call startHeartbeatTimers & stortHeartbeatTimers", () => {
@@ -437,11 +438,13 @@ describe("Test NodeCatalog.list", () => {
 				"config": {},
 				"cpu": null,
 				"cpuSeq": null,
+				"historicLatency": [],
 				"id": broker.nodeID,
 				"ipList": catalog.localNode.ipList,
 				"hostname": catalog.localNode.hostname,
 				"port": null,
 				"lastHeartbeatTime": jasmine.any(Number),
+				"latency": 0,
 				"offlineSince": null,
 				"seq": 1,
 				"local": true,
@@ -453,11 +456,13 @@ describe("Test NodeCatalog.list", () => {
 				"config": {},
 				"cpu": null,
 				"cpuSeq": null,
+				"historicLatency": [],
 				"id": "node-10",
 				"ipList": undefined,
 				"hostname": undefined,
 				"port": undefined,
 				"lastHeartbeatTime": jasmine.any(Number),
+				"latency": 0,
 				"offlineSince": null,
 				"seq": 1,
 				"local": false,
@@ -476,11 +481,13 @@ describe("Test NodeCatalog.list", () => {
 				"config": {},
 				"cpu": null,
 				"cpuSeq": null,
+				"historicLatency": jasmine.any(Array),
 				"id": broker.nodeID,
 				"ipList": catalog.localNode.ipList,
 				"hostname": catalog.localNode.hostname,
 				"port": null,
 				"lastHeartbeatTime": jasmine.any(Number),
+				"latency": jasmine.any(Number),
 				"local": true,
 				"offlineSince": null,
 				"seq": 1,
@@ -493,11 +500,13 @@ describe("Test NodeCatalog.list", () => {
 				"config": {},
 				"cpu": null,
 				"cpuSeq": null,
+				"historicLatency": jasmine.any(Array),
 				"id": "node-10",
 				"ipList": undefined,
 				"hostname": undefined,
 				"port": undefined,
 				"lastHeartbeatTime": jasmine.any(Number),
+				"latency": jasmine.any(Number),
 				"local": false,
 				"offlineSince": null,
 				"seq": 1,

--- a/test/unit/registry/registry.spec.js
+++ b/test/unit/registry/registry.spec.js
@@ -44,7 +44,7 @@ describe("Test Registry constructor", () => {
 
 		let registry = new Registry(broker);
 
-		expect(broker.localBus.on).toHaveBeenCalledTimes(3);
+		expect(broker.localBus.on).toHaveBeenCalledTimes(4);
 		expect(broker.localBus.on).toHaveBeenCalledWith("$broker.started", jasmine.any(Function));
 
 		let seq = registry.nodes.localNode.seq;

--- a/test/unit/strategies/latency.spec.js
+++ b/test/unit/strategies/latency.spec.js
@@ -1,0 +1,99 @@
+"use strict";
+
+let LatencyStrategy = require("../../../src/strategies/latency");
+let { extendExpect } = require("../utils");
+
+extendExpect(expect);
+
+describe("Test LatencyStrategy", () => {
+
+	it("test with empty opts", () => {
+
+		let strategy = new LatencyStrategy({
+			opts: {
+				strategyOptions: {}
+			}
+		});
+
+		expect(strategy.opts.sampleCount).toBe(3);
+		expect(strategy.opts.lowLatency).toBe(10);
+
+		const list = [
+			{ a: "hello", node: { latency: 20 } },
+			{ b: "world", node: { latency: 5 } },
+		];
+
+		expect(strategy.select(list)).toBe(list[1]);
+		expect(strategy.select(list)).toBe(list[1]);
+		expect(strategy.select(list)).toBe(list[1]);
+	});
+
+	it("test with options", () => {
+
+		let strategy = new LatencyStrategy({
+			opts: {
+				strategyOptions: {
+					sampleCount: 5,
+					lowLatency: 30
+				}
+			}
+		});
+
+		expect(strategy.opts.sampleCount).toBe(5);
+		expect(strategy.opts.lowLatency).toBe(30);
+
+		let list = [
+			{ a: "hello", node: { latency: 25 } },
+			{ b: "world", node: { latency: 60 } },
+		];
+
+		expect(strategy.select(list)).toBe(list[0]);
+		expect(strategy.select(list)).toBe(list[0]);
+		expect(strategy.select(list)).toBe(list[0]);
+
+		list = [
+			{ a: "hello", node: { latency: 0 } },
+			{ b: "world", node: { latency: 32 } },
+		];
+
+		expect(strategy.select(list)).toBe(list[1]);
+		expect(strategy.select(list)).toBe(list[1]);
+		expect(strategy.select(list)).toBe(list[1]);
+	});
+
+	it("test without latency values", () => {
+
+		let strategy = new LatencyStrategy({
+			opts: {}
+		});
+
+		const list = [
+			{ a: "hello", node: { latency: 0 } },
+			{ b: "world", node: { latency: 0 } },
+		];
+
+		expect(strategy.select(list)).toBeAnyOf(list);
+		expect(strategy.select(list)).toBeAnyOf(list);
+	});
+
+	it("test with many nodes (random selection)", () => {
+
+		let strategy = new LatencyStrategy({
+			opts: {}
+		});
+
+		const list = [
+			{ node: { latency: 34 } },
+			{ node: { latency: 22 } },
+			{ node: { latency: 75 } },
+			{ node: { latency: 8 } },
+			{ node: { latency: 37 } },
+			{ node: { latency: 55 } },
+			{ node: { latency: 14 } },
+		];
+
+		expect(strategy.select(list)).toBeAnyOf(list);
+		expect(strategy.select(list)).toBeAnyOf(list);
+	});
+
+});

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -958,11 +958,16 @@ describe("Test Transit.sendHeartbeat", () => {
 
 	it("should call publish with correct params", () => {
 		transit.sendHeartbeat({ cpu: 12 });
-		expect(transit.publish).toHaveBeenCalledTimes(1);
-		const packet = transit.publish.mock.calls[0][0];
-		expect(packet).toBeInstanceOf(P.Packet);
-		expect(packet.type).toBe(P.PACKET_HEARTBEAT);
-		expect(packet.payload.cpu).toBe(12);
+		expect(transit.publish).toHaveBeenCalledTimes(2);
+
+		const pingPacket = transit.publish.mock.calls[0][0];
+		expect(pingPacket).toBeInstanceOf(P.Packet);
+		expect(pingPacket.type).toBe(P.PACKET_PING);
+		
+		const heartbeatPacket = transit.publish.mock.calls[1][0];
+		expect(heartbeatPacket).toBeInstanceOf(P.Packet);
+		expect(heartbeatPacket.type).toBe(P.PACKET_HEARTBEAT);
+		expect(heartbeatPacket.payload.cpu).toBe(12);
 	});
 
 });
@@ -1025,4 +1030,3 @@ describe("Test Transit.publish", () => {
 	});
 
 });
-


### PR DESCRIPTION
This injects a `transit.sendPing` before each heartbeat, and listen for `$node.pong` event internally to update the node catalog. Similar to CpuUsage but instead of passively taking data, the node will actively probe latency.

This however requires a change in default settings. By default, heartbeat is sent every 5 seconds, which might be too frequent if we are also adding PING/PONG to the mix. Thus, I've also increased the default heartbeatInterval to 10s.

implement #228 

### sidenote
Latency, in theory, could be measured from the passive heartbeat packet. This, however, will require a change in the packet specs (including a `time` property). But the math is too complicated and I don't want to get too much into that... (this assumes time are synced between nodes or we need to do some adjustment which is a pain...)

### roadmap
Maybe in the next major release we will implement passive measurement of latency (instead of active which clots the transporter channel if you have A LOT OF nodes).