### PR TITLE
service typing should be consistent in naming.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ declare namespace Moleculer {
 	}
 
 	type ServiceActions = { [key: string]: Action | ActionHandler; };
+	type Actions = ServiceActions;
 
 
 	class Context<P = GenericObject, M = GenericObject> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ declare namespace Moleculer {
 		hostname: boolean;
 	}
 
-	type Actions = { [key: string]: Action | ActionHandler; };
+	type ServiceActions = { [key: string]: Action | ActionHandler; };
 
 
 	class Context<P = GenericObject, M = GenericObject> {
@@ -144,7 +144,7 @@ declare namespace Moleculer {
 		settings?: ServiceSettingSchema;
 		dependencies?: string | GenericObject | Array<string> | Array<GenericObject>;
 		metadata?: GenericObject;
-		actions?: Actions;
+		actions?: ServiceActions;
 		mixins?: Array<ServiceSchema>;
 		methods?: ServiceMethods;
 
@@ -168,7 +168,7 @@ declare namespace Moleculer {
 		schema: ServiceSchema;
 		broker: ServiceBroker;
 		logger: LoggerInstance;
-		actions?: Actions;
+		actions?: ServiceActions;
 		Promise: typeof Bluebird;
 
 		waitForServices(serviceNames: string | Array<string> | Array<GenericObject>, timeout?: number, interval?: number): Bluebird<void>;


### PR DESCRIPTION
## :memo: Typescript typing should ideally have consistent naming

Rename `Actions` typing to `ServiceActions` to reflect consistent naming conventions

