### PR TITLE
self-enclosed strategy module

### DIFF
--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -11,4 +11,5 @@ module.exports = {
 	RoundRobin: require("./round-robin"),
 	Random: require("./random"),
 	CpuUsage: require("./cpu-usage"),
+	Latency: require("./latency")
 };

--- a/src/strategies/latency.js
+++ b/src/strategies/latency.js
@@ -1,0 +1,147 @@
+/*
+ * moleculer
+ * Copyright (c) 2018 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const _ = require("lodash");
+
+const { random } = require("lodash");
+const BaseStrategy = require("./base");
+
+/**
+ * Lowest latency invocation strategy
+ *
+ * Since Strategy can be instantiated multiple times, therefore,
+ * we need to have a "master" instance to send ping, and each
+ * individual "slave" instance will update their list dynamically
+ *
+ * These options can be configured in broker registry options:
+ *
+ * const broker = new ServiceBroker({
+ * 	logger: true,
+ * 	registry: {
+ * 		strategy: "LatencyStrategy",
+ * 		strategyOptions: {
+ * 			lowLatency: 10,
+ *          collectCount: 5,
+ *          pingInterval: 10
+ * 		}
+ * 	}
+ * });
+ *
+ * @class LatencyStrategy
+ */
+class LatencyStrategy extends BaseStrategy {
+
+	constructor(registry, broker) {
+		super(registry, broker);
+
+		this.opts = _.defaultsDeep(registry.opts.strategyOptions, {
+			lowLatency: 10,
+            collectCount: 5,
+            pingInterval: 10
+		});
+
+        this.historicLatency = Object.create(null);
+        this.minLatency = null;
+        this.bestNode = null;
+
+        if (this.broker.localBus.listenerCount("$node.latencyMaster") === 0) {
+            this.broker.logger.debug("Latency: We are master");
+            this.broker.localBus.on("$node.latencyMaster", function() {});
+            this.broker.localBus.on("$node.pong", this.processPong.bind(this));
+            this.broker.localBus.on("$node.disconnected", this.cleanUp.bind(this));
+            this.pingTimer();
+        }
+
+        this.broker.localBus.on("$node.latencySlave", this.updateLatency.bind(this));
+	}
+
+    ping() {
+        this.broker.logger.debug("Latency: Sending ping");
+        this.broker.transit.sendPing().then(function() {
+            setTimeout(this.ping.bind(this), 1000 * this.opts.pingInterval);
+        }.bind(this));
+    }
+
+    pingTimer() {
+        // only one instance
+        if (!this.broker.transit) return;
+
+        this.broker.localBus.on("$broker.started", this.ping.bind(this));
+    }
+
+    processPong(payload) {
+        let nodeID = payload.nodeID;
+        let avgLatency = null;
+
+        this.broker.logger.debug("Latency: Process incoming pong");
+
+        if (typeof this.historicLatency[nodeID] === "undefined")
+            this.historicLatency[nodeID] = [];
+
+        if (this.historicLatency[nodeID].length > (this.opts.collectCount - 1))
+            this.historicLatency[nodeID].shift();
+
+        this.historicLatency[nodeID].push(payload.elapsedTime);
+
+        avgLatency = this.historicLatency[nodeID].reduce(function(sum, latency) {
+            return sum + latency;
+        }, 0) / this.historicLatency[nodeID].length;
+
+        if (!this.minLatency || avgLatency < this.minLatency) {
+            this.minLatency = avgLatency;
+            this.bestNode = nodeID;
+        }
+
+        this.broker.logger.debug("Latency:", this.bestNode, this.minLatency);
+
+        this.broker.logger.debug("Latency: Broadcasting latency update");
+
+        this.broker.localBus.emit("$node.latencySlave", {
+            bestNode: this.bestNode,
+            minLatency: this.minLatency
+        });
+    }
+
+    updateLatency(payload) {
+        this.broker.logger.debug("Latency update received", payload);
+        this.bestNode = payload.bestNode;
+        this.minLatency = this.minLatency;
+    }
+
+    cleanUp(payload) {
+        this.broker.logger.debug("Deleting historic latency", payload.node.id);
+        delete this.historicLatency[payload.node.id];
+    }
+
+	select(list) {
+        let bestNode = this.bestNode;
+
+		const sampleCount = this.opts.sampleCount;
+		const count = sampleCount <= 0 || sampleCount > list.length ? list.length : sampleCount;
+
+        if (bestNode === null) {
+            this.broker.logger.debug("Latency: Not yet available (null)");
+            return list[random(0, list.length - 1)];
+        }
+
+        // supposedly this is much faster
+        let node = list.find(function(ep) {
+            return ep.node.id === bestNode
+        })
+
+        if (node) {
+            this.broker.logger.debug("Latency: Select", bestNode, this.minLatency);
+            return node;
+        }else{
+            this.broker.logger.debug("Not yet available (undefined)");
+            return list[random(0, list.length - 1)];
+        }
+	}
+}
+
+module.exports = LatencyStrategy;

--- a/src/strategies/latency.js
+++ b/src/strategies/latency.js
@@ -50,11 +50,13 @@ class LatencyStrategy extends BaseStrategy {
         this.bestNode = null;
 
         if (this.broker.localBus.listenerCount("$node.latencyMaster") === 0) {
-            this.broker.logger.debug("Latency: We are master");
+            this.broker.logger.debug("Latency: We are MASTER");
             this.broker.localBus.on("$node.latencyMaster", function() {});
             this.broker.localBus.on("$node.pong", this.processPong.bind(this));
             this.broker.localBus.on("$node.disconnected", this.cleanUp.bind(this));
             this.pingTimer();
+        }else{
+            this.broker.logger.debug("Latency: We are SLAVE");
         }
 
         this.broker.localBus.on("$node.latencySlave", this.updateLatency.bind(this));
@@ -110,7 +112,7 @@ class LatencyStrategy extends BaseStrategy {
     updateLatency(payload) {
         this.broker.logger.debug("Latency update received", payload);
         this.bestNode = payload.bestNode;
-        this.minLatency = this.minLatency;
+        this.minLatency = payload.minLatency;
     }
 
     cleanUp(payload) {

--- a/test/unit/strategies/latency.spec.js
+++ b/test/unit/strategies/latency.spec.js
@@ -1,0 +1,33 @@
+"use strict";
+
+let LatencyStrategy = require("../../../src/strategies/latency");
+let { extendExpect } = require("../utils");
+const ServiceBroker = require("../../../src/service-broker");
+
+extendExpect(expect);
+
+describe("Test LatencyStrategy", () => {
+
+	const broker = new ServiceBroker();
+
+	it("test with empty opts", () => {
+
+		// this should operate like random
+
+		let strategy = new LatencyStrategy({
+			opts: {
+				strategyOptions: {}
+			}
+		}, broker);
+
+		const list = [
+			{ a: "hello" },
+			{ b: "world" },
+		];
+
+		expect(strategy.select(list)).toBeAnyOf(list);
+		expect(strategy.select(list)).toBeAnyOf(list);
+		expect(strategy.select(list)).toBeAnyOf(list);
+	});
+
+});


### PR DESCRIPTION
per comment from #230, this strategy now does not touch the core module.

Instead,
1) Since `Strategy` can be instantiated multiple times, we will use master-slave to measure/update latency.
2) Upon first instantiation of `LatencyStrategy`, the caller (usually the registry) will claim `$node.latencyMaster`. It will be responsible for `sendPing` and process `$node.pong` events.
3) It then emits `$node.latencySlave` to other instantiations of `LatencyStrategy` (usually are the catalogs), and each instantiation will update its own properties of `bestNode`
4) Upon calling `select`, `Array.prototype.find` will be called to find the bestNode.