### PR TITLE
Fail fast for jest when "testEnvironment": "node" is not set

### DIFF
--- a/src/registry/node-catalog.js
+++ b/src/registry/node-catalog.js
@@ -61,7 +61,7 @@ class NodeCatalog {
 
 		}, this.broker.options.heartbeatInterval * 1000);
 
-		if (typeof this.heartbeatTimer === "number") throw new Error("heartbeatTimer should not be a number. See issue [##362] for details.");
+		if (typeof this.heartbeatTimer === "number") throw new Error("heartbeatTimer should not be a number. See issue [#362] for details.");
 
 
 		this.heartbeatTimer.unref();

--- a/src/registry/node-catalog.js
+++ b/src/registry/node-catalog.js
@@ -60,6 +60,10 @@ class NodeCatalog {
 			});
 
 		}, this.broker.options.heartbeatInterval * 1000);
+
+		if (typeof this.heartbeatTimer === "number") throw new Error("heartbeatTimer should not be a number. See issue [##362] for details.");
+
+
 		this.heartbeatTimer.unref();
 
 		/* istanbul ignore next */


### PR DESCRIPTION
## :memo: Description
Fail fast when `hearbeatTimer` is a number. This occurs in scenarios when a developer is using Jest for testing and they have failed to set `"testEnvironment": "node"`. By throwing an error here it save development time troubleshooting.

### :dart: Relevant issues
ref: #362 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Write a simple Jest test that does't override the default `testEnvironment` configuration and attempt to start a broker. An error will throw referencing issue #362 which has enough information to fix their code.
