### PR TITLE
reject promise if no cpu data is returned fix #379

### DIFF
--- a/src/cpu-usage.js
+++ b/src/cpu-usage.js
@@ -15,34 +15,37 @@ const os = require("os");
 
 /* istanbul ignore next */
 module.exports = function getCpuUsage(sampleTime = 100) {
-	return new Promise(resolve => {
-		const first = os.cpus().map(cpu => cpu.times);
-		setTimeout(() => {
-			const second = os.cpus().map(cpu => cpu.times);
+	return new Promise((resolve, reject) => {
+		try {
+			const first = os.cpus().map(cpu => cpu.times);
 			setTimeout(() => {
-				const third = os.cpus().map(cpu => cpu.times);
+				const second = os.cpus().map(cpu => cpu.times);
+				setTimeout(() => {
+					const third = os.cpus().map(cpu => cpu.times);
 
-				const usages = [];
-				for (let i = 0; i < first.length; i++) {
-					const first_idle = first[i].idle;
-					const first_total = first[i].idle + first[i].user + first[i].nice + first[i].sys + first[i].irq;
-					const second_idle = second[i].idle;
-					const second_total = second[i].idle + second[i].user + second[i].nice + second[i].sys + second[i].irq;
-					const third_idle = third[i].idle;
-					const third_total = third[i].idle + third[i].user + third[i].nice + third[i].sys + third[i].irq;
-					const first_usage = 1 - (second_idle - first_idle) / (second_total - first_total);
-					const second_usage = 1 - (third_idle - second_idle) / (third_total - second_total);
-					const per_usage = (first_usage + second_usage) / 2 * 100;
-					usages.push(per_usage);
-				}
+					const usages = [];
+					for (let i = 0; i < first.length; i++) {
+						const first_idle = first[i].idle;
+						const first_total = first[i].idle + first[i].user + first[i].nice + first[i].sys + first[i].irq;
+						const second_idle = second[i].idle;
+						const second_total = second[i].idle + second[i].user + second[i].nice + second[i].sys + second[i].irq;
+						const third_idle = third[i].idle;
+						const third_total = third[i].idle + third[i].user + third[i].nice + third[i].sys + third[i].irq;
+						const first_usage = 1 - (second_idle - first_idle) / (second_total - first_total);
+						const second_usage = 1 - (third_idle - second_idle) / (third_total - second_total);
+						const per_usage = (first_usage + second_usage) / 2 * 100;
+						usages.push(per_usage);
+					}
 
-				resolve({
-					avg: usages.reduce((a,b) => a + b, 0) / usages.length,
-					usages
-				});
+					resolve({
+						avg: usages.reduce((a, b) => a + b, 0) / usages.length,
+						usages
+					});
 
+				}, sampleTime);
 			}, sampleTime);
-		}, sampleTime);
-
+		} catch (err) {
+			reject();
+		}
 	});
 };

--- a/test/unit/cpu-usage.spec.js
+++ b/test/unit/cpu-usage.spec.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const os = require('os');
+jest.mock('os');
+jest.useFakeTimers();
+
+const getCpuUsage = require('../../src/cpu-usage');
+
+describe('getCpuUsage', () => {
+	it('should report cpu usage', () => {
+		os.cpus = jest.fn()
+			.mockImplementationOnce(() => [{
+				times: {
+					user: 1,
+					nice: 2,
+					sys: 3,
+					idle: 4,
+					irq: 5,
+				}
+			}])
+			.mockImplementationOnce(() => [{
+				times: {
+					user: 2,
+					nice: 3,
+					sys: 4,
+					idle: 5,
+					irq: 6
+				}
+			}])
+			.mockImplementationOnce(() => [{
+				times: {
+					user: 3,
+					nice: 3,
+					sys: 3,
+					idle: 3,
+					irq: 3
+				}
+			}]);
+
+
+		const result = getCpuUsage(100);
+		jest.runAllTimers();
+		return expect(result).resolves.toEqual({ avg: 70, usages: [70] });
+	});
+
+	it('should return rejected promise on missing cpu data', () => {
+		os.cpus = jest.fn().mockImplementationOnce(() => undefined);
+
+		const result = getCpuUsage(100);
+		jest.runAllTimers();
+		return expect(result).rejects.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## :memo: Description
As stated in the issue, sometimes os.cpus() returns undefined which causes an error on further processing.

### :dart: Relevant issues
#379 

### :gem: Type of change
Catch error if os.cpus() returns undefined and reject promise.

- [x ] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
