### PR TITLE
ensure merged dependencies are unique (fix #244)

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -445,7 +445,7 @@ class Service {
 
 			} else if (["mixins", "dependencies"].indexOf(key) !== -1) {
 				// Concat mixins
-				res[key] = _.compact(_.flatten([mods[key], res[key]]));
+				res[key] = _.uniqWith(_.compact(_.flatten([mods[key], res[key]])), _.isEqual);
 
 			} else {
 				// Overwrite

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -989,4 +989,43 @@ describe("Test mergeSchemas", () => {
 
 	});
 
+	describe("merge schemas with unique dependencies", () => {
+		it("should merge dependencies defined in shorthand notation", () => {
+			const origSchema = {
+				dependencies: ["users", "mail"]
+			};
+			const mixinSchema = {
+				dependencies: ["users", "posts"]
+			};
+
+			const result = Service.mergeSchemas(origSchema, mixinSchema);
+			expect(result.dependencies).toEqual(["users", "posts", "mail"]);
+		});
+
+		it("should merge versioned dependencies", () => {
+			const origSchema = {
+				dependencies: [{ name: "users", version: 1 }, { name: "mail", version: "staging" }]
+			};
+			const mixinSchema = {
+				dependencies: [{ name: "users", version: 1 }, { name: "posts", version: "v2" }]
+			};
+
+			const result = Service.mergeSchemas(origSchema, mixinSchema);
+			expect(result.dependencies).toEqual([{ name: "users", version: 1 }, { name: "posts", version: "v2" }, { name: "mail", version: "staging" }]);
+		});
+
+		it("should merge mixed", () => {
+			const origSchema = {
+				dependencies: [{ name: "users", version: 1 }, "mail"]
+			};
+			const mixinSchema = {
+				dependencies: ["users", { name: "posts", version: "v2" }]
+			};
+
+			const result = Service.mergeSchemas(origSchema, mixinSchema);
+			expect(result.dependencies).toEqual(["users", { name: "posts", version: "v2" }, { name: "users", version: 1 }, "mail"]);
+		});
+
+	});
+
 });


### PR DESCRIPTION
## :memo: Description
When a service has a dependency and one/more mixins have the same dependency declared, it is added multiple times although this is not necessary.

### :dart: Relevant issues
Related to #244 

### :gem: Type of change
 Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
