### PR TITLE
Address feature request #344 to use '/' instead of '.' as MQTT topic separator. 

### DIFF
--- a/src/transporters/mqtt.js
+++ b/src/transporters/mqtt.js
@@ -70,7 +70,7 @@ class MqttTransporter extends Transporter {
 			});
 
 			client.on("message", (topic, msg) => {
-				const cmd = topic.split(".")[1];
+				const cmd = topic.split("/")[1];
 				this.incomingMessage(cmd, msg);
 			});
 
@@ -92,6 +92,18 @@ class MqttTransporter extends Transporter {
 			this.client.end();
 			this.client = null;
 		}
+	}
+
+	/**
+	 * Get topic name from command & target nodeID
+	 *
+	 * @param {any} cmd
+	 * @param {any} nodeID
+	 *
+	 * @memberof MqttTransporter
+	 */
+	getTopicName(cmd, nodeID) {
+		return this.prefix + "/" + cmd + (nodeID ? "/" + nodeID : "");
 	}
 
 	/**

--- a/src/transporters/mqtt.js
+++ b/src/transporters/mqtt.js
@@ -8,6 +8,7 @@
 
 const Promise		= require("bluebird");
 const Transporter 	= require("./base");
+const _				= require("lodash");
 
 /**
  * Transporter for MQTT
@@ -28,6 +29,8 @@ class MqttTransporter extends Transporter {
 		super(opts);
 
 		this.client = null;
+
+		this.topicSeperator = _.hasIn(this, "opts.topicSeperator") ? this.opts.topicSeperator : ".";
 	}
 
 	/**
@@ -70,7 +73,7 @@ class MqttTransporter extends Transporter {
 			});
 
 			client.on("message", (topic, msg) => {
-				const cmd = topic.split("/")[1];
+				const cmd = topic.split(this.topicSeperator)[1];
 				this.incomingMessage(cmd, msg);
 			});
 
@@ -103,7 +106,7 @@ class MqttTransporter extends Transporter {
 	 * @memberof MqttTransporter
 	 */
 	getTopicName(cmd, nodeID) {
-		return this.prefix + "/" + cmd + (nodeID ? "/" + nodeID : "");
+		return this.prefix + this.topicSeperator + cmd + (nodeID ? this.topicSeperator + nodeID : "");
 	}
 
 	/**

--- a/test/unit/transporters/mqtt.spec.js
+++ b/test/unit/transporters/mqtt.spec.js
@@ -119,12 +119,12 @@ describe("Test MqttTransporter subscribe & publish", () => {
 		transporter.subscribe("REQ", "node");
 
 		expect(transporter.client.subscribe).toHaveBeenCalledTimes(1);
-		expect(transporter.client.subscribe).toHaveBeenCalledWith("MOL-TEST.REQ.node");
+		expect(transporter.client.subscribe).toHaveBeenCalledWith("MOL-TEST/REQ/node");
 	});
 
 	it("check incoming message handler", () => {
 		// Test subscribe callback
-		transporter.client.onCallbacks.message("prefix.event.name", "incoming data");
+		transporter.client.onCallbacks.message("prefix/event/name", "incoming data");
 		expect(transporter.incomingMessage).toHaveBeenCalledTimes(1);
 		expect(transporter.incomingMessage).toHaveBeenCalledWith("event", "incoming data");
 	});
@@ -135,7 +135,7 @@ describe("Test MqttTransporter subscribe & publish", () => {
 		const packet = new P.Packet(P.PACKET_INFO, "node2", { services: {} });
 		transporter.publish(packet).catch(protectReject).then(() => {
 			expect(transporter.client.publish).toHaveBeenCalledTimes(1);
-			expect(transporter.client.publish).toHaveBeenCalledWith("MOL-TEST.INFO.node2", "json data", jasmine.any(Function));
+			expect(transporter.client.publish).toHaveBeenCalledWith("MOL-TEST/INFO/node2", "json data", jasmine.any(Function));
 
 			expect(transporter.serialize).toHaveBeenCalledTimes(1);
 			expect(transporter.serialize).toHaveBeenCalledWith(packet);

--- a/test/unit/transporters/mqtt.spec.js
+++ b/test/unit/transporters/mqtt.spec.js
@@ -119,12 +119,12 @@ describe("Test MqttTransporter subscribe & publish", () => {
 		transporter.subscribe("REQ", "node");
 
 		expect(transporter.client.subscribe).toHaveBeenCalledTimes(1);
-		expect(transporter.client.subscribe).toHaveBeenCalledWith("MOL-TEST/REQ/node");
+		expect(transporter.client.subscribe).toHaveBeenCalledWith("MOL-TEST" + transporter.topicSeperator +  "REQ" + transporter.topicSeperator + "node");
 	});
 
 	it("check incoming message handler", () => {
 		// Test subscribe callback
-		transporter.client.onCallbacks.message("prefix/event/name", "incoming data");
+		transporter.client.onCallbacks.message("prefix" + transporter.topicSeperator + "event" + transporter.topicSeperator + "name", "incoming data");
 		expect(transporter.incomingMessage).toHaveBeenCalledTimes(1);
 		expect(transporter.incomingMessage).toHaveBeenCalledWith("event", "incoming data");
 	});
@@ -135,7 +135,7 @@ describe("Test MqttTransporter subscribe & publish", () => {
 		const packet = new P.Packet(P.PACKET_INFO, "node2", { services: {} });
 		transporter.publish(packet).catch(protectReject).then(() => {
 			expect(transporter.client.publish).toHaveBeenCalledTimes(1);
-			expect(transporter.client.publish).toHaveBeenCalledWith("MOL-TEST/INFO/node2", "json data", jasmine.any(Function));
+			expect(transporter.client.publish).toHaveBeenCalledWith("MOL-TEST" + transporter.topicSeperator + "INFO" + transporter.topicSeperator + "node2", "json data", jasmine.any(Function));
 
 			expect(transporter.serialize).toHaveBeenCalledTimes(1);
 			expect(transporter.serialize).toHaveBeenCalledWith(packet);


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using MQTT transport with RabbitMQ and the RabbitMQ MQTT Plugin, all dots get converted to slashes and vice versa. As such, nodes on this transport are not able to see each other as the topics are seen with slashes if published with dots.

From: https://www.rabbitmq.com/mqtt.html

> Note that MQTT uses slashes ("/") for topic segment separators and AMQP 0-9-1 uses dots. This plugin translates patterns under the hood to bridge the two, for example, cities/london becomes cities.london and vice versa. This has one important limitation: MQTT topics that have dots in them won't work as expected and are to be avoided, the same goes for AMQP 0-9-1 routing keys that contains slahes.

### :dart: Relevant issues
#344

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Not sure if this is a breaking change. Would depend on people that may use '.' in the namespace perhaps...

### :scroll: Example code
No user facing code changes. This only changes the format of topic generation for publish and subscribe when using a MQTT transport. 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated unit tests to validate '/' instead of '.'
- [x] Implemented this fork in a semi production application that uses a Rabbit MQ Cluster with the Rabbit MQ MQTT Plugin installed.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas