### PR TITLE
Ability to disable process event registration + additional check on service stop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -271,6 +271,12 @@ declare namespace Moleculer {
 		created?: (broker: ServiceBroker) => void;
 		started?: (broker: ServiceBroker) => void;
 		stopped?: (broker: ServiceBroker) => void;
+		
+		/**
+		 * If true, process.on("beforeExit/exit/SIGINT/SIGTERM", ...) handler won't be registered!
+		 * You have to register this manually and stop broker in this case!
+		 */
+		skipProcessEventRegistration?: boolean;
 	}
 
 	interface NodeHealthStatus {

--- a/src/middlewares/context-tracker.js
+++ b/src/middlewares/context-tracker.js
@@ -64,7 +64,7 @@ function wrapTrackerMiddleware(handler, action) {
 }
 
 function waitingForActiveContexts(list, logger, time) {
-	if (list.length === 0)
+	if (!list || list.length === 0)
 		return Promise.resolve();
 
 	return new Promise((resolve) => {

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -231,10 +231,12 @@ class ServiceBroker {
 			};
 
 			process.setMaxListeners(0);
-			process.on("beforeExit", this._closeFn);
-			process.on("exit", this._closeFn);
-			process.on("SIGINT", this._closeFn);
-			process.on("SIGTERM", this._closeFn);
+			if ((this.options.skipProcessEventRegistration || false) !== true) {
+				process.on("beforeExit", this._closeFn);
+				process.on("exit", this._closeFn);
+				process.on("SIGINT", this._closeFn);
+				process.on("SIGTERM", this._closeFn);
+			}
 		} catch(err) {
 			if (this.logger)
 				this.fatal("Unable to create ServiceBroker.", err, true);
@@ -398,10 +400,12 @@ class ServiceBroker {
 
 				this.localBus.emit("$broker.stopped");
 
-				process.removeListener("beforeExit", this._closeFn);
-				process.removeListener("exit", this._closeFn);
-				process.removeListener("SIGINT", this._closeFn);
-				process.removeListener("SIGTERM", this._closeFn);
+				if ((this.options.skipProcessEventRegistration || false) !== true) {
+					process.removeListener("beforeExit", this._closeFn);
+					process.removeListener("exit", this._closeFn);
+					process.removeListener("SIGINT", this._closeFn);
+					process.removeListener("SIGTERM", this._closeFn);
+				}
 			});
 	}
 


### PR DESCRIPTION
## :memo: Description

Added ability to disable process event registration in ServiceBroker. This way this can be done manually in users code to have ability to do own cleanup.

Checking if any service registered (service._trackedContexts in context-tracker.js defined) when stopping services. Otherwise I was getting
```
Unable to stop all services. {"error":{"message":"Cannot read property 'length' of undefined","stack":"TypeError: Cannot read property 'length' of undefined\n
    at waitingForActiveContexts (/app/node_modules/moleculer/src/middlewares/context-tracker.js:67:11)\n
    at ServiceBroker.serviceStopping (/app/node_modules/moleculer/src/middlewares/context-tracker.js:110:11)\n
    at p.then (/app/node_modules/moleculer/src/middleware.js:72:50)\n
    at tryCatcher (/app/node_modules/bluebird/js/release/util.js:16:23)\n
    at Promise._settlePromiseFromHandler (/app/node_modules/bluebird/js/release/promise.js:512:31)\n
    at Promise._settlePromise (/app/node_modules/bluebird/js/release/promise.js:569:18)\n
    at Promise._settlePromiseCtx (/app/node_modules/bluebird/js/release/promise.js:606:10)\n
    at Async._drainQueue (/app/node_modules/bluebird/js/release/async.js:138:12)\n
    at Async._drainQueues (/app/node_modules/bluebird/js/release/async.js:143:10)\n
    at Immediate.Async.drainQueues [as _onImmediate] (/app/node_modules/bluebird/js/release/async.js:17:14)\n
    at runCallback (timers.js:696:18)\n
    at tryOnImmediate (timers.js:667:5)\n
    at processImmediate (timers.js:649:5)"}}
```
when stopping a broker with no registered services.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### :scroll: Example code
```js
const broker = new ServiceBroker({
  skipProcessEventRegistration: true,
  ...
})
``` 

## :vertical_traffic_light: How Has This Been Tested?

Nothing changed if additional service broker option is not passed.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
