### PR TITLE
fix metrics d.ts bug

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ declare namespace Moleculer {
 	type ActionParams = { [key: string]: ActionParamTypes };
 	type MetricsParamsFuncType= (params: object) => object;
 	type MetricsMetaFuncType= (meta: object) => object;
-	type MetricsOptions = { params?: boolean | string[] | MetricsParamsFuncType , meta?: boolean | string[] | MetricsMetaFuncType };
+	type MetricsOptions = { params?: boolean | string[] | MetricsParamsFuncType, meta?: boolean | string[] | MetricsMetaFuncType };
 
 	interface Action {
 		name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,9 @@ declare namespace Moleculer {
 	type ActionParamSchema = { [key: string]: any };
 	type ActionParamTypes = "boolean" | "number" | "string" | "object" | "array" | ActionParamSchema;
 	type ActionParams = { [key: string]: ActionParamTypes };
-	type MetricsOptions = { params?: boolean | string[] | function, meta?: boolean | string[] | function };
+	type MetricsParamsFuncType= (params: object) => object;
+	type MetricsMetaFuncType= (meta: object) => object;
+	type MetricsOptions = { params?: boolean | string[] | MetricsParamsFuncType , meta?: boolean | string[] | MetricsMetaFuncType };
 
 	interface Action {
 		name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Moleculer {
 	type ActionParamSchema = { [key: string]: any };
 	type ActionParamTypes = "boolean" | "number" | "string" | "object" | "array" | ActionParamSchema;
 	type ActionParams = { [key: string]: ActionParamTypes };
-	type MetricsOptions = { params?: "boolean" | "array" | "function", meta?: "boolean" | "array" | "function" };
+	type MetricsOptions = { params?: boolean | string[] | function, meta?: boolean | string[] | function };
 
 	interface Action {
 		name: string;


### PR DESCRIPTION
@Action({params:{p1:'string'}, metrics:{params:true}})
async action1(ctx) {...}

@Action({params:{p1:'string', p2:'string'}, metrics:{params:['p1', 'p2']}})
async action2(ctx) {...}