### PR TITLE
Remove @types/ioredis dependency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import * as Ioredis from 'ioredis';
-
 declare namespace Moleculer {
 	type GenericObject = { [name: string]: any };
 
@@ -414,7 +412,7 @@ declare namespace Moleculer {
 		namespace: string;
 		nodeID: string;
 		logger: LoggerInstance;
-		cacher?: Cacher | RedisCacher;
+		cacher?: Cacher;
 		serializer?: Serializer;
 		validator?: Validator;
 		transit: GenericObject;
@@ -637,10 +635,7 @@ declare namespace Moleculer {
 		set(key: string, data: any, ttl?: number): PromiseLike<any>;
 		del(key: string|Array<string>): PromiseLike<any>;
 		clean(match?: string|Array<string>): PromiseLike<any>;
-	}
-
-	class RedisCacher extends Cacher {
-		client: Ioredis.Redis;
+		client?: any;
 	}
 
 	class Serializer {
@@ -736,7 +731,7 @@ declare namespace Moleculer {
 
 	const Cachers: {
 		Memory: Cacher,
-		Redis: RedisCacher
+		Redis: Cacher
 	};
 	const Serializers: {
 		JSON: Serializer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,15 +231,6 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "dev": true
     },
-    "@types/ioredis": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.0.6.tgz",
-      "integrity": "sha512-FB8acNZCTLs2zXI3KuAAZJnKkFD04eNoBfgV6gT1ZABNrxbEVkBawPDLBNzhJWSfGT2eh5ELcS1cIwL4OGz/tA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "author": "Icebob",
   "license": "MIT",
   "devDependencies": {
-    "@types/ioredis": "4.0.6",
     "@types/node": "11.9.4",
     "amqplib": "0.5.3",
     "avsc": "5.4.7",


### PR DESCRIPTION
## :memo: Description

Suggested fix for #475. **This should not be merged without being accepted by the discussion there.**

Partially reverts #459 to fix issues with people not using the Redis cacher.

Adds `client` as an optional property typed to `any` on the cacher for visibility. This will require TS users to at least check for the property or cast the type to `Redis.Redis` themselves (recommended implementation).

### :dart: Relevant issues

#475 
#459 
#456 

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```ts
import * as Redis from 'ioredis';

const pipeline = (this.broker.cacher.client as Redis.Redis).pipeline();
pipeline.set('foo', 'bar');
pipeline.set('baz', 'qux');
pipeline.exec();
```

## :vertical_traffic_light: How Has This Been Tested?

Reverts to previous state plus an optional `any` typed property. Does not break any existing code.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
