### PR TITLE
Allow versioned strings for waitForService()

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -751,7 +751,30 @@ class ServiceBroker {
 		if (!Array.isArray(serviceNames))
 			serviceNames = [serviceNames];
 
-		const serviceObjs = serviceNames.map(x => _.isPlainObject(x) ? x : { name: x }).filter(x => x.name);
+		const serviceObjs = serviceNames.map(x => {
+			if (_.isPlainObject(x)) {
+				return x;
+			}
+
+			if (_.isString(x)) {
+				// Parse versioned service identifier strings
+				const split = x.split(".");
+				if (
+					split.length === 2 &&
+					split[0].length > 0 &&
+					split[0].match(/^v\d+$/)
+				) {
+					return {
+						name: split[1],
+						version: Number(split[0].slice(1)),
+					};
+				}
+				// If not versioned, fall back to the existing default action to hopefully avoid breaking existing implementations
+			}
+
+			return { name: x };
+		}).filter(x => x.name);
+
 		if (serviceObjs.length == 0)
 			return Promise.resolve();
 

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1233,6 +1233,32 @@ describe("Test broker.waitForServices", () => {
 		return p;
 	});
 
+	it("should wait for service when service is passed as a versioned string", () => {
+		res = false;
+		broker.registry.hasService.mockClear();
+		let p = broker.waitForServices("v1.posts", 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", 1);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
+	it("should wait for service when service is passed as an array of versioned strings", () => {
+		res = false;
+		broker.registry.hasService.mockClear();
+		let p = broker.waitForServices(["v1.posts"], 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", 1);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
 	it("should not wait for service when service is passed as an array of object without name", () => {
 		res = false;
 		broker.registry.hasService.mockClear();


### PR DESCRIPTION
## :memo: Description

Added an enhancement to the `waitForService()` function to support versioned string identifiers for services (eg: `v1.posts`).

### :dart: Relevant issues

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)

### :scroll: Example code
```js
broker.waitForServices("v1.posts");
broker.waitForServices(["v1.posts", "v3.users"]);
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test to verify the function waited for service specified by a versioned string
- [x] Unit test to verify the function waited for service specified by an array of versioned strings
- [x] Verified that the tests of the existing functionality still passed.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
