### PR TITLE
Fix metrics options and findNextActionEndpoint output type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,10 @@ declare namespace Moleculer {
 	type ActionParamSchema = { [key: string]: any };
 	type ActionParamTypes = "boolean" | "number" | "string" | "object" | "array" | ActionParamSchema;
 	type ActionParams = { [key: string]: ActionParamTypes };
-	type MetricsOptions = { params?: "boolean" | "array" | "function", meta?: "boolean" | "array" | "function" };
+
+	type MetricsParamsFuncType= (params: ActionParams) => any;
+	type MetricsMetaFuncType= (meta: object) => any;
+	type MetricsOptions = { params?: boolean | string[] | MetricsParamsFuncType, meta?: boolean | string[] | MetricsMetaFuncType };
 
 	interface Action {
 		name: string;
@@ -268,6 +271,21 @@ declare namespace Moleculer {
 		params: P;
 	};
 
+	interface Endpoint {
+		broker: ServiceBroker;
+
+		id: string;
+		node: GenericObject;
+
+		local: boolean;
+		state:boolean;
+	}
+
+	interface ActionEndpoint extends Endpoint {
+		service: Service;
+		action: Action;
+	}
+
 	class ServiceBroker {
 		constructor(options?: BrokerOptions);
 
@@ -300,7 +318,7 @@ declare namespace Moleculer {
 
 		use(...mws: Array<Function>): void;
 
-		findNextActionEndpoint(actionName: string, opts?: GenericObject): string;
+		findNextActionEndpoint(actionName: string, opts?: GenericObject): ActionEndpoint | MoleculerRetryableError;
 
 		/**
 		 * Call an action (local or global)


### PR DESCRIPTION
## :memo: Description

Added handler function types and updated MetricsOptions to proper types.
Added interfaces for `Enpoint` and `ActionEndpoint` to update the output type of `ServiceBroker.findNextActionEndpoint`

### :dart: Relevant issues
#288 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Build sample application using Typescript and compile with `MetricsOptions` set in an action

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
