### PR TITLE
Fix transit response to return Duplex streams without a read method

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -522,7 +522,7 @@ class Transit {
 	 * @memberof Transit
 	 */
 	_sendRequest(ctx, resolve, reject) {
-		const isStream = ctx.params && typeof ctx.params.on === "function" && typeof ctx.params.read === "function" && typeof ctx.params.pipe === "function";
+		const isStream = ctx.params && ctx.params.readable === true && typeof ctx.params.on === "function" && typeof ctx.params.pipe === "function";
 
 		const request = {
 			action: ctx.action,
@@ -751,7 +751,7 @@ class Transit {
 
 		const publishCatch = err => this.logger.error(`Unable to send '${id}' response to '${nodeID}' node.`, err);
 
-		if (data && typeof data.on === "function" && typeof data.read === "function" && typeof data.pipe === "function") {
+		if (data && data.readable === true && typeof data.on === "function" && typeof data.pipe === "function") {
 			// Streaming response
 			payload.stream = true;
 			const stream = data;


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
Related to #325 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
