### PR TITLE
Fixed 'ERR wrong number of arguments' on empty cache clean

### DIFF
--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -180,7 +180,11 @@ class RedisCacher extends BaseCacher {
 				match: pattern,
 				count: 100
 			});
-			stream.on("data", (keys) => {
+            stream.on("data", (keys = []) => {
+                if (!keys.length) {
+                    return;
+                }
+
 				stream.pause();
 				this.client.del(keys)
 					.then(() => {

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -180,10 +180,10 @@ class RedisCacher extends BaseCacher {
 				match: pattern,
 				count: 100
 			});
-            stream.on("data", (keys = []) => {
-                if (!keys.length) {
-                    return;
-                }
+			stream.on("data", (keys = []) => {
+				if (!keys.length) {
+					return;
+				}
 
 				stream.pause();
 				this.client.del(keys)

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -55,12 +55,12 @@ describe("Test RedisCacher set & get without prefix", () => {
 		}
 	};
 
-    let prefix = "MOL-";
-    let dataEvent;
+	let prefix = "MOL-";
+	let dataEvent;
 
 
 	beforeEach(() => {
-        dataEvent = jest.fn().mockImplementation((eventType, callback) => {
+		dataEvent = jest.fn().mockImplementation((eventType, callback) => {
 			if (eventType === "data") {
 				callback(["key1", "key2"]);
 			}
@@ -132,14 +132,14 @@ describe("Test RedisCacher set & get without prefix", () => {
 	});
 
 	it("should not call del if data returns an empty array", () => {
-        dataEvent.mockImplementationOnce((eventType, callback) => {
+		dataEvent.mockImplementationOnce((eventType, callback) => {
 			if (eventType === "data") {
 				callback([]);
 			}
 			if (eventType === "end") {
 				callback();
 			}
-        });
+		});
 
 		return cacher.clean()
 			.catch(protectReject)


### PR DESCRIPTION
## :memo: Description

Fixed 'ERR wrong number of arguments' error on an empty cache clean for redis cacher 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
