### PR TITLE
fix calling action on service with version 0

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -60,7 +60,7 @@ class Service {
 		this.metadata = schema.metadata || {};
 		this.schema = schema;
 
-		if (this.version && this.settings.$noVersionPrefix !== true)
+		if ((this.version || this.version === 0) && this.settings.$noVersionPrefix !== true)
 			this.fullName = (typeof(this.version) == "number" ? "v" + this.version : this.version) + "." + this.name;
 		else
 			this.fullName = this.name;

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -368,6 +368,14 @@ describe("Test _createAction function", () => {
 		expect(action.myProp).toBe("teszt");
 	});
 
+	it("should create action with version 0", () => {
+		let service = broker.createService({ name: "users", version: 0 });
+
+		let action = service._createAction({ handler }, "find");
+		expect(action.name).toBe("v0.users.find");
+		expect(action.rawName).toBe("find");
+	});
+
 	it("should create action with version string", () => {
 		let service = broker.createService({ name: "users", version: "staging" });
 


### PR DESCRIPTION
## :memo: Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Calling an action on a service with `version: 0` using `broker.call('v0.users.find')` results in `ServiceNotFoundError: Service 'v0.users.find' is not found.` Calling with `broker.call('users.find')` is successful. However, calling `broker.getLocalService('users')` returns `undefined` and `broker.getLocalService('users', 0)` returns the service correctly.

This PR fixes that inconsistency by recognizing 0 as a valid version and appending `v0` appropriately so the call to `v0.users.find` works.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->
None

### :gem: Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] added jest test case

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
