### PR TITLE
fix logger types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,14 @@ declare namespace Moleculer {
 		trace: (...args: any[]) => void;
 	}
 
+	interface LoggerBindings {
+  		nodeID: string;
+  		ns: string;
+  		mod: string;
+  		svc: string;
+  		ver: string | void;
+	}
+	
 	class LoggerInstance {
 		fatal(...args: any[]): void;
 		error(...args: any[]): void;
@@ -227,7 +235,7 @@ declare namespace Moleculer {
 		namespace?: string;
 		nodeID?: string;
 
-		logger?: Logger | boolean;
+		logger?: ((bindings: LoggerBindings) => Logger) | Logger | boolean;
 		logLevel?: LogLevels | LogLevelConfig;
 		logFormatter?: Function | string;
 		logObjectPrinter?: Function;


### PR DESCRIPTION
## :memo: Description

This PR fix incorrect typing, when can't use `logger` as function in broker options

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
