### PR TITLE
AMQP connection recovery + Support for AMQP cluster connection

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -108,18 +108,22 @@ class Transit {
 			this.__connectResolve = resolve;
 
 			const doConnect = () => {
-				/* istanbul ignore next */
-				this.tx.connect().catch(err => {
+				let reconnectStarted = false;
+				const errorHandler = (err) => {
 					if (this.disconnecting) return;
+					if (reconnectStarted) return;
 
-					this.logger.warn("Connection is failed.", err.message);
+					this.logger.warn("Connection is failed.", err && err.message || 'Unknown error');
 					this.logger.debug(err);
 
+					reconnectStarted = true;
 					setTimeout(() => {
 						this.logger.info("Reconnecting...");
 						doConnect();
 					}, 5 * 1000);
-				});
+				};
+				/* istanbul ignore next */
+				this.tx.connect(errorHandler).catch(errorHandler);
 			};
 
 			doConnect();

--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -148,11 +148,12 @@ class AmqpTransporter extends Transporter {
 						})
 						.on("close", (err) => {
 							this.connected = false;
-							reject(err);
-							if (!this.connectionDisconnecting)
+							if (!this.connectionDisconnecting) {
 								this.logger.error("AMQP connection is closed.");
-							else
+								reject(err);
+							} else {
 								this.logger.info("AMQP connection is closed gracefully.");
+							}
 						})
 						.on("blocked", (reason) => {
 							this.logger.warn("AMQP connection is blocked.", reason);

--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -129,10 +129,10 @@ class AmqpTransporter extends Transporter {
 			const uri = this.opts.url[urlIndex];
 			const urlParsed = url.parse(uri);
 
-			amqp.connect(uri, {
-				...(this.opts.socketOptions || {}),
-				servername: urlParsed.hostname
-			})
+			amqp.connect(uri, Object.assign({},
+				(this.opts.socketOptions || {}),
+				{servername: urlParsed.hostname}
+			))
 				.then(connection => {
 					this.connection = connection;
 					this.logger.info("AMQP is connected.");

--- a/test/unit/transporters/amqp.spec.js
+++ b/test/unit/transporters/amqp.spec.js
@@ -53,7 +53,7 @@ describe("Test AmqpTransporter constructor", () => {
 		let transporter = new AmqpTransporter("amqp://localhost");
 		expect(transporter).toBeDefined();
 		expect(transporter.opts).toEqual({
-			url: "amqp://localhost",
+			url: ["amqp://localhost"],
 			prefetch: 1,
 			eventTimeToLive: null,
 			heartbeatTimeToLive: null,
@@ -72,7 +72,7 @@ describe("Test AmqpTransporter constructor", () => {
 
 	it("check constructor with options", () => {
 		let opts = {
-			url: "amqp://localhost",
+			url: ["amqp://localhost"],
 			prefetch: 3,
 			eventTimeToLive: 10000,
 			heartbeatTimeToLive: 30000,

--- a/test/unit/transporters/index.spec.js
+++ b/test/unit/transporters/index.spec.js
@@ -103,7 +103,7 @@ describe("Test Transporter resolver", () => {
 				prefetch: 1,
 				heartbeatTimeToLive: null,
 				eventTimeToLive: null,
-				url: "amqp://localhost",
+				url: ["amqp://localhost"],
 				exchangeOptions: {},
 				messageOptions: {},
 				queueOptions: {},


### PR DESCRIPTION
## :memo: Description

**AMQP connection recovery fix**  

Connection to AMQP was not recovering - rejecting resolved promise doesn't work.  
Am I missing something? Should service not automatically recover once connected? Which brings a question, does reconnect work for other transits?  
I resolved this on AMQP transit by passing error callback to connect method and calling this error callback on errors. 

**Support for AMQP cluster connections/mulitple HA proxies**

AMQP `url` can now be an array of URLs or semicolon delimited string containing multiple URLs.  
Nothing fancy, just round robin try thru urls when re-connecting.  


### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## :vertical_traffic_light: How Has This Been Tested?

**AMQP connection recovery**  

No automatic tests added. AMQP connection successfully recovered after restarting RabbitMQ service.

**Support for AMQP cluster connections/multiple HAproxies**

All existing tests pass (covering existing use case with single url).  
Running with multiple urls in production.  

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
