### PR TITLE
Allow to pass socket options to amqp transport

### DIFF
--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -99,7 +99,7 @@ class AmqpTransporter extends Transporter {
 				this.broker.fatal("The 'amqplib' package is missing. Please install it with 'npm install amqplib --save' command.", err, true);
 			}
 
-			amqp.connect(this.opts.url)
+			amqp.connect(this.opts.url, this.opts.socketOptions)
 				.then(connection => {
 					this.connection = connection;
 					this.logger.info("AMQP is connected.");


### PR DESCRIPTION
## :memo: Description

Take into account `socketOptions` passed to transporter options when initiating amqp connection.

### :dart: Relevant issues
Unability to connect to RabbitMQ with ssl. Have to pass `servername` in `socketOptions` to connect, so it matches the CN on the certificate.

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### :scroll: Example code
```js
const broker = new ServiceBroker({
  ...
  transporter: {
    type: 'AMQP',
    options: {
      url: process.env.RABBIT_URL,
      socketOptions: {
        servername: process.env.RABBIT_SERVER_NAME
      },
      eventTimeToLive: 5000,
      prefetch: 50
    }
  },
  ...
})
``` 

## :vertical_traffic_light: How Has This Been Tested?

I successfully connected to rabbitqm by passing `socketOptions`.  
Nothing is broken if `socketOptions` are not passed.  

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
