### PR TITLE
Mark handlers as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare namespace Moleculer {
 		params?: ActionParams;
 		service?: Service;
 		cache?: boolean | ActionCacheOptions;
-		handler: ActionHandler;
+		handler?: ActionHandler;
 		metrics?: MetricsOptions;
 		bulkhead?: BulkheadOptions;
 		circuitBreaker?: BrokerCircuitBreakerOptions;
@@ -130,7 +130,7 @@ declare namespace Moleculer {
 	interface ServiceEvent {
 		name?: string;
 		group?: string;
-		handler: ServiceEventHandler;
+		handler?: ServiceEventHandler;
 	}
 
 	type ServiceEvents = { [key: string]: ServiceEventHandler | ServiceEvent };


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

PR fixes #467.  A service's actions and events can be comprised from included mixins as well as the local definitions.  Since the `handler` definitions may reside in the mixin and not the service (or vice-versa), marking the `handler` as a required property is incorrect.  The PR marks the `handler` for `Action` and `ServiceEvent` as optional.

### :dart: Relevant issues
#467 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## :vertical_traffic_light: How Has This Been Tested?

Tested the type in my own repo.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
