### PR TITLE
Return async expect statement

### DIFF
--- a/docs/Moleculer.code-snippets
+++ b/docs/Moleculer.code-snippets
@@ -125,7 +125,7 @@
 			"    describe(\"Test '$1.hello' action\", () => {",
 			"",
 			"        it(\"should return with 'Hello Moleculer'\", () => {",
-			"            expect(broker.call(\"$1.hello\")).resolves.toBe(\"Hello Moleculer\");",
+			"            return expect(broker.call(\"$1.hello\")).resolves.toBe(\"Hello Moleculer\");",
 			"        });",
 			"",
 			"    });",


### PR DESCRIPTION
Because expect().resolves() returns a Promise, tests will always pass unless the result is
returned. The snippet here doesn't include the return call.

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
Fixes #392 
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] npm run test
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
