### PR TITLE
fix(handle uv_os_get_passwd error)

### DIFF
--- a/src/health.js
+++ b/src/health.js
@@ -48,7 +48,7 @@ const getUserInfo = () => {
 	} catch (e) {
 		return {};
 	}
-}
+};
 
 const getOsInfo = () => {
 	return {

--- a/src/health.js
+++ b/src/health.js
@@ -42,6 +42,14 @@ const getMemoryInfo = () => {
 	return mem;
 };
 
+const getUserInfo = () => {
+	try {
+		return os.userInfo();
+	} catch (e) {
+		return {};
+	}
+}
+
 const getOsInfo = () => {
 	return {
 		uptime: os.uptime(),
@@ -50,7 +58,7 @@ const getOsInfo = () => {
 		hostname: os.hostname(),
 		arch: os.arch(),
 		platform: os.platform(),
-		user: os.userInfo()
+		user: getUserInfo()
 	};
 };
 


### PR DESCRIPTION
## :memo: Description

When running an application in Openshift Origin (kubernetes, docker) each call to `$node.health` causes something like
```
[2018-10-20T20:28:38.445Z] ERROR service-33-2g5bm-7/HEALTH:    Request error! Error : ENOENT: no such file or directory, uv_os_get_passwd 
 Error: ENOENT: no such file or directory, uv_os_get_passwd
    at getOsInfo (/app/node_modules/moleculer/src/health.js:53:12)
```

Fix is pretty the same as for `tilelive-postgis`
>

### :dart: Relevant issues
https://github.com/stepankuzmin/tilelive-postgis/issues/10 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

- [x] manually on open shift

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas