### PR TITLE
Update BrokerTransitOptions with disableReconnect parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,7 @@ declare namespace Moleculer {
 	}
 
 	interface BrokerTransitOptions {
+		disableReconnect?: boolean;
 		maxQueueSize?: number;
 	}
 


### PR DESCRIPTION
## :memo: Description
Missed it at the previous [pull request](https://github.com/moleculerjs/moleculer/pull/391).

