### PR TITLE
Added missing fields to BrokerOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -171,7 +171,7 @@ declare namespace Moleculer {
 		logger?: Logger | boolean;
 		logLevel?: string;
         logFormatter?: Function | string;
-        logObjectPrinter?: Function
+        logObjectPrinter?: Function;
 
 		transporter?: Transporter | string | GenericObject;
 		requestTimeout?: number;
@@ -180,8 +180,8 @@ declare namespace Moleculer {
 		heartbeatInterval?: number;
         heartbeatTimeout?: number
     
-        trackContext?: boolean
-        gracefulStopTimeout?: number
+        trackContext?: boolean;
+        gracefulStopTimeout?: number;
 
 		disableBalancer?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -170,14 +170,18 @@ declare namespace Moleculer {
 
 		logger?: Logger | boolean;
 		logLevel?: string;
-		logFormatter?: Function | string;
+        logFormatter?: Function | string;
+        logObjectPrinter?: Function
 
 		transporter?: Transporter | string | GenericObject;
 		requestTimeout?: number;
 		requestRetry?: number;
 		maxCallLevel?: number;
 		heartbeatInterval?: number;
-		heartbeatTimeout?: number;
+        heartbeatTimeout?: number
+    
+        trackContext?: boolean
+        gracefulStopTimeout?: number
 
 		disableBalancer?: boolean;
 


### PR DESCRIPTION
## :memo: Description

Added missing fields to BrokerOptions TypeScript definition based upon http://moleculer.services/0.12/docs/broker.html#Broker-options. TypeScript definition for BrokerOptions is missing logObjectPrinter, trackContext, and gracefulStopTimeout properties.

### :dart: Relevant issues
NONE

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
import { ServiceBroker } from 'moleculer'

let broker = new ServiceBroker({
  name: 'test',
  trackContext: true,
  gracefulStopTimeout: 10 * 1000,
  ...
})
``` 

## :vertical_traffic_light: How Has This Been Tested?

Trivial issue.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
