### PR TITLE
Fix a warning of unreturned Promise in amqp transport connect code

### DIFF
--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -130,7 +130,6 @@ class AmqpTransporter extends Transporter {
 						.createChannel()
 						.then((channel) => {
 							this.channel = channel;
-							this.onConnected().then(resolve);
 							this.logger.info("AMQP channel is created.");
 
 							channel.prefetch(this.opts.prefetch);
@@ -157,7 +156,10 @@ class AmqpTransporter extends Transporter {
 								.on("return", (msg) => {
 									this.logger.warn("AMQP channel returned a message.", msg);
 								});
+
+							return this.onConnected();
 						})
+						.then(resolve)
 						.catch((err) => {
 							/* istanbul ignore next*/
 							this.logger.error("AMQP failed to create channel.");


### PR DESCRIPTION
## :memo: Description

Fixed a warning of non-returned promise in amqp connect code.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

molecular still successfully connects to rabbitmq and works.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
