### PR TITLE
Improving es6 support.

### DIFF
--- a/test/integration/broker.spec.js
+++ b/test/integration/broker.spec.js
@@ -28,7 +28,7 @@ describe("Test load services", () => {
 
 	it("should load all services", () => {
 		let count = broker.loadServices("./test/services");
-		expect(count).toBe(4);
+		expect(count).toBe(5);
 
 		return broker.start().catch(protectReject).then(() => {
 			expect(broker.getLocalService("math")).toBeDefined();

--- a/test/services/greeter.es6.service.js
+++ b/test/services/greeter.es6.service.js
@@ -1,7 +1,3 @@
-/**
- * IT IS NOT WORKING WITH THE LATEST JEST VERSION
- *
- */
 const Service = require("../../src/service");
 
 class GreeterService extends Service {

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -778,15 +778,15 @@ describe("Test loadServices", () => {
 	let broker = new ServiceBroker({ logger: false });
 	broker.loadService = jest.fn();
 
-	it("should load 4 services", () => {
+	it("should load 5 services", () => {
 		let count = broker.loadServices("./test/services");
-		expect(count).toBe(4);
-		expect(broker.loadService).toHaveBeenCalledTimes(4);
+		expect(count).toBe(5);
+		expect(broker.loadService).toHaveBeenCalledTimes(5);
 		expect(broker.loadService).toHaveBeenCalledWith("test/services/users.service.js");
 		expect(broker.loadService).toHaveBeenCalledWith("test/services/posts.service.js");
 		expect(broker.loadService).toHaveBeenCalledWith("test/services/math.service.js");
 		expect(broker.loadService).toHaveBeenCalledWith("test/services/utils/util.service.js");
-		//expect(broker.loadService).toHaveBeenCalledWith("test/services/greeter.es6.service.js");
+		expect(broker.loadService).toHaveBeenCalledWith("test/services/greeter.es6.service.js");
 	});
 
 	it("should load 1 services", () => {
@@ -895,10 +895,10 @@ describe("Test broker.createService", () => {
 	});
 
 	it("should load es6 class service", () => {
-		const es6Service = require("../services/greeter.es6._ervice");
-		Object.setPrototypeOf(es6Service, broker.ServiceFactory);
+		const es6Service = require("../services/greeter.es6.service");
 		es6Service.prototype.parseServiceSchema = jest.fn();
 
+		Object.setPrototypeOf(es6Service, broker.ServiceFactory);
 		let service = broker.createService(es6Service);
 		expect(service).toBeInstanceOf(es6Service);
 	});
@@ -1934,9 +1934,9 @@ describe("Test hot-reload feature", () => {
 			broker.watchService.mockClear();
 
 			let count = broker.loadServices("./test/services");
-			expect(count).toBe(4);
+			expect(count).toBe(5);
 
-			expect(broker.watchService).toHaveBeenCalledTimes(4);
+			expect(broker.watchService).toHaveBeenCalledTimes(5);
 		});
 	});
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Comments 

This handle issue #337 forcing base class reference to same as used from global moleculer-runner cli.
This also may prevent other erros from using a global runner on a different version than used on project node_modules.

This also handle issue #328 without the 'schema.default' trick.

This PR does not handle ES6 module import using " import * from X" notation.

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Full: service-broker.spec
- [x] Added: "should load es6 module class service"
- [x] Changed: "should load 6 services"

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas

