### PR TITLE
Add option to enable auto delete queues in amqp transport

### DIFF
--- a/test/unit/transporters/amqp.spec.js
+++ b/test/unit/transporters/amqp.spec.js
@@ -60,7 +60,8 @@ describe("Test AmqpTransporter constructor", () => {
 			exchangeOptions: {},
 			messageOptions: {},
 			queueOptions: {},
-			consumeOptions: {}
+			consumeOptions: {},
+			autoDeleteQueues: -1
 		});
 		expect(transporter.connected).toBe(false);
 		expect(transporter.hasBuiltInBalancer).toBe(true);
@@ -78,7 +79,8 @@ describe("Test AmqpTransporter constructor", () => {
 			exchangeOptions: { alternateExchange: "retry" },
 			messageOptions: { expiration: 120000, persistent: true, mandatory: true },
 			queueOptions: { deadLetterExchange: "dlx", maxLength: 100 },
-			consumeOptions: { priority: 5 }
+			consumeOptions: { priority: 5 },
+			autoDeleteQueues: -1
 		};
 		let transporter = new AmqpTransporter(opts);
 		expect(transporter.opts).toEqual(opts);

--- a/test/unit/transporters/index.spec.js
+++ b/test/unit/transporters/index.spec.js
@@ -107,7 +107,8 @@ describe("Test Transporter resolver", () => {
 				exchangeOptions: {},
 				messageOptions: {},
 				queueOptions: {},
-				consumeOptions: {}
+				consumeOptions: {},
+				autoDeleteQueues: -1
 			});
 		});
 	});


### PR DESCRIPTION
## :memo: Description

In some systems, it is impossible to generate constant unique nodeIDs (ex. multiple instances of Heroku dynos). In this case nodeID must has some random part.  
Problem with doing this and using AMQP transport is you end up with a lot of obsolete queues in RabbitMQ.  

That's why I added `autoDeleteQueues` option to amqp options. If true queues will be autodeleted once service is stopped (queue listener removed).  
Of course you loose some functionality in this case. Once service is re-started it will have new request queue, meaning not finished reqeusts will be lost.  

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### :scroll: Example code
```js
const broker = new ServiceBroker({
  ...
  transporter: {
    type: 'AMQP',
    options: {
      ...
      autoDeleteQueues: true,
    }
  },
  ...
})
``` 

## :vertical_traffic_light: How Has This Been Tested?

If new option is not set funcionality is not changed.  
Manually tested that when option is enabled, services still communicate successfully and queues get deleted after service is stop.  

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
