### PR TITLE
adds ability to customise console object rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 node_modules/
 coverage/

--- a/src/logger.js
+++ b/src/logger.js
@@ -42,9 +42,10 @@ module.exports = {
 	 * @param {Object} bindings
 	 * @param {String?} logLevel
 	 * @param {Function?} logFormatter Custom log formatter function
+	 * @param {Function?} logObjectPrinter Custom object formatter function
 	 * @returns {Object} logger
 	 */
-	createDefaultLogger(baseLogger, bindings, logLevel, logFormatter) {
+	createDefaultLogger(baseLogger, bindings, logLevel, logFormatter, logObjectPrinter) {
 		const noop = function() {};
 
 		const getModuleName = () => {
@@ -99,10 +100,12 @@ module.exports = {
 				if (_.isFunction(format))
 					return method.call(baseLogger, logFormatter(type, args, bindings));
 
+				const defaultLogObjectPrinter = o => util.inspect(o, { showHidden: false, depth: 2, colors: chalk.enabled, breakLength: Number.POSITIVE_INFINITY });
+
 				// Format arguments (inspect & colorize the objects & array)
 				let pargs = args.map(p => {
 					if (_.isObject(p) || _.isArray(p))
-						return util.inspect(p, { showHidden: false, depth: 2, colors: chalk.enabled, breakLength: Number.POSITIVE_INFINITY });
+						return _.isFunction(logObjectPrinter) ? logObjectPrinter(p) : defaultLogObjectPrinter(p);
 					return p;
 				});
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -102,7 +102,7 @@ module.exports = {
 				// Format arguments (inspect & colorize the objects & array)
 				let pargs = args.map(p => {
 					if (_.isObject(p) || _.isArray(p))
-						return util.inspect(p, { showHidden: false, depth: 2, colors: chalk.enabled });
+						return util.inspect(p, { showHidden: false, depth: 2, colors: chalk.enabled, breakLength: Number.POSITIVE_INFINITY });
 					return p;
 				});
 

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -472,7 +472,7 @@ class ServiceBroker {
 
 		// Create console logger
 		if (this.options.logger === true || this.options.logger === console)
-			return Logger.createDefaultLogger(console, bindings, this.options.logLevel || "info", this.options.logFormatter);
+			return Logger.createDefaultLogger(console, bindings, this.options.logLevel || "info", this.options.logFormatter, this.options.logObjectPrinter);
 
 		return Logger.createDefaultLogger();
 	}

--- a/test/unit/logger.spec.js
+++ b/test/unit/logger.spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const chalk = require("chalk");
+const util = require("util");
 chalk.enabled = false;
 
 const { extend, createDefaultLogger } = require("../../src/logger");
@@ -146,4 +147,58 @@ describe("Test createDefaultLogger", () => {
 		expect(logFormatter).toHaveBeenCalledWith("info", ["info level"], {"nodeID": "server-2", "ns": "", "svc": "posts", "ver": 2});
 	});
 
+	it("should use default logObjectPrinter", () => {
+		let con = {
+			info: jest.fn()
+		};
+
+		let bindings = {
+			svc: "posts",
+			ver: 2,
+			nodeID: "server-2",
+			ns: ""
+		};
+
+		let logObjectPrinter =  o => util.inspect(o, { depth: 4, colors: false, breakLength: 5 })
+		let logger = createDefaultLogger(con, bindings, "info", undefined, logObjectPrinter);
+		const obj = {a: "a".repeat(20), b: "b".repeat(20), c: "c".repeat(20)}
+
+		logger.info("with object", obj);
+
+		expect(con.info).toHaveBeenCalledTimes(1);
+		expect(con.info).toHaveBeenCalledWith(
+			"[1970-01-01T00:00:00.000Z]",
+			"INFO ",
+			"server-2/POSTS:v2:",
+			"with object",
+			"{ a: 'aaaaaaaaaaaaaaaaaaaa',\n  b: 'bbbbbbbbbbbbbbbbbbbb',\n  c: 'cccccccccccccccccccc' }"
+		);
+	});
+
+	it("should use custom logObjectPrinter", () => {
+		let con = {
+			info: jest.fn()
+		};
+
+		let bindings = {
+			svc: "posts",
+			ver: 2,
+			nodeID: "server-2",
+			ns: ""
+		};
+
+		let logger = createDefaultLogger(con, bindings, "info");
+		const obj = {a: "a".repeat(20), b: "b".repeat(20), c: "c".repeat(20)}
+
+		logger.info("with object", obj);
+
+		expect(con.info).toHaveBeenCalledTimes(1);
+		expect(con.info).toHaveBeenCalledWith(
+			"[1970-01-01T00:00:00.000Z]",
+			"INFO ",
+			"server-2/POSTS:v2:",
+			"with object",
+			"{ a: 'aaaaaaaaaaaaaaaaaaaa', b: 'bbbbbbbbbbbbbbbbbbbb', c: 'cccccccccccccccccccc' }"
+		);
+	});
 });

--- a/test/unit/logger.spec.js
+++ b/test/unit/logger.spec.js
@@ -147,7 +147,7 @@ describe("Test createDefaultLogger", () => {
 		expect(logFormatter).toHaveBeenCalledWith("info", ["info level"], {"nodeID": "server-2", "ns": "", "svc": "posts", "ver": 2});
 	});
 
-	it("should use default logObjectPrinter", () => {
+	it("should use custom logObjectPrinter", () => {
 		let con = {
 			info: jest.fn()
 		};
@@ -175,7 +175,7 @@ describe("Test createDefaultLogger", () => {
 		);
 	});
 
-	it("should use custom logObjectPrinter", () => {
+	it("should use default logObjectPrinter", () => {
 		let con = {
 			info: jest.fn()
 		};


### PR DESCRIPTION
## :memo: Description
When trying to log a big object the logged text is written on multiple lines due to the `util.inspect()` behaviour.

Actually `this.logger.info('Test with a big object',  process.release)` prints:

```
[2018-06-01T10:39:20.379Z] INFO  xxx-19680/MATH: Test with a big object { name: 'node',
  lts: 'Carbon',
  sourceUrl: 'https://nodejs.org/download/release/v8.10.0/node-v8.10.0.tar.gz',
  headersUrl: 'https://nodejs.org/download/release/v8.10.0/node-v8.10.0-headers.tar.gz' }
```

With this fix the new log will be:
```
[2018-06-01T10:45:17.710Z] INFO  xxx-19743/MATH: Test with a big object { name: 'node', lts: 'Carbon', sourceUrl: 'https://nodejs.org/download/release/v8.10.0/node-v8.10.0.tar.gz', headersUrl: 'https://nodejs.org/download/release/v8.10.0/node-v8.10.0-headers.tar.gz' }
```

It looks better on console and allows us to work with command line utils like grep, awk...

This fix changes the default `breakLength` to Infinity
> breakLength <number> The length at which an object's keys are split across multiple lines. Set to Infinity to format an object as a single line. Default: 60 for legacy compatibility.
https://nodejs.org/api/util.html#util_util_inspect_object_options

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?
Add the following code in a service
```
created: {
  this.logger.info('Test with a big object',  process.release)
},
````
## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **New and existing unit tests pass locally with my changes**
