### PR TITLE
Allow specifying 0 retries in call options

### DIFF
--- a/src/middlewares/retry.js
+++ b/src/middlewares/retry.js
@@ -11,7 +11,7 @@ function wrapRetryMiddleware(handler, action) {
 	const opts = Object.assign({}, this.options.retryPolicy, action.retryPolicy || {});
 	if (opts.enabled) {
 		return function retryMiddleware(ctx) {
-			const attempts = ctx.options.retries ? ctx.options.retries : opts.retries;
+			const attempts = typeof ctx.options.retries === 'number' ? ctx.options.retries : opts.retries;
 			if (ctx._retryAttempts == null)
 				ctx._retryAttempts = 0;
 


### PR DESCRIPTION
## :memo: Description

Passing 0 as `retries` in call options was ignored (before this change).  
Is this a design decision or a bug?  
Also not sure if this would be a breaking change.  

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

/

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
