### PR TITLE
Fix incompatibility issue between ES6 Promise and Bluebird in Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from "bluebird";
 declare namespace Moleculer {
 	type GenericObject = { [name: string]: any };
 
@@ -22,7 +21,7 @@ declare namespace Moleculer {
 		trace(...args: any[]): void;
 	}
 
-	type ActionHandler<T = any> = ((ctx: Context) => Bluebird<T> | T) & ThisType<Service>;
+	type ActionHandler<T = any> = ((ctx: Context) => PromiseLike<T> | T) & ThisType<Service>;
 	type ActionParamSchema = { [key: string]: any };
 	type ActionParamTypes = "boolean" | "number" | "string" | "object" | "array" | ActionParamSchema;
 	type ActionParams = { [key: string]: ActionParamTypes };
@@ -96,7 +95,7 @@ declare namespace Moleculer {
 		cachedResult: boolean;
 
 		setParams(newParams: P, cloning?: boolean): void;
-		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: GenericObject): Bluebird<T>;
+		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
 		emit(eventName: string, data: any, groups: Array<string>): void;
 		emit(eventName: string, data: any, groups: string): void;
 		emit(eventName: string, data: any): void;
@@ -154,8 +153,8 @@ declare namespace Moleculer {
 
 		events?: ServiceEvents;
 		created?: () => void;
-		started?: () => Bluebird<void>;
-		stopped?: () => Bluebird<void>;
+		started?: () => PromiseLike<void>;
+		stopped?: () => PromiseLike<void>;
 		[name: string]: any;
 	}
 
@@ -173,13 +172,13 @@ declare namespace Moleculer {
 		broker: ServiceBroker;
 		logger: LoggerInstance;
 		actions?: ServiceActions;
-		Promise: typeof Bluebird;
+		Promise: PromiseConstructorLike;
 
-		waitForServices(serviceNames: string | Array<string> | Array<GenericObject>, timeout?: number, interval?: number): Bluebird<void>;
+		waitForServices(serviceNames: string | Array<string> | Array<GenericObject>, timeout?: number, interval?: number): PromiseLike<void>;
 
 		_init(): void;
-		_start(): Bluebird<void>;
-		_stop(): Bluebird<void>;
+		_start(): PromiseLike<void>;
+		_stop(): PromiseLike<void>;
 		[name: string]: any;
 	}
 
@@ -331,9 +330,9 @@ declare namespace Moleculer {
 		};
 	}
 
-	type FallbackHandler = (ctx: Context, err: Errors.MoleculerError) => Bluebird<any>;
+	type FallbackHandler = (ctx: Context, err: Errors.MoleculerError) => PromiseLike<any>;
 	type FallbackResponse = string | number | GenericObject;
-	type FallbackResponseHandler = (ctx: Context, err: Errors.MoleculerError) => Bluebird<any>;
+	type FallbackResponseHandler = (ctx: Context, err: Errors.MoleculerError) => PromiseLike<any>;
 
 	interface CallingOptions {
 		timeout?: number;
@@ -378,7 +377,7 @@ declare namespace Moleculer {
 	class ServiceBroker {
 		constructor(options?: BrokerOptions);
 
-		Promise: typeof Bluebird;
+		Promise: PromiseConstructorLike;
 
 		namespace: string;
 		nodeID: string;
@@ -389,8 +388,8 @@ declare namespace Moleculer {
 		transit: GenericObject;
 		middlewares: MiddlewareHandler;
 
-		start(): Bluebird<void>;
-		stop(): Bluebird<void>;
+		start(): PromiseLike<void>;
+		stop(): PromiseLike<void>;
 
 		repl(): void;
 
@@ -401,10 +400,10 @@ declare namespace Moleculer {
 		watchService(service: Service): void;
 		hotReloadService(service: Service): Service;
 		createService(schema: ServiceSchema, schemaMods?: ServiceSchema): Service;
-		destroyService(service: Service): Bluebird<void>;
+		destroyService(service: Service): PromiseLike<void>;
 
 		getLocalService(serviceName: string, version?: string | number): Service;
-		waitForServices(serviceNames: string | Array<string> | Array<GenericObject>, timeout?: number, interval?: number, logger?: LoggerInstance): Bluebird<void>;
+		waitForServices(serviceNames: string | Array<string> | Array<GenericObject>, timeout?: number, interval?: number, logger?: LoggerInstance): PromiseLike<void>;
 
 		/**
 		 *
@@ -425,13 +424,13 @@ declare namespace Moleculer {
 		 *
 		 * @memberof ServiceBroker
 		 */
-		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: CallingOptions): Bluebird<T>;
+		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: CallingOptions): PromiseLike<T>;
 
 		/**
 		 * Multiple action calls.
 		 *
 		 * @param {Array<CallDefinition> | { [name: string]: CallDefinition }} def Calling definitions.
-		 * @returns {Bluebird<Array<GenericObject>|GenericObject>}
+		 * @returns {PromiseLike<Array<GenericObject>|GenericObject>}
 		 * | (broker: ServiceBroker): Service)
 		 * @example
 		 * Call `mcall` with an array:
@@ -460,7 +459,7 @@ declare namespace Moleculer {
 		 *
 		 * @memberof ServiceBroker
 		 */
-		mcall<T = any>(def: Array<CallDefinition> | { [name: string]: CallDefinition }): Bluebird<Array<T> | T>;
+		mcall<T = any>(def: Array<CallDefinition> | { [name: string]: CallDefinition }): PromiseLike<Array<T> | T>;
 
 		/**
 		 * Emit an event (global & local)
@@ -497,9 +496,9 @@ declare namespace Moleculer {
 		 */
 		broadcastLocal(eventName: string, payload?: any, groups?: string | Array<string>): void;
 
-		ping(): Bluebird<PongResponses>;
-		ping(nodeID: string, timeout?: number): Bluebird<PongResponse>;
-		ping(nodeID: Array<string>, timeout?: number): Bluebird<PongResponses>;
+		ping(): PromiseLike<PongResponses>;
+		ping(nodeID: string, timeout?: number): PromiseLike<PongResponse>;
+		ping(nodeID: Array<string>, timeout?: number): PromiseLike<PongResponses>;
 
 		getHealthStatus(): NodeHealthStatus;
 		getLocalNodeInfo(): {
@@ -511,7 +510,7 @@ declare namespace Moleculer {
 			services: Array<any>;
 		};
 
-		getCpuUsage(): Bluebird<any>;
+		getCpuUsage(): PromiseLike<any>;
 
 		MOLECULER_VERSION: string;
 		PROTOCOL_VERSION: string;
@@ -575,24 +574,24 @@ declare namespace Moleculer {
 	class Transporter {
 		constructor(opts?: GenericObject);
 		init(transit: Transit, messageHandler: (cmd: string, msg: string) => void, afterConnect: (wasReconnect: boolean) => void): void;
-		connect(): Bluebird<any>;
-		disconnect(): Bluebird<any>;
+		connect(): PromiseLike<any>;
+		disconnect(): PromiseLike<any>;
 
-		makeSubscriptions(topics: Array<GenericObject>): Bluebird<void>;
-		subscribe(cmd: string, nodeID?: string): Bluebird<void>;
-		subscribeBalancedRequest(action: string): Bluebird<void>;
-		subscribeBalancedEvent(event: string, group: string): Bluebird<void>;
-		unsubscribeFromBalancedCommands(): Bluebird<void>;
+		makeSubscriptions(topics: Array<GenericObject>): PromiseLike<void>;
+		subscribe(cmd: string, nodeID?: string): PromiseLike<void>;
+		subscribeBalancedRequest(action: string): PromiseLike<void>;
+		subscribeBalancedEvent(event: string, group: string): PromiseLike<void>;
+		unsubscribeFromBalancedCommands(): PromiseLike<void>;
 
-		incomingMessage(cmd: string, msg: Buffer): Bluebird<void>;
+		incomingMessage(cmd: string, msg: Buffer): PromiseLike<void>;
 
-		prepublish(packet: Packet): Bluebird<void>;
-		publish(packet: Packet): Bluebird<void>;
-		publishBalancedEvent(packet: Packet, group: string): Bluebird<void>;
-		publishBalancedRequest(packet: Packet): Bluebird<void>;
+		prepublish(packet: Packet): PromiseLike<void>;
+		publish(packet: Packet): PromiseLike<void>;
+		publishBalancedEvent(packet: Packet, group: string): PromiseLike<void>;
+		publishBalancedRequest(packet: Packet): PromiseLike<void>;
 
 		getTopicName(cmd: string, nodeID?: string): string;
-		makeBalancedSubscriptions(): Bluebird<void>;
+		makeBalancedSubscriptions(): PromiseLike<void>;
 
 		serialize(packet: Packet): Buffer;
 		deserialize(type: string, data: Buffer): Packet;
@@ -601,11 +600,11 @@ declare namespace Moleculer {
 	class Cacher {
 		constructor(opts?: GenericObject);
 		init(broker: ServiceBroker): void;
-		close(): Bluebird<any>;
-		get(key: string): Bluebird<null | GenericObject>;
-		set(key: string, data: any, ttl?: number): Bluebird<any>;
-		del(key: string|Array<string>): Bluebird<any>;
-		clean(match?: string|Array<string>): Bluebird<any>;
+		close(): PromiseLike<any>;
+		get(key: string): PromiseLike<null | GenericObject>;
+		set(key: string, data: any, ttl?: number): PromiseLike<any>;
+		del(key: string|Array<string>): PromiseLike<any>;
+		clean(match?: string|Array<string>): PromiseLike<any>;
 	}
 
 	class Serializer {
@@ -646,8 +645,8 @@ declare namespace Moleculer {
 	}
 
 	namespace Transporters {
-		type MessageHandler = ((cmd: string, msg: any) => Bluebird<void>) & ThisType<Base>;
-		type AfterConnectHandler = ((wasReconnect?: boolean) => Bluebird<void>) & ThisType<Base>;
+		type MessageHandler = ((cmd: string, msg: any) => PromiseLike<void>) & ThisType<Base>;
+		type AfterConnectHandler = ((wasReconnect?: boolean) => PromiseLike<void>) & ThisType<Base>;
 
 		class Base {
 			constructor(opts?: GenericObject);
@@ -655,23 +654,23 @@ declare namespace Moleculer {
 			public init(transit: Transit, messageHandler: MessageHandler, afterConnect: AfterConnectHandler): void;
 			public init(transit: Transit, messageHandler: MessageHandler): void;
 
-			public connect(): Bluebird<any>;
-			public onConnected(wasReconnect?: boolean): Bluebird<void>;
-			public disconnect(): Bluebird<void>;
+			public connect(): PromiseLike<any>;
+			public onConnected(wasReconnect?: boolean): PromiseLike<void>;
+			public disconnect(): PromiseLike<void>;
 
 			public getTopicName(cmd: string, nodeID?: string): string;
-			public makeSubscriptions(topics: Array<GenericObject>): Bluebird<void>;
-			public subscribe(cmd: string, nodeID: string): Bluebird<void>;
-			public subscribeBalancedRequest(action: string): Bluebird<void>;
-			public subscribeBalancedEvent(event: string, group: string): Bluebird<void>;
-			public unsubscribeFromBalancedCommands(): Bluebird<void>;
+			public makeSubscriptions(topics: Array<GenericObject>): PromiseLike<void>;
+			public subscribe(cmd: string, nodeID: string): PromiseLike<void>;
+			public subscribeBalancedRequest(action: string): PromiseLike<void>;
+			public subscribeBalancedEvent(event: string, group: string): PromiseLike<void>;
+			public unsubscribeFromBalancedCommands(): PromiseLike<void>;
 
-			protected incomingMessage(cmd: string, msg: Buffer): Bluebird<void>;
+			protected incomingMessage(cmd: string, msg: Buffer): PromiseLike<void>;
 
-			public publish(packet: Packet): Bluebird<void>;
-			public publishBalancedEvent(packet: Packet, group: string): Bluebird<void>;
-			public publishBalancedRequest(packet: Packet): Bluebird<void>;
-			public prepublish(packet: Packet): Bluebird<void>;
+			public publish(packet: Packet): PromiseLike<void>;
+			public publishBalancedEvent(packet: Packet, group: string): PromiseLike<void>;
+			public publishBalancedRequest(packet: Packet): PromiseLike<void>;
+			public prepublish(packet: Packet): PromiseLike<void>;
 
 			public serialize(packet: Packet): Buffer;
 			public deserialize(type: string, data: Buffer): Packet;
@@ -808,30 +807,30 @@ declare namespace Moleculer {
 	}
 
 	interface Transit {
-		afterConnect(wasReconnect: boolean): Bluebird<void>;
-		connect(): Bluebird<void>;
-		disconnect(): Bluebird<void>;
-		sendDisconnectPacket(): Bluebird<void>;
-		makeSubscriptions(): Bluebird<Array<void>>;
-		messageHandler(cmd: string, msg: GenericObject): boolean | Bluebird<void> | undefined;
-		request(ctx: Context): Bluebird<void>;
+		afterConnect(wasReconnect: boolean): PromiseLike<void>;
+		connect(): PromiseLike<void>;
+		disconnect(): PromiseLike<void>;
+		sendDisconnectPacket(): PromiseLike<void>;
+		makeSubscriptions(): PromiseLike<Array<void>>;
+		messageHandler(cmd: string, msg: GenericObject): boolean | PromiseLike<void> | undefined;
+		request(ctx: Context): PromiseLike<void>;
 		sendBroadcastEvent(nodeID: string, eventName: string, data: GenericObject, nodeGroups: GenericObject): void;
 		sendBalancedEvent(eventName: string, data: GenericObject, nodeGroups: GenericObject): void;
 		sendEventToGroups(eventName: string, data: GenericObject, groups: Array<string>): void;
 		sendEventToGroups(eventName: string, data: GenericObject): void;
 		removePendingRequest(id: string): void;
 		removePendingRequestByNodeID(nodeID: string): void;
-		sendResponse(nodeID: string, id: string, data: GenericObject, err: Error): Bluebird<void>;
-		sendResponse(nodeID: string, id: string, data: GenericObject): Bluebird<void>;
-		discoverNodes(): Bluebird<void>;
-		discoverNode(nodeID: string): Bluebird<void>;
-		sendNodeInfo(nodeID: string): Bluebird<void | Array<void>>;
-		sendPing(nodeID: string): Bluebird<void>;
-		sendPong(payload: GenericObject): Bluebird<void>;
+		sendResponse(nodeID: string, id: string, data: GenericObject, err: Error): PromiseLike<void>;
+		sendResponse(nodeID: string, id: string, data: GenericObject): PromiseLike<void>;
+		discoverNodes(): PromiseLike<void>;
+		discoverNode(nodeID: string): PromiseLike<void>;
+		sendNodeInfo(nodeID: string): PromiseLike<void | Array<void>>;
+		sendPing(nodeID: string): PromiseLike<void>;
+		sendPong(payload: GenericObject): PromiseLike<void>;
 		processPong(payload: GenericObject): void;
-		sendHeartbeat(localNode: NodeHealthStatus): Bluebird<void>;
-		subscribe(topic: string, nodeID: string): Bluebird<void>;
-		publish(packet: Packet): Bluebird<void>;
+		sendHeartbeat(localNode: NodeHealthStatus): PromiseLike<void>;
+		subscribe(topic: string, nodeID: string): PromiseLike<void>;
+		publish(packet: Packet): PromiseLike<void>;
 
 		pendingRequests: Map<string, TransitRequest>
 		nodeID: string;


### PR DESCRIPTION
## :memo: Description
I added async started and stopped functions to my service schema but Typescript gives the error below:

```js
import http from 'http';
import { ServiceSchema } from 'moleculer';

const serviceSchema: ServiceSchema = {
  name: 'www',

  settings: {
    port: 3000,
  },

  created() {
    this.server = http.createServer(this.httpHandler);
  },

  async started() {
    this.server.listen(this.settings.port);
  },

  async stopped() {
    this.server.close();
  },

  methods: {
    httpHandler(req: any, res: any) {
      res.end('Hello Moleculer!');
    },
  },
};
```

Here is the ts error:

```
Type '() => Promise<void>' is not assignable to type '() => Bluebird<void>'.
  Type 'Promise<void>' is not assignable to type 'Bluebird<void>'.
    Property 'caught' is missing in type 'Promise<void>'.
Type '() => Promise<void>' is not assignable to type '() => Bluebird<void>'.
  Type 'Promise<void>' is not assignable to type 'Bluebird<void>'.
```

Bluebird itself implements PromiseLike interface, so I thought It would be good choice to use PromiseLike instead of Bluebird to remove incompatibility. Or we could use union type, maybe?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
