### PR TITLE
shows mqtt granted qos

### DIFF
--- a/src/transporters/mqtt.js
+++ b/src/transporters/mqtt.js
@@ -134,9 +134,12 @@ class MqttTransporter extends Transporter {
 	subscribe(cmd, nodeID) {
 		return new Promise((resolve, reject) => {
 			const topic = this.getTopicName(cmd, nodeID);
-			this.client.subscribe(topic, { qos: this.qos }, err => {
+			this.client.subscribe(topic, { qos: this.qos }, (err, granted) => {
 				if (err)
 					return reject(err);
+
+				this.logger.info("MQTT server granted", granted);
+
 				resolve();
 			});
 		});


### PR DESCRIPTION
## :memo: Description
In MQTT you can require a QoS but is the server that grants the level.
This PR adds a log that shows the granted level.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
