### PR TITLE
added seq property on PacketInfo protobuf message

### DIFF
--- a/src/serializers/proto/packets.proto
+++ b/src/serializers/proto/packets.proto
@@ -51,8 +51,7 @@ message PacketInfo {
 	repeated string ipList			= 5;
 	required string hostname		= 6;
 	required Client client 			= 7;
-	required int32  seq 			= 8;
-
+	optional int32  seq 			= 8;
 
 	message Client {
 		required string type 			= 1;

--- a/src/serializers/proto/packets.proto
+++ b/src/serializers/proto/packets.proto
@@ -51,6 +51,8 @@ message PacketInfo {
 	repeated string ipList			= 5;
 	required string hostname		= 6;
 	required Client client 			= 7;
+	required int32  seq 			= 8;
+
 
 	message Client {
 		required string type 			= 1;

--- a/src/serializers/proto/packets.proto.js
+++ b/src/serializers/proto/packets.proto.js
@@ -9,18 +9,19 @@ var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.ut
 // Exported root namespace
 var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
 
+/* istanbul ignore next */
 $root.packets = (function() {
 
-    /**
+	/**
      * Namespace packets.
      * @exports packets
      * @namespace
      */
-    var packets = {};
+	var packets = {};
 
-    packets.PacketEvent = (function() {
+	packets.PacketEvent = (function() {
 
-        /**
+		/**
          * Properties of a PacketEvent.
          * @memberof packets
          * @interface IPacketEvent
@@ -32,7 +33,7 @@ $root.packets = (function() {
          * @property {boolean} broadcast PacketEvent broadcast
          */
 
-        /**
+		/**
          * Constructs a new PacketEvent.
          * @memberof packets
          * @classdesc Represents a PacketEvent.
@@ -40,63 +41,63 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketEvent=} [properties] Properties to set
          */
-        function PacketEvent(properties) {
-            this.groups = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketEvent(properties) {
+			this.groups = [];
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketEvent ver.
          * @member {string} ver
          * @memberof packets.PacketEvent
          * @instance
          */
-        PacketEvent.prototype.ver = "";
+		PacketEvent.prototype.ver = "";
 
-        /**
+		/**
          * PacketEvent sender.
          * @member {string} sender
          * @memberof packets.PacketEvent
          * @instance
          */
-        PacketEvent.prototype.sender = "";
+		PacketEvent.prototype.sender = "";
 
-        /**
+		/**
          * PacketEvent event.
          * @member {string} event
          * @memberof packets.PacketEvent
          * @instance
          */
-        PacketEvent.prototype.event = "";
+		PacketEvent.prototype.event = "";
 
-        /**
+		/**
          * PacketEvent data.
          * @member {string} data
          * @memberof packets.PacketEvent
          * @instance
          */
-        PacketEvent.prototype.data = "";
+		PacketEvent.prototype.data = "";
 
-        /**
+		/**
          * PacketEvent groups.
          * @member {Array.<string>} groups
          * @memberof packets.PacketEvent
          * @instance
          */
-        PacketEvent.prototype.groups = $util.emptyArray;
+		PacketEvent.prototype.groups = $util.emptyArray;
 
-        /**
+		/**
          * PacketEvent broadcast.
          * @member {boolean} broadcast
          * @memberof packets.PacketEvent
          * @instance
          */
-        PacketEvent.prototype.broadcast = false;
+		PacketEvent.prototype.broadcast = false;
 
-        /**
+		/**
          * Creates a new PacketEvent instance using the specified properties.
          * @function create
          * @memberof packets.PacketEvent
@@ -104,11 +105,11 @@ $root.packets = (function() {
          * @param {packets.IPacketEvent=} [properties] Properties to set
          * @returns {packets.PacketEvent} PacketEvent instance
          */
-        PacketEvent.create = function create(properties) {
-            return new PacketEvent(properties);
-        };
+		PacketEvent.create = function create(properties) {
+			return new PacketEvent(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketEvent message. Does not implicitly {@link packets.PacketEvent.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketEvent
@@ -117,22 +118,22 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketEvent.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 2 =*/26).string(message.event);
-            if (message.data != null && message.hasOwnProperty("data"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
-            if (message.groups != null && message.groups.length)
-                for (var i = 0; i < message.groups.length; ++i)
-                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.groups[i]);
-            writer.uint32(/* id 6, wireType 0 =*/48).bool(message.broadcast);
-            return writer;
-        };
+		PacketEvent.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 2 =*/26).string(message.event);
+			if (message.data != null && message.hasOwnProperty("data"))
+				writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
+			if (message.groups != null && message.groups.length)
+				for (var i = 0; i < message.groups.length; ++i)
+					writer.uint32(/* id 5, wireType 2 =*/42).string(message.groups[i]);
+			writer.uint32(/* id 6, wireType 0 =*/48).bool(message.broadcast);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketEvent message, length delimited. Does not implicitly {@link packets.PacketEvent.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketEvent
@@ -141,11 +142,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketEvent.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketEvent.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketEvent message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketEvent
@@ -156,50 +157,50 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketEvent.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketEvent();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.event = reader.string();
-                    break;
-                case 4:
-                    message.data = reader.string();
-                    break;
-                case 5:
-                    if (!(message.groups && message.groups.length))
-                        message.groups = [];
-                    message.groups.push(reader.string());
-                    break;
-                case 6:
-                    message.broadcast = reader.bool();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("event"))
-                throw $util.ProtocolError("missing required 'event'", { instance: message });
-            if (!message.hasOwnProperty("broadcast"))
-                throw $util.ProtocolError("missing required 'broadcast'", { instance: message });
-            return message;
-        };
+		PacketEvent.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketEvent();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.event = reader.string();
+						break;
+					case 4:
+						message.data = reader.string();
+						break;
+					case 5:
+						if (!(message.groups && message.groups.length))
+							message.groups = [];
+						message.groups.push(reader.string());
+						break;
+					case 6:
+						message.broadcast = reader.bool();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("event"))
+				throw $util.ProtocolError("missing required 'event'", { instance: message });
+			if (!message.hasOwnProperty("broadcast"))
+				throw $util.ProtocolError("missing required 'broadcast'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketEvent message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketEvent
@@ -209,13 +210,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketEvent.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketEvent.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketEvent message.
          * @function verify
          * @memberof packets.PacketEvent
@@ -223,31 +224,31 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketEvent.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isString(message.event))
-                return "event: string expected";
-            if (message.data != null && message.hasOwnProperty("data"))
-                if (!$util.isString(message.data))
-                    return "data: string expected";
-            if (message.groups != null && message.hasOwnProperty("groups")) {
-                if (!Array.isArray(message.groups))
-                    return "groups: array expected";
-                for (var i = 0; i < message.groups.length; ++i)
-                    if (!$util.isString(message.groups[i]))
-                        return "groups: string[] expected";
-            }
-            if (typeof message.broadcast !== "boolean")
-                return "broadcast: boolean expected";
-            return null;
-        };
+		PacketEvent.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isString(message.event))
+				return "event: string expected";
+			if (message.data != null && message.hasOwnProperty("data"))
+				if (!$util.isString(message.data))
+					return "data: string expected";
+			if (message.groups != null && message.hasOwnProperty("groups")) {
+				if (!Array.isArray(message.groups))
+					return "groups: array expected";
+				for (var i = 0; i < message.groups.length; ++i)
+					if (!$util.isString(message.groups[i]))
+						return "groups: string[] expected";
+			}
+			if (typeof message.broadcast !== "boolean")
+				return "broadcast: boolean expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketEvent message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketEvent
@@ -255,31 +256,31 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketEvent} PacketEvent
          */
-        PacketEvent.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketEvent)
-                return object;
-            var message = new $root.packets.PacketEvent();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.event != null)
-                message.event = String(object.event);
-            if (object.data != null)
-                message.data = String(object.data);
-            if (object.groups) {
-                if (!Array.isArray(object.groups))
-                    throw TypeError(".packets.PacketEvent.groups: array expected");
-                message.groups = [];
-                for (var i = 0; i < object.groups.length; ++i)
-                    message.groups[i] = String(object.groups[i]);
-            }
-            if (object.broadcast != null)
-                message.broadcast = Boolean(object.broadcast);
-            return message;
-        };
+		PacketEvent.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketEvent)
+				return object;
+			var message = new $root.packets.PacketEvent();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.event != null)
+				message.event = String(object.event);
+			if (object.data != null)
+				message.data = String(object.data);
+			if (object.groups) {
+				if (!Array.isArray(object.groups))
+					throw TypeError(".packets.PacketEvent.groups: array expected");
+				message.groups = [];
+				for (var i = 0; i < object.groups.length; ++i)
+					message.groups[i] = String(object.groups[i]);
+			}
+			if (object.broadcast != null)
+				message.broadcast = Boolean(object.broadcast);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketEvent message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketEvent
@@ -288,54 +289,54 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketEvent.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.groups = [];
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.event = "";
-                object.data = "";
-                object.broadcast = false;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.event != null && message.hasOwnProperty("event"))
-                object.event = message.event;
-            if (message.data != null && message.hasOwnProperty("data"))
-                object.data = message.data;
-            if (message.groups && message.groups.length) {
-                object.groups = [];
-                for (var j = 0; j < message.groups.length; ++j)
-                    object.groups[j] = message.groups[j];
-            }
-            if (message.broadcast != null && message.hasOwnProperty("broadcast"))
-                object.broadcast = message.broadcast;
-            return object;
-        };
+		PacketEvent.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.arrays || options.defaults)
+				object.groups = [];
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.event = "";
+				object.data = "";
+				object.broadcast = false;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.event != null && message.hasOwnProperty("event"))
+				object.event = message.event;
+			if (message.data != null && message.hasOwnProperty("data"))
+				object.data = message.data;
+			if (message.groups && message.groups.length) {
+				object.groups = [];
+				for (var j = 0; j < message.groups.length; ++j)
+					object.groups[j] = message.groups[j];
+			}
+			if (message.broadcast != null && message.hasOwnProperty("broadcast"))
+				object.broadcast = message.broadcast;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketEvent to JSON.
          * @function toJSON
          * @memberof packets.PacketEvent
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketEvent.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketEvent.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketEvent;
-    })();
+		return PacketEvent;
+	})();
 
-    packets.PacketRequest = (function() {
+	packets.PacketRequest = (function() {
 
-        /**
+		/**
          * Properties of a PacketRequest.
          * @memberof packets
          * @interface IPacketRequest
@@ -353,7 +354,7 @@ $root.packets = (function() {
          * @property {boolean|null} [stream] PacketRequest stream
          */
 
-        /**
+		/**
          * Constructs a new PacketRequest.
          * @memberof packets
          * @classdesc Represents a PacketRequest.
@@ -361,110 +362,110 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketRequest=} [properties] Properties to set
          */
-        function PacketRequest(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketRequest(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketRequest ver.
          * @member {string} ver
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.ver = "";
+		PacketRequest.prototype.ver = "";
 
-        /**
+		/**
          * PacketRequest sender.
          * @member {string} sender
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.sender = "";
+		PacketRequest.prototype.sender = "";
 
-        /**
+		/**
          * PacketRequest id.
          * @member {string} id
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.id = "";
+		PacketRequest.prototype.id = "";
 
-        /**
+		/**
          * PacketRequest action.
          * @member {string} action
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.action = "";
+		PacketRequest.prototype.action = "";
 
-        /**
+		/**
          * PacketRequest params.
          * @member {Uint8Array} params
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.params = $util.newBuffer([]);
+		PacketRequest.prototype.params = $util.newBuffer([]);
 
-        /**
+		/**
          * PacketRequest meta.
          * @member {string} meta
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.meta = "";
+		PacketRequest.prototype.meta = "";
 
-        /**
+		/**
          * PacketRequest timeout.
          * @member {number} timeout
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.timeout = 0;
+		PacketRequest.prototype.timeout = 0;
 
-        /**
+		/**
          * PacketRequest level.
          * @member {number} level
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.level = 0;
+		PacketRequest.prototype.level = 0;
 
-        /**
+		/**
          * PacketRequest metrics.
          * @member {boolean} metrics
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.metrics = false;
+		PacketRequest.prototype.metrics = false;
 
-        /**
+		/**
          * PacketRequest parentID.
          * @member {string} parentID
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.parentID = "";
+		PacketRequest.prototype.parentID = "";
 
-        /**
+		/**
          * PacketRequest requestID.
          * @member {string} requestID
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.requestID = "";
+		PacketRequest.prototype.requestID = "";
 
-        /**
+		/**
          * PacketRequest stream.
          * @member {boolean} stream
          * @memberof packets.PacketRequest
          * @instance
          */
-        PacketRequest.prototype.stream = false;
+		PacketRequest.prototype.stream = false;
 
-        /**
+		/**
          * Creates a new PacketRequest instance using the specified properties.
          * @function create
          * @memberof packets.PacketRequest
@@ -472,11 +473,11 @@ $root.packets = (function() {
          * @param {packets.IPacketRequest=} [properties] Properties to set
          * @returns {packets.PacketRequest} PacketRequest instance
          */
-        PacketRequest.create = function create(properties) {
-            return new PacketRequest(properties);
-        };
+		PacketRequest.create = function create(properties) {
+			return new PacketRequest(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketRequest message. Does not implicitly {@link packets.PacketRequest.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketRequest
@@ -485,30 +486,30 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
-            writer.uint32(/* id 4, wireType 2 =*/34).string(message.action);
-            if (message.params != null && message.hasOwnProperty("params"))
-                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.params);
-            writer.uint32(/* id 6, wireType 2 =*/50).string(message.meta);
-            writer.uint32(/* id 7, wireType 1 =*/57).double(message.timeout);
-            writer.uint32(/* id 8, wireType 0 =*/64).int32(message.level);
-            if (message.metrics != null && message.hasOwnProperty("metrics"))
-                writer.uint32(/* id 9, wireType 0 =*/72).bool(message.metrics);
-            if (message.parentID != null && message.hasOwnProperty("parentID"))
-                writer.uint32(/* id 10, wireType 2 =*/82).string(message.parentID);
-            if (message.requestID != null && message.hasOwnProperty("requestID"))
-                writer.uint32(/* id 11, wireType 2 =*/90).string(message.requestID);
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                writer.uint32(/* id 12, wireType 0 =*/96).bool(message.stream);
-            return writer;
-        };
+		PacketRequest.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
+			writer.uint32(/* id 4, wireType 2 =*/34).string(message.action);
+			if (message.params != null && message.hasOwnProperty("params"))
+				writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.params);
+			writer.uint32(/* id 6, wireType 2 =*/50).string(message.meta);
+			writer.uint32(/* id 7, wireType 1 =*/57).double(message.timeout);
+			writer.uint32(/* id 8, wireType 0 =*/64).int32(message.level);
+			if (message.metrics != null && message.hasOwnProperty("metrics"))
+				writer.uint32(/* id 9, wireType 0 =*/72).bool(message.metrics);
+			if (message.parentID != null && message.hasOwnProperty("parentID"))
+				writer.uint32(/* id 10, wireType 2 =*/82).string(message.parentID);
+			if (message.requestID != null && message.hasOwnProperty("requestID"))
+				writer.uint32(/* id 11, wireType 2 =*/90).string(message.requestID);
+			if (message.stream != null && message.hasOwnProperty("stream"))
+				writer.uint32(/* id 12, wireType 0 =*/96).bool(message.stream);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketRequest message, length delimited. Does not implicitly {@link packets.PacketRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketRequest
@@ -517,11 +518,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketRequest.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketRequest message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketRequest
@@ -532,72 +533,72 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.id = reader.string();
-                    break;
-                case 4:
-                    message.action = reader.string();
-                    break;
-                case 5:
-                    message.params = reader.bytes();
-                    break;
-                case 6:
-                    message.meta = reader.string();
-                    break;
-                case 7:
-                    message.timeout = reader.double();
-                    break;
-                case 8:
-                    message.level = reader.int32();
-                    break;
-                case 9:
-                    message.metrics = reader.bool();
-                    break;
-                case 10:
-                    message.parentID = reader.string();
-                    break;
-                case 11:
-                    message.requestID = reader.string();
-                    break;
-                case 12:
-                    message.stream = reader.bool();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("id"))
-                throw $util.ProtocolError("missing required 'id'", { instance: message });
-            if (!message.hasOwnProperty("action"))
-                throw $util.ProtocolError("missing required 'action'", { instance: message });
-            if (!message.hasOwnProperty("meta"))
-                throw $util.ProtocolError("missing required 'meta'", { instance: message });
-            if (!message.hasOwnProperty("timeout"))
-                throw $util.ProtocolError("missing required 'timeout'", { instance: message });
-            if (!message.hasOwnProperty("level"))
-                throw $util.ProtocolError("missing required 'level'", { instance: message });
-            return message;
-        };
+		PacketRequest.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketRequest();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.id = reader.string();
+						break;
+					case 4:
+						message.action = reader.string();
+						break;
+					case 5:
+						message.params = reader.bytes();
+						break;
+					case 6:
+						message.meta = reader.string();
+						break;
+					case 7:
+						message.timeout = reader.double();
+						break;
+					case 8:
+						message.level = reader.int32();
+						break;
+					case 9:
+						message.metrics = reader.bool();
+						break;
+					case 10:
+						message.parentID = reader.string();
+						break;
+					case 11:
+						message.requestID = reader.string();
+						break;
+					case 12:
+						message.stream = reader.bool();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("id"))
+				throw $util.ProtocolError("missing required 'id'", { instance: message });
+			if (!message.hasOwnProperty("action"))
+				throw $util.ProtocolError("missing required 'action'", { instance: message });
+			if (!message.hasOwnProperty("meta"))
+				throw $util.ProtocolError("missing required 'meta'", { instance: message });
+			if (!message.hasOwnProperty("timeout"))
+				throw $util.ProtocolError("missing required 'timeout'", { instance: message });
+			if (!message.hasOwnProperty("level"))
+				throw $util.ProtocolError("missing required 'level'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketRequest
@@ -607,13 +608,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketRequest.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketRequest message.
          * @function verify
          * @memberof packets.PacketRequest
@@ -621,42 +622,42 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isString(message.id))
-                return "id: string expected";
-            if (!$util.isString(message.action))
-                return "action: string expected";
-            if (message.params != null && message.hasOwnProperty("params"))
-                if (!(message.params && typeof message.params.length === "number" || $util.isString(message.params)))
-                    return "params: buffer expected";
-            if (!$util.isString(message.meta))
-                return "meta: string expected";
-            if (typeof message.timeout !== "number")
-                return "timeout: number expected";
-            if (!$util.isInteger(message.level))
-                return "level: integer expected";
-            if (message.metrics != null && message.hasOwnProperty("metrics"))
-                if (typeof message.metrics !== "boolean")
-                    return "metrics: boolean expected";
-            if (message.parentID != null && message.hasOwnProperty("parentID"))
-                if (!$util.isString(message.parentID))
-                    return "parentID: string expected";
-            if (message.requestID != null && message.hasOwnProperty("requestID"))
-                if (!$util.isString(message.requestID))
-                    return "requestID: string expected";
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                if (typeof message.stream !== "boolean")
-                    return "stream: boolean expected";
-            return null;
-        };
+		PacketRequest.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isString(message.id))
+				return "id: string expected";
+			if (!$util.isString(message.action))
+				return "action: string expected";
+			if (message.params != null && message.hasOwnProperty("params"))
+				if (!(message.params && typeof message.params.length === "number" || $util.isString(message.params)))
+					return "params: buffer expected";
+			if (!$util.isString(message.meta))
+				return "meta: string expected";
+			if (typeof message.timeout !== "number")
+				return "timeout: number expected";
+			if (!$util.isInteger(message.level))
+				return "level: integer expected";
+			if (message.metrics != null && message.hasOwnProperty("metrics"))
+				if (typeof message.metrics !== "boolean")
+					return "metrics: boolean expected";
+			if (message.parentID != null && message.hasOwnProperty("parentID"))
+				if (!$util.isString(message.parentID))
+					return "parentID: string expected";
+			if (message.requestID != null && message.hasOwnProperty("requestID"))
+				if (!$util.isString(message.requestID))
+					return "requestID: string expected";
+			if (message.stream != null && message.hasOwnProperty("stream"))
+				if (typeof message.stream !== "boolean")
+					return "stream: boolean expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketRequest
@@ -664,41 +665,41 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketRequest} PacketRequest
          */
-        PacketRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketRequest)
-                return object;
-            var message = new $root.packets.PacketRequest();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.action != null)
-                message.action = String(object.action);
-            if (object.params != null)
-                if (typeof object.params === "string")
-                    $util.base64.decode(object.params, message.params = $util.newBuffer($util.base64.length(object.params)), 0);
-                else if (object.params.length)
-                    message.params = object.params;
-            if (object.meta != null)
-                message.meta = String(object.meta);
-            if (object.timeout != null)
-                message.timeout = Number(object.timeout);
-            if (object.level != null)
-                message.level = object.level | 0;
-            if (object.metrics != null)
-                message.metrics = Boolean(object.metrics);
-            if (object.parentID != null)
-                message.parentID = String(object.parentID);
-            if (object.requestID != null)
-                message.requestID = String(object.requestID);
-            if (object.stream != null)
-                message.stream = Boolean(object.stream);
-            return message;
-        };
+		PacketRequest.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketRequest)
+				return object;
+			var message = new $root.packets.PacketRequest();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.id != null)
+				message.id = String(object.id);
+			if (object.action != null)
+				message.action = String(object.action);
+			if (object.params != null)
+				if (typeof object.params === "string")
+					$util.base64.decode(object.params, message.params = $util.newBuffer($util.base64.length(object.params)), 0);
+				else if (object.params.length)
+					message.params = object.params;
+			if (object.meta != null)
+				message.meta = String(object.meta);
+			if (object.timeout != null)
+				message.timeout = Number(object.timeout);
+			if (object.level != null)
+				message.level = object.level | 0;
+			if (object.metrics != null)
+				message.metrics = Boolean(object.metrics);
+			if (object.parentID != null)
+				message.parentID = String(object.parentID);
+			if (object.requestID != null)
+				message.requestID = String(object.requestID);
+			if (object.stream != null)
+				message.stream = Boolean(object.stream);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketRequest
@@ -707,74 +708,74 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.id = "";
-                object.action = "";
-                if (options.bytes === String)
-                    object.params = "";
-                else {
-                    object.params = [];
-                    if (options.bytes !== Array)
-                        object.params = $util.newBuffer(object.params);
-                }
-                object.meta = "";
-                object.timeout = 0;
-                object.level = 0;
-                object.metrics = false;
-                object.parentID = "";
-                object.requestID = "";
-                object.stream = false;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.action != null && message.hasOwnProperty("action"))
-                object.action = message.action;
-            if (message.params != null && message.hasOwnProperty("params"))
-                object.params = options.bytes === String ? $util.base64.encode(message.params, 0, message.params.length) : options.bytes === Array ? Array.prototype.slice.call(message.params) : message.params;
-            if (message.meta != null && message.hasOwnProperty("meta"))
-                object.meta = message.meta;
-            if (message.timeout != null && message.hasOwnProperty("timeout"))
-                object.timeout = options.json && !isFinite(message.timeout) ? String(message.timeout) : message.timeout;
-            if (message.level != null && message.hasOwnProperty("level"))
-                object.level = message.level;
-            if (message.metrics != null && message.hasOwnProperty("metrics"))
-                object.metrics = message.metrics;
-            if (message.parentID != null && message.hasOwnProperty("parentID"))
-                object.parentID = message.parentID;
-            if (message.requestID != null && message.hasOwnProperty("requestID"))
-                object.requestID = message.requestID;
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                object.stream = message.stream;
-            return object;
-        };
+		PacketRequest.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.id = "";
+				object.action = "";
+				if (options.bytes === String)
+					object.params = "";
+				else {
+					object.params = [];
+					if (options.bytes !== Array)
+						object.params = $util.newBuffer(object.params);
+				}
+				object.meta = "";
+				object.timeout = 0;
+				object.level = 0;
+				object.metrics = false;
+				object.parentID = "";
+				object.requestID = "";
+				object.stream = false;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.id != null && message.hasOwnProperty("id"))
+				object.id = message.id;
+			if (message.action != null && message.hasOwnProperty("action"))
+				object.action = message.action;
+			if (message.params != null && message.hasOwnProperty("params"))
+				object.params = options.bytes === String ? $util.base64.encode(message.params, 0, message.params.length) : options.bytes === Array ? Array.prototype.slice.call(message.params) : message.params;
+			if (message.meta != null && message.hasOwnProperty("meta"))
+				object.meta = message.meta;
+			if (message.timeout != null && message.hasOwnProperty("timeout"))
+				object.timeout = options.json && !isFinite(message.timeout) ? String(message.timeout) : message.timeout;
+			if (message.level != null && message.hasOwnProperty("level"))
+				object.level = message.level;
+			if (message.metrics != null && message.hasOwnProperty("metrics"))
+				object.metrics = message.metrics;
+			if (message.parentID != null && message.hasOwnProperty("parentID"))
+				object.parentID = message.parentID;
+			if (message.requestID != null && message.hasOwnProperty("requestID"))
+				object.requestID = message.requestID;
+			if (message.stream != null && message.hasOwnProperty("stream"))
+				object.stream = message.stream;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketRequest to JSON.
          * @function toJSON
          * @memberof packets.PacketRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketRequest.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketRequest;
-    })();
+		return PacketRequest;
+	})();
 
-    packets.PacketResponse = (function() {
+	packets.PacketResponse = (function() {
 
-        /**
+		/**
          * Properties of a PacketResponse.
          * @memberof packets
          * @interface IPacketResponse
@@ -788,7 +789,7 @@ $root.packets = (function() {
          * @property {boolean|null} [stream] PacketResponse stream
          */
 
-        /**
+		/**
          * Constructs a new PacketResponse.
          * @memberof packets
          * @classdesc Represents a PacketResponse.
@@ -796,78 +797,78 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketResponse=} [properties] Properties to set
          */
-        function PacketResponse(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketResponse(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketResponse ver.
          * @member {string} ver
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.ver = "";
+		PacketResponse.prototype.ver = "";
 
-        /**
+		/**
          * PacketResponse sender.
          * @member {string} sender
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.sender = "";
+		PacketResponse.prototype.sender = "";
 
-        /**
+		/**
          * PacketResponse id.
          * @member {string} id
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.id = "";
+		PacketResponse.prototype.id = "";
 
-        /**
+		/**
          * PacketResponse success.
          * @member {boolean} success
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.success = false;
+		PacketResponse.prototype.success = false;
 
-        /**
+		/**
          * PacketResponse data.
          * @member {Uint8Array} data
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.data = $util.newBuffer([]);
+		PacketResponse.prototype.data = $util.newBuffer([]);
 
-        /**
+		/**
          * PacketResponse error.
          * @member {string} error
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.error = "";
+		PacketResponse.prototype.error = "";
 
-        /**
+		/**
          * PacketResponse meta.
          * @member {string} meta
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.meta = "";
+		PacketResponse.prototype.meta = "";
 
-        /**
+		/**
          * PacketResponse stream.
          * @member {boolean} stream
          * @memberof packets.PacketResponse
          * @instance
          */
-        PacketResponse.prototype.stream = false;
+		PacketResponse.prototype.stream = false;
 
-        /**
+		/**
          * Creates a new PacketResponse instance using the specified properties.
          * @function create
          * @memberof packets.PacketResponse
@@ -875,11 +876,11 @@ $root.packets = (function() {
          * @param {packets.IPacketResponse=} [properties] Properties to set
          * @returns {packets.PacketResponse} PacketResponse instance
          */
-        PacketResponse.create = function create(properties) {
-            return new PacketResponse(properties);
-        };
+		PacketResponse.create = function create(properties) {
+			return new PacketResponse(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketResponse message. Does not implicitly {@link packets.PacketResponse.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketResponse
@@ -888,24 +889,24 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
-            writer.uint32(/* id 4, wireType 0 =*/32).bool(message.success);
-            if (message.data != null && message.hasOwnProperty("data"))
-                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.data);
-            if (message.error != null && message.hasOwnProperty("error"))
-                writer.uint32(/* id 6, wireType 2 =*/50).string(message.error);
-            writer.uint32(/* id 7, wireType 2 =*/58).string(message.meta);
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.stream);
-            return writer;
-        };
+		PacketResponse.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
+			writer.uint32(/* id 4, wireType 0 =*/32).bool(message.success);
+			if (message.data != null && message.hasOwnProperty("data"))
+				writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.data);
+			if (message.error != null && message.hasOwnProperty("error"))
+				writer.uint32(/* id 6, wireType 2 =*/50).string(message.error);
+			writer.uint32(/* id 7, wireType 2 =*/58).string(message.meta);
+			if (message.stream != null && message.hasOwnProperty("stream"))
+				writer.uint32(/* id 8, wireType 0 =*/64).bool(message.stream);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketResponse message, length delimited. Does not implicitly {@link packets.PacketResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketResponse
@@ -914,11 +915,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketResponse.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketResponse message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketResponse
@@ -929,56 +930,56 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.id = reader.string();
-                    break;
-                case 4:
-                    message.success = reader.bool();
-                    break;
-                case 5:
-                    message.data = reader.bytes();
-                    break;
-                case 6:
-                    message.error = reader.string();
-                    break;
-                case 7:
-                    message.meta = reader.string();
-                    break;
-                case 8:
-                    message.stream = reader.bool();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("id"))
-                throw $util.ProtocolError("missing required 'id'", { instance: message });
-            if (!message.hasOwnProperty("success"))
-                throw $util.ProtocolError("missing required 'success'", { instance: message });
-            if (!message.hasOwnProperty("meta"))
-                throw $util.ProtocolError("missing required 'meta'", { instance: message });
-            return message;
-        };
+		PacketResponse.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketResponse();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.id = reader.string();
+						break;
+					case 4:
+						message.success = reader.bool();
+						break;
+					case 5:
+						message.data = reader.bytes();
+						break;
+					case 6:
+						message.error = reader.string();
+						break;
+					case 7:
+						message.meta = reader.string();
+						break;
+					case 8:
+						message.stream = reader.bool();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("id"))
+				throw $util.ProtocolError("missing required 'id'", { instance: message });
+			if (!message.hasOwnProperty("success"))
+				throw $util.ProtocolError("missing required 'success'", { instance: message });
+			if (!message.hasOwnProperty("meta"))
+				throw $util.ProtocolError("missing required 'meta'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketResponse
@@ -988,13 +989,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketResponse.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketResponse message.
          * @function verify
          * @memberof packets.PacketResponse
@@ -1002,32 +1003,32 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isString(message.id))
-                return "id: string expected";
-            if (typeof message.success !== "boolean")
-                return "success: boolean expected";
-            if (message.data != null && message.hasOwnProperty("data"))
-                if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
-                    return "data: buffer expected";
-            if (message.error != null && message.hasOwnProperty("error"))
-                if (!$util.isString(message.error))
-                    return "error: string expected";
-            if (!$util.isString(message.meta))
-                return "meta: string expected";
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                if (typeof message.stream !== "boolean")
-                    return "stream: boolean expected";
-            return null;
-        };
+		PacketResponse.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isString(message.id))
+				return "id: string expected";
+			if (typeof message.success !== "boolean")
+				return "success: boolean expected";
+			if (message.data != null && message.hasOwnProperty("data"))
+				if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
+					return "data: buffer expected";
+			if (message.error != null && message.hasOwnProperty("error"))
+				if (!$util.isString(message.error))
+					return "error: string expected";
+			if (!$util.isString(message.meta))
+				return "meta: string expected";
+			if (message.stream != null && message.hasOwnProperty("stream"))
+				if (typeof message.stream !== "boolean")
+					return "stream: boolean expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketResponse
@@ -1035,33 +1036,33 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketResponse} PacketResponse
          */
-        PacketResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketResponse)
-                return object;
-            var message = new $root.packets.PacketResponse();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.success != null)
-                message.success = Boolean(object.success);
-            if (object.data != null)
-                if (typeof object.data === "string")
-                    $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
-                else if (object.data.length)
-                    message.data = object.data;
-            if (object.error != null)
-                message.error = String(object.error);
-            if (object.meta != null)
-                message.meta = String(object.meta);
-            if (object.stream != null)
-                message.stream = Boolean(object.stream);
-            return message;
-        };
+		PacketResponse.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketResponse)
+				return object;
+			var message = new $root.packets.PacketResponse();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.id != null)
+				message.id = String(object.id);
+			if (object.success != null)
+				message.success = Boolean(object.success);
+			if (object.data != null)
+				if (typeof object.data === "string")
+					$util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
+				else if (object.data.length)
+					message.data = object.data;
+			if (object.error != null)
+				message.error = String(object.error);
+			if (object.meta != null)
+				message.meta = String(object.meta);
+			if (object.stream != null)
+				message.stream = Boolean(object.stream);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketResponse
@@ -1070,62 +1071,62 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.id = "";
-                object.success = false;
-                if (options.bytes === String)
-                    object.data = "";
-                else {
-                    object.data = [];
-                    if (options.bytes !== Array)
-                        object.data = $util.newBuffer(object.data);
-                }
-                object.error = "";
-                object.meta = "";
-                object.stream = false;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.success != null && message.hasOwnProperty("success"))
-                object.success = message.success;
-            if (message.data != null && message.hasOwnProperty("data"))
-                object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
-            if (message.error != null && message.hasOwnProperty("error"))
-                object.error = message.error;
-            if (message.meta != null && message.hasOwnProperty("meta"))
-                object.meta = message.meta;
-            if (message.stream != null && message.hasOwnProperty("stream"))
-                object.stream = message.stream;
-            return object;
-        };
+		PacketResponse.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.id = "";
+				object.success = false;
+				if (options.bytes === String)
+					object.data = "";
+				else {
+					object.data = [];
+					if (options.bytes !== Array)
+						object.data = $util.newBuffer(object.data);
+				}
+				object.error = "";
+				object.meta = "";
+				object.stream = false;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.id != null && message.hasOwnProperty("id"))
+				object.id = message.id;
+			if (message.success != null && message.hasOwnProperty("success"))
+				object.success = message.success;
+			if (message.data != null && message.hasOwnProperty("data"))
+				object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
+			if (message.error != null && message.hasOwnProperty("error"))
+				object.error = message.error;
+			if (message.meta != null && message.hasOwnProperty("meta"))
+				object.meta = message.meta;
+			if (message.stream != null && message.hasOwnProperty("stream"))
+				object.stream = message.stream;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketResponse to JSON.
          * @function toJSON
          * @memberof packets.PacketResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketResponse.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketResponse;
-    })();
+		return PacketResponse;
+	})();
 
-    packets.PacketDiscover = (function() {
+	packets.PacketDiscover = (function() {
 
-        /**
+		/**
          * Properties of a PacketDiscover.
          * @memberof packets
          * @interface IPacketDiscover
@@ -1133,7 +1134,7 @@ $root.packets = (function() {
          * @property {string} sender PacketDiscover sender
          */
 
-        /**
+		/**
          * Constructs a new PacketDiscover.
          * @memberof packets
          * @classdesc Represents a PacketDiscover.
@@ -1141,30 +1142,30 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketDiscover=} [properties] Properties to set
          */
-        function PacketDiscover(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketDiscover(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketDiscover ver.
          * @member {string} ver
          * @memberof packets.PacketDiscover
          * @instance
          */
-        PacketDiscover.prototype.ver = "";
+		PacketDiscover.prototype.ver = "";
 
-        /**
+		/**
          * PacketDiscover sender.
          * @member {string} sender
          * @memberof packets.PacketDiscover
          * @instance
          */
-        PacketDiscover.prototype.sender = "";
+		PacketDiscover.prototype.sender = "";
 
-        /**
+		/**
          * Creates a new PacketDiscover instance using the specified properties.
          * @function create
          * @memberof packets.PacketDiscover
@@ -1172,11 +1173,11 @@ $root.packets = (function() {
          * @param {packets.IPacketDiscover=} [properties] Properties to set
          * @returns {packets.PacketDiscover} PacketDiscover instance
          */
-        PacketDiscover.create = function create(properties) {
-            return new PacketDiscover(properties);
-        };
+		PacketDiscover.create = function create(properties) {
+			return new PacketDiscover(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketDiscover message. Does not implicitly {@link packets.PacketDiscover.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketDiscover
@@ -1185,15 +1186,15 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketDiscover.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            return writer;
-        };
+		PacketDiscover.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketDiscover message, length delimited. Does not implicitly {@link packets.PacketDiscover.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketDiscover
@@ -1202,11 +1203,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketDiscover.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketDiscover.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketDiscover message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketDiscover
@@ -1217,32 +1218,32 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketDiscover.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDiscover();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            return message;
-        };
+		PacketDiscover.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDiscover();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketDiscover message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketDiscover
@@ -1252,13 +1253,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketDiscover.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketDiscover.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketDiscover message.
          * @function verify
          * @memberof packets.PacketDiscover
@@ -1266,17 +1267,17 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketDiscover.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            return null;
-        };
+		PacketDiscover.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketDiscover message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketDiscover
@@ -1284,18 +1285,18 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketDiscover} PacketDiscover
          */
-        PacketDiscover.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketDiscover)
-                return object;
-            var message = new $root.packets.PacketDiscover();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            return message;
-        };
+		PacketDiscover.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketDiscover)
+				return object;
+			var message = new $root.packets.PacketDiscover();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketDiscover message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketDiscover
@@ -1304,38 +1305,38 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketDiscover.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            return object;
-        };
+		PacketDiscover.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketDiscover to JSON.
          * @function toJSON
          * @memberof packets.PacketDiscover
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketDiscover.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketDiscover.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketDiscover;
-    })();
+		return PacketDiscover;
+	})();
 
-    packets.PacketInfo = (function() {
+	packets.PacketInfo = (function() {
 
-        /**
+		/**
          * Properties of a PacketInfo.
          * @memberof packets
          * @interface IPacketInfo
@@ -1346,10 +1347,10 @@ $root.packets = (function() {
          * @property {Array.<string>|null} [ipList] PacketInfo ipList
          * @property {string} hostname PacketInfo hostname
          * @property {packets.PacketInfo.IClient} client PacketInfo client
-         * @property {number} seq PacketInfo seq
+         * @property {number|null} [seq] PacketInfo seq
          */
 
-        /**
+		/**
          * Constructs a new PacketInfo.
          * @memberof packets
          * @classdesc Represents a PacketInfo.
@@ -1357,79 +1358,79 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketInfo=} [properties] Properties to set
          */
-        function PacketInfo(properties) {
-            this.ipList = [];
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketInfo(properties) {
+			this.ipList = [];
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketInfo ver.
          * @member {string} ver
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.ver = "";
+		PacketInfo.prototype.ver = "";
 
-        /**
+		/**
          * PacketInfo sender.
          * @member {string} sender
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.sender = "";
+		PacketInfo.prototype.sender = "";
 
-        /**
+		/**
          * PacketInfo services.
          * @member {string} services
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.services = "";
+		PacketInfo.prototype.services = "";
 
-        /**
+		/**
          * PacketInfo config.
          * @member {string} config
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.config = "";
+		PacketInfo.prototype.config = "";
 
-        /**
+		/**
          * PacketInfo ipList.
          * @member {Array.<string>} ipList
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.ipList = $util.emptyArray;
+		PacketInfo.prototype.ipList = $util.emptyArray;
 
-        /**
+		/**
          * PacketInfo hostname.
          * @member {string} hostname
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.hostname = "";
+		PacketInfo.prototype.hostname = "";
 
-        /**
+		/**
          * PacketInfo client.
          * @member {packets.PacketInfo.IClient} client
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.client = null;
+		PacketInfo.prototype.client = null;
 
-        /**
+		/**
          * PacketInfo seq.
          * @member {number} seq
          * @memberof packets.PacketInfo
          * @instance
          */
-        PacketInfo.prototype.seq = 0;
+		PacketInfo.prototype.seq = 0;
 
-        /**
+		/**
          * Creates a new PacketInfo instance using the specified properties.
          * @function create
          * @memberof packets.PacketInfo
@@ -1437,11 +1438,11 @@ $root.packets = (function() {
          * @param {packets.IPacketInfo=} [properties] Properties to set
          * @returns {packets.PacketInfo} PacketInfo instance
          */
-        PacketInfo.create = function create(properties) {
-            return new PacketInfo(properties);
-        };
+		PacketInfo.create = function create(properties) {
+			return new PacketInfo(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketInfo message. Does not implicitly {@link packets.PacketInfo.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketInfo
@@ -1450,23 +1451,24 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketInfo.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 2 =*/26).string(message.services);
-            writer.uint32(/* id 4, wireType 2 =*/34).string(message.config);
-            if (message.ipList != null && message.ipList.length)
-                for (var i = 0; i < message.ipList.length; ++i)
-                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.ipList[i]);
-            writer.uint32(/* id 6, wireType 2 =*/50).string(message.hostname);
-            $root.packets.PacketInfo.Client.encode(message.client, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
-            writer.uint32(/* id 8, wireType 0 =*/64).int32(message.seq);
-            return writer;
-        };
+		PacketInfo.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 2 =*/26).string(message.services);
+			writer.uint32(/* id 4, wireType 2 =*/34).string(message.config);
+			if (message.ipList != null && message.ipList.length)
+				for (var i = 0; i < message.ipList.length; ++i)
+					writer.uint32(/* id 5, wireType 2 =*/42).string(message.ipList[i]);
+			writer.uint32(/* id 6, wireType 2 =*/50).string(message.hostname);
+			$root.packets.PacketInfo.Client.encode(message.client, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+			if (message.seq != null && message.hasOwnProperty("seq"))
+				writer.uint32(/* id 8, wireType 0 =*/64).int32(message.seq);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketInfo message, length delimited. Does not implicitly {@link packets.PacketInfo.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketInfo
@@ -1475,11 +1477,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketInfo.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketInfo.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketInfo message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketInfo
@@ -1490,62 +1492,60 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketInfo.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.services = reader.string();
-                    break;
-                case 4:
-                    message.config = reader.string();
-                    break;
-                case 5:
-                    if (!(message.ipList && message.ipList.length))
-                        message.ipList = [];
-                    message.ipList.push(reader.string());
-                    break;
-                case 6:
-                    message.hostname = reader.string();
-                    break;
-                case 7:
-                    message.client = $root.packets.PacketInfo.Client.decode(reader, reader.uint32());
-                    break;
-                case 8:
-                    message.seq = reader.int32();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("services"))
-                throw $util.ProtocolError("missing required 'services'", { instance: message });
-            if (!message.hasOwnProperty("config"))
-                throw $util.ProtocolError("missing required 'config'", { instance: message });
-            if (!message.hasOwnProperty("hostname"))
-                throw $util.ProtocolError("missing required 'hostname'", { instance: message });
-            if (!message.hasOwnProperty("client"))
-                throw $util.ProtocolError("missing required 'client'", { instance: message });
-            if (!message.hasOwnProperty("seq"))
-                throw $util.ProtocolError("missing required 'seq'", { instance: message });
-            return message;
-        };
+		PacketInfo.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.services = reader.string();
+						break;
+					case 4:
+						message.config = reader.string();
+						break;
+					case 5:
+						if (!(message.ipList && message.ipList.length))
+							message.ipList = [];
+						message.ipList.push(reader.string());
+						break;
+					case 6:
+						message.hostname = reader.string();
+						break;
+					case 7:
+						message.client = $root.packets.PacketInfo.Client.decode(reader, reader.uint32());
+						break;
+					case 8:
+						message.seq = reader.int32();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("services"))
+				throw $util.ProtocolError("missing required 'services'", { instance: message });
+			if (!message.hasOwnProperty("config"))
+				throw $util.ProtocolError("missing required 'config'", { instance: message });
+			if (!message.hasOwnProperty("hostname"))
+				throw $util.ProtocolError("missing required 'hostname'", { instance: message });
+			if (!message.hasOwnProperty("client"))
+				throw $util.ProtocolError("missing required 'client'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketInfo message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketInfo
@@ -1555,13 +1555,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketInfo.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketInfo.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketInfo message.
          * @function verify
          * @memberof packets.PacketInfo
@@ -1569,37 +1569,38 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketInfo.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isString(message.services))
-                return "services: string expected";
-            if (!$util.isString(message.config))
-                return "config: string expected";
-            if (message.ipList != null && message.hasOwnProperty("ipList")) {
-                if (!Array.isArray(message.ipList))
-                    return "ipList: array expected";
-                for (var i = 0; i < message.ipList.length; ++i)
-                    if (!$util.isString(message.ipList[i]))
-                        return "ipList: string[] expected";
-            }
-            if (!$util.isString(message.hostname))
-                return "hostname: string expected";
-            {
-                var error = $root.packets.PacketInfo.Client.verify(message.client);
-                if (error)
-                    return "client." + error;
-            }
-            if (!$util.isInteger(message.seq))
-                return "seq: integer expected";
-            return null;
-        };
+		PacketInfo.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isString(message.services))
+				return "services: string expected";
+			if (!$util.isString(message.config))
+				return "config: string expected";
+			if (message.ipList != null && message.hasOwnProperty("ipList")) {
+				if (!Array.isArray(message.ipList))
+					return "ipList: array expected";
+				for (var i = 0; i < message.ipList.length; ++i)
+					if (!$util.isString(message.ipList[i]))
+						return "ipList: string[] expected";
+			}
+			if (!$util.isString(message.hostname))
+				return "hostname: string expected";
+			{
+				var error = $root.packets.PacketInfo.Client.verify(message.client);
+				if (error)
+					return "client." + error;
+			}
+			if (message.seq != null && message.hasOwnProperty("seq"))
+				if (!$util.isInteger(message.seq))
+					return "seq: integer expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketInfo message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketInfo
@@ -1607,38 +1608,38 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketInfo} PacketInfo
          */
-        PacketInfo.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketInfo)
-                return object;
-            var message = new $root.packets.PacketInfo();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.services != null)
-                message.services = String(object.services);
-            if (object.config != null)
-                message.config = String(object.config);
-            if (object.ipList) {
-                if (!Array.isArray(object.ipList))
-                    throw TypeError(".packets.PacketInfo.ipList: array expected");
-                message.ipList = [];
-                for (var i = 0; i < object.ipList.length; ++i)
-                    message.ipList[i] = String(object.ipList[i]);
-            }
-            if (object.hostname != null)
-                message.hostname = String(object.hostname);
-            if (object.client != null) {
-                if (typeof object.client !== "object")
-                    throw TypeError(".packets.PacketInfo.client: object expected");
-                message.client = $root.packets.PacketInfo.Client.fromObject(object.client);
-            }
-            if (object.seq != null)
-                message.seq = object.seq | 0;
-            return message;
-        };
+		PacketInfo.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketInfo)
+				return object;
+			var message = new $root.packets.PacketInfo();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.services != null)
+				message.services = String(object.services);
+			if (object.config != null)
+				message.config = String(object.config);
+			if (object.ipList) {
+				if (!Array.isArray(object.ipList))
+					throw TypeError(".packets.PacketInfo.ipList: array expected");
+				message.ipList = [];
+				for (var i = 0; i < object.ipList.length; ++i)
+					message.ipList[i] = String(object.ipList[i]);
+			}
+			if (object.hostname != null)
+				message.hostname = String(object.hostname);
+			if (object.client != null) {
+				if (typeof object.client !== "object")
+					throw TypeError(".packets.PacketInfo.client: object expected");
+				message.client = $root.packets.PacketInfo.Client.fromObject(object.client);
+			}
+			if (object.seq != null)
+				message.seq = object.seq | 0;
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketInfo message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketInfo
@@ -1647,57 +1648,57 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketInfo.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.arrays || options.defaults)
-                object.ipList = [];
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.services = "";
-                object.config = "";
-                object.hostname = "";
-                object.client = null;
-                object.seq = 0;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.services != null && message.hasOwnProperty("services"))
-                object.services = message.services;
-            if (message.config != null && message.hasOwnProperty("config"))
-                object.config = message.config;
-            if (message.ipList && message.ipList.length) {
-                object.ipList = [];
-                for (var j = 0; j < message.ipList.length; ++j)
-                    object.ipList[j] = message.ipList[j];
-            }
-            if (message.hostname != null && message.hasOwnProperty("hostname"))
-                object.hostname = message.hostname;
-            if (message.client != null && message.hasOwnProperty("client"))
-                object.client = $root.packets.PacketInfo.Client.toObject(message.client, options);
-            if (message.seq != null && message.hasOwnProperty("seq"))
-                object.seq = message.seq;
-            return object;
-        };
+		PacketInfo.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.arrays || options.defaults)
+				object.ipList = [];
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.services = "";
+				object.config = "";
+				object.hostname = "";
+				object.client = null;
+				object.seq = 0;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.services != null && message.hasOwnProperty("services"))
+				object.services = message.services;
+			if (message.config != null && message.hasOwnProperty("config"))
+				object.config = message.config;
+			if (message.ipList && message.ipList.length) {
+				object.ipList = [];
+				for (var j = 0; j < message.ipList.length; ++j)
+					object.ipList[j] = message.ipList[j];
+			}
+			if (message.hostname != null && message.hasOwnProperty("hostname"))
+				object.hostname = message.hostname;
+			if (message.client != null && message.hasOwnProperty("client"))
+				object.client = $root.packets.PacketInfo.Client.toObject(message.client, options);
+			if (message.seq != null && message.hasOwnProperty("seq"))
+				object.seq = message.seq;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketInfo to JSON.
          * @function toJSON
          * @memberof packets.PacketInfo
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketInfo.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketInfo.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        PacketInfo.Client = (function() {
+		PacketInfo.Client = (function() {
 
-            /**
+			/**
              * Properties of a Client.
              * @memberof packets.PacketInfo
              * @interface IClient
@@ -1706,7 +1707,7 @@ $root.packets = (function() {
              * @property {string} langVersion Client langVersion
              */
 
-            /**
+			/**
              * Constructs a new Client.
              * @memberof packets.PacketInfo
              * @classdesc Represents a Client.
@@ -1714,38 +1715,38 @@ $root.packets = (function() {
              * @constructor
              * @param {packets.PacketInfo.IClient=} [properties] Properties to set
              */
-            function Client(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
+			function Client(properties) {
+				if (properties)
+					for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+						if (properties[keys[i]] != null)
+							this[keys[i]] = properties[keys[i]];
+			}
 
-            /**
+			/**
              * Client type.
              * @member {string} type
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-            Client.prototype.type = "";
+			Client.prototype.type = "";
 
-            /**
+			/**
              * Client version.
              * @member {string} version
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-            Client.prototype.version = "";
+			Client.prototype.version = "";
 
-            /**
+			/**
              * Client langVersion.
              * @member {string} langVersion
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-            Client.prototype.langVersion = "";
+			Client.prototype.langVersion = "";
 
-            /**
+			/**
              * Creates a new Client instance using the specified properties.
              * @function create
              * @memberof packets.PacketInfo.Client
@@ -1753,11 +1754,11 @@ $root.packets = (function() {
              * @param {packets.PacketInfo.IClient=} [properties] Properties to set
              * @returns {packets.PacketInfo.Client} Client instance
              */
-            Client.create = function create(properties) {
-                return new Client(properties);
-            };
+			Client.create = function create(properties) {
+				return new Client(properties);
+			};
 
-            /**
+			/**
              * Encodes the specified Client message. Does not implicitly {@link packets.PacketInfo.Client.verify|verify} messages.
              * @function encode
              * @memberof packets.PacketInfo.Client
@@ -1766,16 +1767,16 @@ $root.packets = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Client.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.langVersion);
-                return writer;
-            };
+			Client.encode = function encode(message, writer) {
+				if (!writer)
+					writer = $Writer.create();
+				writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
+				writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
+				writer.uint32(/* id 3, wireType 2 =*/26).string(message.langVersion);
+				return writer;
+			};
 
-            /**
+			/**
              * Encodes the specified Client message, length delimited. Does not implicitly {@link packets.PacketInfo.Client.verify|verify} messages.
              * @function encodeDelimited
              * @memberof packets.PacketInfo.Client
@@ -1784,11 +1785,11 @@ $root.packets = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Client.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
+			Client.encodeDelimited = function encodeDelimited(message, writer) {
+				return this.encode(message, writer).ldelim();
+			};
 
-            /**
+			/**
              * Decodes a Client message from the specified reader or buffer.
              * @function decode
              * @memberof packets.PacketInfo.Client
@@ -1799,37 +1800,37 @@ $root.packets = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Client.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo.Client();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.type = reader.string();
-                        break;
-                    case 2:
-                        message.version = reader.string();
-                        break;
-                    case 3:
-                        message.langVersion = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                if (!message.hasOwnProperty("type"))
-                    throw $util.ProtocolError("missing required 'type'", { instance: message });
-                if (!message.hasOwnProperty("version"))
-                    throw $util.ProtocolError("missing required 'version'", { instance: message });
-                if (!message.hasOwnProperty("langVersion"))
-                    throw $util.ProtocolError("missing required 'langVersion'", { instance: message });
-                return message;
-            };
+			Client.decode = function decode(reader, length) {
+				if (!(reader instanceof $Reader))
+					reader = $Reader.create(reader);
+				var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo.Client();
+				while (reader.pos < end) {
+					var tag = reader.uint32();
+					switch (tag >>> 3) {
+						case 1:
+							message.type = reader.string();
+							break;
+						case 2:
+							message.version = reader.string();
+							break;
+						case 3:
+							message.langVersion = reader.string();
+							break;
+						default:
+							reader.skipType(tag & 7);
+							break;
+					}
+				}
+				if (!message.hasOwnProperty("type"))
+					throw $util.ProtocolError("missing required 'type'", { instance: message });
+				if (!message.hasOwnProperty("version"))
+					throw $util.ProtocolError("missing required 'version'", { instance: message });
+				if (!message.hasOwnProperty("langVersion"))
+					throw $util.ProtocolError("missing required 'langVersion'", { instance: message });
+				return message;
+			};
 
-            /**
+			/**
              * Decodes a Client message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
              * @memberof packets.PacketInfo.Client
@@ -1839,13 +1840,13 @@ $root.packets = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Client.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
+			Client.decodeDelimited = function decodeDelimited(reader) {
+				if (!(reader instanceof $Reader))
+					reader = new $Reader(reader);
+				return this.decode(reader, reader.uint32());
+			};
 
-            /**
+			/**
              * Verifies a Client message.
              * @function verify
              * @memberof packets.PacketInfo.Client
@@ -1853,19 +1854,19 @@ $root.packets = (function() {
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-            Client.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (!$util.isString(message.type))
-                    return "type: string expected";
-                if (!$util.isString(message.version))
-                    return "version: string expected";
-                if (!$util.isString(message.langVersion))
-                    return "langVersion: string expected";
-                return null;
-            };
+			Client.verify = function verify(message) {
+				if (typeof message !== "object" || message === null)
+					return "object expected";
+				if (!$util.isString(message.type))
+					return "type: string expected";
+				if (!$util.isString(message.version))
+					return "version: string expected";
+				if (!$util.isString(message.langVersion))
+					return "langVersion: string expected";
+				return null;
+			};
 
-            /**
+			/**
              * Creates a Client message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
              * @memberof packets.PacketInfo.Client
@@ -1873,20 +1874,20 @@ $root.packets = (function() {
              * @param {Object.<string,*>} object Plain object
              * @returns {packets.PacketInfo.Client} Client
              */
-            Client.fromObject = function fromObject(object) {
-                if (object instanceof $root.packets.PacketInfo.Client)
-                    return object;
-                var message = new $root.packets.PacketInfo.Client();
-                if (object.type != null)
-                    message.type = String(object.type);
-                if (object.version != null)
-                    message.version = String(object.version);
-                if (object.langVersion != null)
-                    message.langVersion = String(object.langVersion);
-                return message;
-            };
+			Client.fromObject = function fromObject(object) {
+				if (object instanceof $root.packets.PacketInfo.Client)
+					return object;
+				var message = new $root.packets.PacketInfo.Client();
+				if (object.type != null)
+					message.type = String(object.type);
+				if (object.version != null)
+					message.version = String(object.version);
+				if (object.langVersion != null)
+					message.langVersion = String(object.langVersion);
+				return message;
+			};
 
-            /**
+			/**
              * Creates a plain object from a Client message. Also converts values to other types if specified.
              * @function toObject
              * @memberof packets.PacketInfo.Client
@@ -1895,44 +1896,44 @@ $root.packets = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Client.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.type = "";
-                    object.version = "";
-                    object.langVersion = "";
-                }
-                if (message.type != null && message.hasOwnProperty("type"))
-                    object.type = message.type;
-                if (message.version != null && message.hasOwnProperty("version"))
-                    object.version = message.version;
-                if (message.langVersion != null && message.hasOwnProperty("langVersion"))
-                    object.langVersion = message.langVersion;
-                return object;
-            };
+			Client.toObject = function toObject(message, options) {
+				if (!options)
+					options = {};
+				var object = {};
+				if (options.defaults) {
+					object.type = "";
+					object.version = "";
+					object.langVersion = "";
+				}
+				if (message.type != null && message.hasOwnProperty("type"))
+					object.type = message.type;
+				if (message.version != null && message.hasOwnProperty("version"))
+					object.version = message.version;
+				if (message.langVersion != null && message.hasOwnProperty("langVersion"))
+					object.langVersion = message.langVersion;
+				return object;
+			};
 
-            /**
+			/**
              * Converts this Client to JSON.
              * @function toJSON
              * @memberof packets.PacketInfo.Client
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-            Client.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
+			Client.prototype.toJSON = function toJSON() {
+				return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+			};
 
-            return Client;
-        })();
+			return Client;
+		})();
 
-        return PacketInfo;
-    })();
+		return PacketInfo;
+	})();
 
-    packets.PacketDisconnect = (function() {
+	packets.PacketDisconnect = (function() {
 
-        /**
+		/**
          * Properties of a PacketDisconnect.
          * @memberof packets
          * @interface IPacketDisconnect
@@ -1940,7 +1941,7 @@ $root.packets = (function() {
          * @property {string} sender PacketDisconnect sender
          */
 
-        /**
+		/**
          * Constructs a new PacketDisconnect.
          * @memberof packets
          * @classdesc Represents a PacketDisconnect.
@@ -1948,30 +1949,30 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketDisconnect=} [properties] Properties to set
          */
-        function PacketDisconnect(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketDisconnect(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketDisconnect ver.
          * @member {string} ver
          * @memberof packets.PacketDisconnect
          * @instance
          */
-        PacketDisconnect.prototype.ver = "";
+		PacketDisconnect.prototype.ver = "";
 
-        /**
+		/**
          * PacketDisconnect sender.
          * @member {string} sender
          * @memberof packets.PacketDisconnect
          * @instance
          */
-        PacketDisconnect.prototype.sender = "";
+		PacketDisconnect.prototype.sender = "";
 
-        /**
+		/**
          * Creates a new PacketDisconnect instance using the specified properties.
          * @function create
          * @memberof packets.PacketDisconnect
@@ -1979,11 +1980,11 @@ $root.packets = (function() {
          * @param {packets.IPacketDisconnect=} [properties] Properties to set
          * @returns {packets.PacketDisconnect} PacketDisconnect instance
          */
-        PacketDisconnect.create = function create(properties) {
-            return new PacketDisconnect(properties);
-        };
+		PacketDisconnect.create = function create(properties) {
+			return new PacketDisconnect(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketDisconnect message. Does not implicitly {@link packets.PacketDisconnect.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketDisconnect
@@ -1992,15 +1993,15 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketDisconnect.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            return writer;
-        };
+		PacketDisconnect.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketDisconnect message, length delimited. Does not implicitly {@link packets.PacketDisconnect.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketDisconnect
@@ -2009,11 +2010,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketDisconnect.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketDisconnect.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketDisconnect message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketDisconnect
@@ -2024,32 +2025,32 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketDisconnect.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDisconnect();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            return message;
-        };
+		PacketDisconnect.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDisconnect();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketDisconnect message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketDisconnect
@@ -2059,13 +2060,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketDisconnect.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketDisconnect.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketDisconnect message.
          * @function verify
          * @memberof packets.PacketDisconnect
@@ -2073,17 +2074,17 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketDisconnect.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            return null;
-        };
+		PacketDisconnect.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketDisconnect message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketDisconnect
@@ -2091,18 +2092,18 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketDisconnect} PacketDisconnect
          */
-        PacketDisconnect.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketDisconnect)
-                return object;
-            var message = new $root.packets.PacketDisconnect();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            return message;
-        };
+		PacketDisconnect.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketDisconnect)
+				return object;
+			var message = new $root.packets.PacketDisconnect();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketDisconnect message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketDisconnect
@@ -2111,38 +2112,38 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketDisconnect.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            return object;
-        };
+		PacketDisconnect.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketDisconnect to JSON.
          * @function toJSON
          * @memberof packets.PacketDisconnect
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketDisconnect.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketDisconnect.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketDisconnect;
-    })();
+		return PacketDisconnect;
+	})();
 
-    packets.PacketHeartbeat = (function() {
+	packets.PacketHeartbeat = (function() {
 
-        /**
+		/**
          * Properties of a PacketHeartbeat.
          * @memberof packets
          * @interface IPacketHeartbeat
@@ -2151,7 +2152,7 @@ $root.packets = (function() {
          * @property {number} cpu PacketHeartbeat cpu
          */
 
-        /**
+		/**
          * Constructs a new PacketHeartbeat.
          * @memberof packets
          * @classdesc Represents a PacketHeartbeat.
@@ -2159,38 +2160,38 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketHeartbeat=} [properties] Properties to set
          */
-        function PacketHeartbeat(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketHeartbeat(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketHeartbeat ver.
          * @member {string} ver
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-        PacketHeartbeat.prototype.ver = "";
+		PacketHeartbeat.prototype.ver = "";
 
-        /**
+		/**
          * PacketHeartbeat sender.
          * @member {string} sender
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-        PacketHeartbeat.prototype.sender = "";
+		PacketHeartbeat.prototype.sender = "";
 
-        /**
+		/**
          * PacketHeartbeat cpu.
          * @member {number} cpu
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-        PacketHeartbeat.prototype.cpu = 0;
+		PacketHeartbeat.prototype.cpu = 0;
 
-        /**
+		/**
          * Creates a new PacketHeartbeat instance using the specified properties.
          * @function create
          * @memberof packets.PacketHeartbeat
@@ -2198,11 +2199,11 @@ $root.packets = (function() {
          * @param {packets.IPacketHeartbeat=} [properties] Properties to set
          * @returns {packets.PacketHeartbeat} PacketHeartbeat instance
          */
-        PacketHeartbeat.create = function create(properties) {
-            return new PacketHeartbeat(properties);
-        };
+		PacketHeartbeat.create = function create(properties) {
+			return new PacketHeartbeat(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketHeartbeat message. Does not implicitly {@link packets.PacketHeartbeat.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketHeartbeat
@@ -2211,16 +2212,16 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketHeartbeat.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 1 =*/25).double(message.cpu);
-            return writer;
-        };
+		PacketHeartbeat.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 1 =*/25).double(message.cpu);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketHeartbeat message, length delimited. Does not implicitly {@link packets.PacketHeartbeat.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketHeartbeat
@@ -2229,11 +2230,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketHeartbeat.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketHeartbeat.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketHeartbeat message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketHeartbeat
@@ -2244,37 +2245,37 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketHeartbeat.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketHeartbeat();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.cpu = reader.double();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("cpu"))
-                throw $util.ProtocolError("missing required 'cpu'", { instance: message });
-            return message;
-        };
+		PacketHeartbeat.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketHeartbeat();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.cpu = reader.double();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("cpu"))
+				throw $util.ProtocolError("missing required 'cpu'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketHeartbeat message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketHeartbeat
@@ -2284,13 +2285,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketHeartbeat.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketHeartbeat.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketHeartbeat message.
          * @function verify
          * @memberof packets.PacketHeartbeat
@@ -2298,19 +2299,19 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketHeartbeat.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (typeof message.cpu !== "number")
-                return "cpu: number expected";
-            return null;
-        };
+		PacketHeartbeat.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (typeof message.cpu !== "number")
+				return "cpu: number expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketHeartbeat message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketHeartbeat
@@ -2318,20 +2319,20 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketHeartbeat} PacketHeartbeat
          */
-        PacketHeartbeat.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketHeartbeat)
-                return object;
-            var message = new $root.packets.PacketHeartbeat();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.cpu != null)
-                message.cpu = Number(object.cpu);
-            return message;
-        };
+		PacketHeartbeat.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketHeartbeat)
+				return object;
+			var message = new $root.packets.PacketHeartbeat();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.cpu != null)
+				message.cpu = Number(object.cpu);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketHeartbeat message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketHeartbeat
@@ -2340,41 +2341,41 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketHeartbeat.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.cpu = 0;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.cpu != null && message.hasOwnProperty("cpu"))
-                object.cpu = options.json && !isFinite(message.cpu) ? String(message.cpu) : message.cpu;
-            return object;
-        };
+		PacketHeartbeat.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.cpu = 0;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.cpu != null && message.hasOwnProperty("cpu"))
+				object.cpu = options.json && !isFinite(message.cpu) ? String(message.cpu) : message.cpu;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketHeartbeat to JSON.
          * @function toJSON
          * @memberof packets.PacketHeartbeat
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketHeartbeat.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketHeartbeat.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketHeartbeat;
-    })();
+		return PacketHeartbeat;
+	})();
 
-    packets.PacketPing = (function() {
+	packets.PacketPing = (function() {
 
-        /**
+		/**
          * Properties of a PacketPing.
          * @memberof packets
          * @interface IPacketPing
@@ -2383,7 +2384,7 @@ $root.packets = (function() {
          * @property {number|Long} time PacketPing time
          */
 
-        /**
+		/**
          * Constructs a new PacketPing.
          * @memberof packets
          * @classdesc Represents a PacketPing.
@@ -2391,38 +2392,38 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketPing=} [properties] Properties to set
          */
-        function PacketPing(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketPing(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketPing ver.
          * @member {string} ver
          * @memberof packets.PacketPing
          * @instance
          */
-        PacketPing.prototype.ver = "";
+		PacketPing.prototype.ver = "";
 
-        /**
+		/**
          * PacketPing sender.
          * @member {string} sender
          * @memberof packets.PacketPing
          * @instance
          */
-        PacketPing.prototype.sender = "";
+		PacketPing.prototype.sender = "";
 
-        /**
+		/**
          * PacketPing time.
          * @member {number|Long} time
          * @memberof packets.PacketPing
          * @instance
          */
-        PacketPing.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+		PacketPing.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-        /**
+		/**
          * Creates a new PacketPing instance using the specified properties.
          * @function create
          * @memberof packets.PacketPing
@@ -2430,11 +2431,11 @@ $root.packets = (function() {
          * @param {packets.IPacketPing=} [properties] Properties to set
          * @returns {packets.PacketPing} PacketPing instance
          */
-        PacketPing.create = function create(properties) {
-            return new PacketPing(properties);
-        };
+		PacketPing.create = function create(properties) {
+			return new PacketPing(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketPing message. Does not implicitly {@link packets.PacketPing.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketPing
@@ -2443,16 +2444,16 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketPing.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
-            return writer;
-        };
+		PacketPing.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketPing message, length delimited. Does not implicitly {@link packets.PacketPing.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketPing
@@ -2461,11 +2462,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketPing.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketPing.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketPing message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketPing
@@ -2476,37 +2477,37 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketPing.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPing();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.time = reader.int64();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("time"))
-                throw $util.ProtocolError("missing required 'time'", { instance: message });
-            return message;
-        };
+		PacketPing.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPing();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.time = reader.int64();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("time"))
+				throw $util.ProtocolError("missing required 'time'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketPing message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketPing
@@ -2516,13 +2517,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketPing.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketPing.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketPing message.
          * @function verify
          * @memberof packets.PacketPing
@@ -2530,19 +2531,19 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketPing.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
-                return "time: integer|Long expected";
-            return null;
-        };
+		PacketPing.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
+				return "time: integer|Long expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketPing message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketPing
@@ -2550,27 +2551,27 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketPing} PacketPing
          */
-        PacketPing.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketPing)
-                return object;
-            var message = new $root.packets.PacketPing();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.time != null)
-                if ($util.Long)
-                    (message.time = $util.Long.fromValue(object.time)).unsigned = false;
-                else if (typeof object.time === "string")
-                    message.time = parseInt(object.time, 10);
-                else if (typeof object.time === "number")
-                    message.time = object.time;
-                else if (typeof object.time === "object")
-                    message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
-            return message;
-        };
+		PacketPing.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketPing)
+				return object;
+			var message = new $root.packets.PacketPing();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.time != null)
+				if ($util.Long)
+					(message.time = $util.Long.fromValue(object.time)).unsigned = false;
+				else if (typeof object.time === "string")
+					message.time = parseInt(object.time, 10);
+				else if (typeof object.time === "number")
+					message.time = object.time;
+				else if (typeof object.time === "object")
+					message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketPing message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketPing
@@ -2579,48 +2580,48 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketPing.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                if ($util.Long) {
-                    var long = new $util.Long(0, 0, false);
-                    object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-                } else
-                    object.time = options.longs === String ? "0" : 0;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.time != null && message.hasOwnProperty("time"))
-                if (typeof message.time === "number")
-                    object.time = options.longs === String ? String(message.time) : message.time;
-                else
-                    object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
-            return object;
-        };
+		PacketPing.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				if ($util.Long) {
+					var long = new $util.Long(0, 0, false);
+					object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+				} else
+					object.time = options.longs === String ? "0" : 0;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.time != null && message.hasOwnProperty("time"))
+				if (typeof message.time === "number")
+					object.time = options.longs === String ? String(message.time) : message.time;
+				else
+					object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketPing to JSON.
          * @function toJSON
          * @memberof packets.PacketPing
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketPing.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketPing.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketPing;
-    })();
+		return PacketPing;
+	})();
 
-    packets.PacketPong = (function() {
+	packets.PacketPong = (function() {
 
-        /**
+		/**
          * Properties of a PacketPong.
          * @memberof packets
          * @interface IPacketPong
@@ -2630,7 +2631,7 @@ $root.packets = (function() {
          * @property {number|Long} arrived PacketPong arrived
          */
 
-        /**
+		/**
          * Constructs a new PacketPong.
          * @memberof packets
          * @classdesc Represents a PacketPong.
@@ -2638,46 +2639,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketPong=} [properties] Properties to set
          */
-        function PacketPong(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketPong(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketPong ver.
          * @member {string} ver
          * @memberof packets.PacketPong
          * @instance
          */
-        PacketPong.prototype.ver = "";
+		PacketPong.prototype.ver = "";
 
-        /**
+		/**
          * PacketPong sender.
          * @member {string} sender
          * @memberof packets.PacketPong
          * @instance
          */
-        PacketPong.prototype.sender = "";
+		PacketPong.prototype.sender = "";
 
-        /**
+		/**
          * PacketPong time.
          * @member {number|Long} time
          * @memberof packets.PacketPong
          * @instance
          */
-        PacketPong.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+		PacketPong.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-        /**
+		/**
          * PacketPong arrived.
          * @member {number|Long} arrived
          * @memberof packets.PacketPong
          * @instance
          */
-        PacketPong.prototype.arrived = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+		PacketPong.prototype.arrived = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-        /**
+		/**
          * Creates a new PacketPong instance using the specified properties.
          * @function create
          * @memberof packets.PacketPong
@@ -2685,11 +2686,11 @@ $root.packets = (function() {
          * @param {packets.IPacketPong=} [properties] Properties to set
          * @returns {packets.PacketPong} PacketPong instance
          */
-        PacketPong.create = function create(properties) {
-            return new PacketPong(properties);
-        };
+		PacketPong.create = function create(properties) {
+			return new PacketPong(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketPong message. Does not implicitly {@link packets.PacketPong.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketPong
@@ -2698,17 +2699,17 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketPong.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
-            writer.uint32(/* id 4, wireType 0 =*/32).int64(message.arrived);
-            return writer;
-        };
+		PacketPong.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
+			writer.uint32(/* id 4, wireType 0 =*/32).int64(message.arrived);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketPong message, length delimited. Does not implicitly {@link packets.PacketPong.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketPong
@@ -2717,11 +2718,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketPong.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketPong.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketPong message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketPong
@@ -2732,42 +2733,42 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketPong.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPong();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.time = reader.int64();
-                    break;
-                case 4:
-                    message.arrived = reader.int64();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("time"))
-                throw $util.ProtocolError("missing required 'time'", { instance: message });
-            if (!message.hasOwnProperty("arrived"))
-                throw $util.ProtocolError("missing required 'arrived'", { instance: message });
-            return message;
-        };
+		PacketPong.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPong();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.time = reader.int64();
+						break;
+					case 4:
+						message.arrived = reader.int64();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("time"))
+				throw $util.ProtocolError("missing required 'time'", { instance: message });
+			if (!message.hasOwnProperty("arrived"))
+				throw $util.ProtocolError("missing required 'arrived'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketPong message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketPong
@@ -2777,13 +2778,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketPong.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketPong.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketPong message.
          * @function verify
          * @memberof packets.PacketPong
@@ -2791,21 +2792,21 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketPong.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
-                return "time: integer|Long expected";
-            if (!$util.isInteger(message.arrived) && !(message.arrived && $util.isInteger(message.arrived.low) && $util.isInteger(message.arrived.high)))
-                return "arrived: integer|Long expected";
-            return null;
-        };
+		PacketPong.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
+				return "time: integer|Long expected";
+			if (!$util.isInteger(message.arrived) && !(message.arrived && $util.isInteger(message.arrived.low) && $util.isInteger(message.arrived.high)))
+				return "arrived: integer|Long expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketPong message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketPong
@@ -2813,36 +2814,36 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketPong} PacketPong
          */
-        PacketPong.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketPong)
-                return object;
-            var message = new $root.packets.PacketPong();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.time != null)
-                if ($util.Long)
-                    (message.time = $util.Long.fromValue(object.time)).unsigned = false;
-                else if (typeof object.time === "string")
-                    message.time = parseInt(object.time, 10);
-                else if (typeof object.time === "number")
-                    message.time = object.time;
-                else if (typeof object.time === "object")
-                    message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
-            if (object.arrived != null)
-                if ($util.Long)
-                    (message.arrived = $util.Long.fromValue(object.arrived)).unsigned = false;
-                else if (typeof object.arrived === "string")
-                    message.arrived = parseInt(object.arrived, 10);
-                else if (typeof object.arrived === "number")
-                    message.arrived = object.arrived;
-                else if (typeof object.arrived === "object")
-                    message.arrived = new $util.LongBits(object.arrived.low >>> 0, object.arrived.high >>> 0).toNumber();
-            return message;
-        };
+		PacketPong.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketPong)
+				return object;
+			var message = new $root.packets.PacketPong();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.time != null)
+				if ($util.Long)
+					(message.time = $util.Long.fromValue(object.time)).unsigned = false;
+				else if (typeof object.time === "string")
+					message.time = parseInt(object.time, 10);
+				else if (typeof object.time === "number")
+					message.time = object.time;
+				else if (typeof object.time === "object")
+					message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
+			if (object.arrived != null)
+				if ($util.Long)
+					(message.arrived = $util.Long.fromValue(object.arrived)).unsigned = false;
+				else if (typeof object.arrived === "string")
+					message.arrived = parseInt(object.arrived, 10);
+				else if (typeof object.arrived === "number")
+					message.arrived = object.arrived;
+				else if (typeof object.arrived === "object")
+					message.arrived = new $util.LongBits(object.arrived.low >>> 0, object.arrived.high >>> 0).toNumber();
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketPong message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketPong
@@ -2851,58 +2852,58 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketPong.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                if ($util.Long) {
-                    var long = new $util.Long(0, 0, false);
-                    object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-                } else
-                    object.time = options.longs === String ? "0" : 0;
-                if ($util.Long) {
-                    var long = new $util.Long(0, 0, false);
-                    object.arrived = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-                } else
-                    object.arrived = options.longs === String ? "0" : 0;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.time != null && message.hasOwnProperty("time"))
-                if (typeof message.time === "number")
-                    object.time = options.longs === String ? String(message.time) : message.time;
-                else
-                    object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
-            if (message.arrived != null && message.hasOwnProperty("arrived"))
-                if (typeof message.arrived === "number")
-                    object.arrived = options.longs === String ? String(message.arrived) : message.arrived;
-                else
-                    object.arrived = options.longs === String ? $util.Long.prototype.toString.call(message.arrived) : options.longs === Number ? new $util.LongBits(message.arrived.low >>> 0, message.arrived.high >>> 0).toNumber() : message.arrived;
-            return object;
-        };
+		PacketPong.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				if ($util.Long) {
+					var long = new $util.Long(0, 0, false);
+					object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+				} else
+					object.time = options.longs === String ? "0" : 0;
+				if ($util.Long) {
+					var long = new $util.Long(0, 0, false);
+					object.arrived = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+				} else
+					object.arrived = options.longs === String ? "0" : 0;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.time != null && message.hasOwnProperty("time"))
+				if (typeof message.time === "number")
+					object.time = options.longs === String ? String(message.time) : message.time;
+				else
+					object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
+			if (message.arrived != null && message.hasOwnProperty("arrived"))
+				if (typeof message.arrived === "number")
+					object.arrived = options.longs === String ? String(message.arrived) : message.arrived;
+				else
+					object.arrived = options.longs === String ? $util.Long.prototype.toString.call(message.arrived) : options.longs === Number ? new $util.LongBits(message.arrived.low >>> 0, message.arrived.high >>> 0).toNumber() : message.arrived;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketPong to JSON.
          * @function toJSON
          * @memberof packets.PacketPong
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketPong.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketPong.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketPong;
-    })();
+		return PacketPong;
+	})();
 
-    packets.PacketGossipHello = (function() {
+	packets.PacketGossipHello = (function() {
 
-        /**
+		/**
          * Properties of a PacketGossipHello.
          * @memberof packets
          * @interface IPacketGossipHello
@@ -2912,7 +2913,7 @@ $root.packets = (function() {
          * @property {number} port PacketGossipHello port
          */
 
-        /**
+		/**
          * Constructs a new PacketGossipHello.
          * @memberof packets
          * @classdesc Represents a PacketGossipHello.
@@ -2920,46 +2921,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipHello=} [properties] Properties to set
          */
-        function PacketGossipHello(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketGossipHello(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketGossipHello ver.
          * @member {string} ver
          * @memberof packets.PacketGossipHello
          * @instance
          */
-        PacketGossipHello.prototype.ver = "";
+		PacketGossipHello.prototype.ver = "";
 
-        /**
+		/**
          * PacketGossipHello sender.
          * @member {string} sender
          * @memberof packets.PacketGossipHello
          * @instance
          */
-        PacketGossipHello.prototype.sender = "";
+		PacketGossipHello.prototype.sender = "";
 
-        /**
+		/**
          * PacketGossipHello host.
          * @member {string} host
          * @memberof packets.PacketGossipHello
          * @instance
          */
-        PacketGossipHello.prototype.host = "";
+		PacketGossipHello.prototype.host = "";
 
-        /**
+		/**
          * PacketGossipHello port.
          * @member {number} port
          * @memberof packets.PacketGossipHello
          * @instance
          */
-        PacketGossipHello.prototype.port = 0;
+		PacketGossipHello.prototype.port = 0;
 
-        /**
+		/**
          * Creates a new PacketGossipHello instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipHello
@@ -2967,11 +2968,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipHello=} [properties] Properties to set
          * @returns {packets.PacketGossipHello} PacketGossipHello instance
          */
-        PacketGossipHello.create = function create(properties) {
-            return new PacketGossipHello(properties);
-        };
+		PacketGossipHello.create = function create(properties) {
+			return new PacketGossipHello(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketGossipHello message. Does not implicitly {@link packets.PacketGossipHello.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipHello
@@ -2980,17 +2981,17 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketGossipHello.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            writer.uint32(/* id 3, wireType 2 =*/26).string(message.host);
-            writer.uint32(/* id 4, wireType 0 =*/32).int32(message.port);
-            return writer;
-        };
+		PacketGossipHello.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			writer.uint32(/* id 3, wireType 2 =*/26).string(message.host);
+			writer.uint32(/* id 4, wireType 0 =*/32).int32(message.port);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketGossipHello message, length delimited. Does not implicitly {@link packets.PacketGossipHello.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipHello
@@ -2999,11 +3000,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketGossipHello.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketGossipHello.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketGossipHello message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipHello
@@ -3014,42 +3015,42 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketGossipHello.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipHello();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.host = reader.string();
-                    break;
-                case 4:
-                    message.port = reader.int32();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            if (!message.hasOwnProperty("host"))
-                throw $util.ProtocolError("missing required 'host'", { instance: message });
-            if (!message.hasOwnProperty("port"))
-                throw $util.ProtocolError("missing required 'port'", { instance: message });
-            return message;
-        };
+		PacketGossipHello.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipHello();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.host = reader.string();
+						break;
+					case 4:
+						message.port = reader.int32();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			if (!message.hasOwnProperty("host"))
+				throw $util.ProtocolError("missing required 'host'", { instance: message });
+			if (!message.hasOwnProperty("port"))
+				throw $util.ProtocolError("missing required 'port'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketGossipHello message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipHello
@@ -3059,13 +3060,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketGossipHello.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketGossipHello.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketGossipHello message.
          * @function verify
          * @memberof packets.PacketGossipHello
@@ -3073,21 +3074,21 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketGossipHello.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (!$util.isString(message.host))
-                return "host: string expected";
-            if (!$util.isInteger(message.port))
-                return "port: integer expected";
-            return null;
-        };
+		PacketGossipHello.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (!$util.isString(message.host))
+				return "host: string expected";
+			if (!$util.isInteger(message.port))
+				return "port: integer expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketGossipHello message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipHello
@@ -3095,22 +3096,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipHello} PacketGossipHello
          */
-        PacketGossipHello.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketGossipHello)
-                return object;
-            var message = new $root.packets.PacketGossipHello();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.host != null)
-                message.host = String(object.host);
-            if (object.port != null)
-                message.port = object.port | 0;
-            return message;
-        };
+		PacketGossipHello.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketGossipHello)
+				return object;
+			var message = new $root.packets.PacketGossipHello();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.host != null)
+				message.host = String(object.host);
+			if (object.port != null)
+				message.port = object.port | 0;
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketGossipHello message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipHello
@@ -3119,44 +3120,44 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketGossipHello.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.host = "";
-                object.port = 0;
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.host != null && message.hasOwnProperty("host"))
-                object.host = message.host;
-            if (message.port != null && message.hasOwnProperty("port"))
-                object.port = message.port;
-            return object;
-        };
+		PacketGossipHello.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.host = "";
+				object.port = 0;
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.host != null && message.hasOwnProperty("host"))
+				object.host = message.host;
+			if (message.port != null && message.hasOwnProperty("port"))
+				object.port = message.port;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketGossipHello to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipHello
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketGossipHello.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketGossipHello.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketGossipHello;
-    })();
+		return PacketGossipHello;
+	})();
 
-    packets.PacketGossipRequest = (function() {
+	packets.PacketGossipRequest = (function() {
 
-        /**
+		/**
          * Properties of a PacketGossipRequest.
          * @memberof packets
          * @interface IPacketGossipRequest
@@ -3166,7 +3167,7 @@ $root.packets = (function() {
          * @property {string|null} [offline] PacketGossipRequest offline
          */
 
-        /**
+		/**
          * Constructs a new PacketGossipRequest.
          * @memberof packets
          * @classdesc Represents a PacketGossipRequest.
@@ -3174,46 +3175,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipRequest=} [properties] Properties to set
          */
-        function PacketGossipRequest(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketGossipRequest(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketGossipRequest ver.
          * @member {string} ver
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-        PacketGossipRequest.prototype.ver = "";
+		PacketGossipRequest.prototype.ver = "";
 
-        /**
+		/**
          * PacketGossipRequest sender.
          * @member {string} sender
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-        PacketGossipRequest.prototype.sender = "";
+		PacketGossipRequest.prototype.sender = "";
 
-        /**
+		/**
          * PacketGossipRequest online.
          * @member {string} online
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-        PacketGossipRequest.prototype.online = "";
+		PacketGossipRequest.prototype.online = "";
 
-        /**
+		/**
          * PacketGossipRequest offline.
          * @member {string} offline
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-        PacketGossipRequest.prototype.offline = "";
+		PacketGossipRequest.prototype.offline = "";
 
-        /**
+		/**
          * Creates a new PacketGossipRequest instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipRequest
@@ -3221,11 +3222,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipRequest=} [properties] Properties to set
          * @returns {packets.PacketGossipRequest} PacketGossipRequest instance
          */
-        PacketGossipRequest.create = function create(properties) {
-            return new PacketGossipRequest(properties);
-        };
+		PacketGossipRequest.create = function create(properties) {
+			return new PacketGossipRequest(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketGossipRequest message. Does not implicitly {@link packets.PacketGossipRequest.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipRequest
@@ -3234,19 +3235,19 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketGossipRequest.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            if (message.online != null && message.hasOwnProperty("online"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
-            if (message.offline != null && message.hasOwnProperty("offline"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
-            return writer;
-        };
+		PacketGossipRequest.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			if (message.online != null && message.hasOwnProperty("online"))
+				writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
+			if (message.offline != null && message.hasOwnProperty("offline"))
+				writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketGossipRequest message, length delimited. Does not implicitly {@link packets.PacketGossipRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipRequest
@@ -3255,11 +3256,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketGossipRequest.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketGossipRequest.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketGossipRequest message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipRequest
@@ -3270,38 +3271,38 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketGossipRequest.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipRequest();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.online = reader.string();
-                    break;
-                case 4:
-                    message.offline = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            return message;
-        };
+		PacketGossipRequest.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipRequest();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.online = reader.string();
+						break;
+					case 4:
+						message.offline = reader.string();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketGossipRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipRequest
@@ -3311,13 +3312,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketGossipRequest.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketGossipRequest.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketGossipRequest message.
          * @function verify
          * @memberof packets.PacketGossipRequest
@@ -3325,23 +3326,23 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketGossipRequest.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (message.online != null && message.hasOwnProperty("online"))
-                if (!$util.isString(message.online))
-                    return "online: string expected";
-            if (message.offline != null && message.hasOwnProperty("offline"))
-                if (!$util.isString(message.offline))
-                    return "offline: string expected";
-            return null;
-        };
+		PacketGossipRequest.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (message.online != null && message.hasOwnProperty("online"))
+				if (!$util.isString(message.online))
+					return "online: string expected";
+			if (message.offline != null && message.hasOwnProperty("offline"))
+				if (!$util.isString(message.offline))
+					return "offline: string expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketGossipRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipRequest
@@ -3349,22 +3350,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipRequest} PacketGossipRequest
          */
-        PacketGossipRequest.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketGossipRequest)
-                return object;
-            var message = new $root.packets.PacketGossipRequest();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.online != null)
-                message.online = String(object.online);
-            if (object.offline != null)
-                message.offline = String(object.offline);
-            return message;
-        };
+		PacketGossipRequest.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketGossipRequest)
+				return object;
+			var message = new $root.packets.PacketGossipRequest();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.online != null)
+				message.online = String(object.online);
+			if (object.offline != null)
+				message.offline = String(object.offline);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketGossipRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipRequest
@@ -3373,44 +3374,44 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketGossipRequest.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.online = "";
-                object.offline = "";
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.online != null && message.hasOwnProperty("online"))
-                object.online = message.online;
-            if (message.offline != null && message.hasOwnProperty("offline"))
-                object.offline = message.offline;
-            return object;
-        };
+		PacketGossipRequest.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.online = "";
+				object.offline = "";
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.online != null && message.hasOwnProperty("online"))
+				object.online = message.online;
+			if (message.offline != null && message.hasOwnProperty("offline"))
+				object.offline = message.offline;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketGossipRequest to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketGossipRequest.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketGossipRequest.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketGossipRequest;
-    })();
+		return PacketGossipRequest;
+	})();
 
-    packets.PacketGossipResponse = (function() {
+	packets.PacketGossipResponse = (function() {
 
-        /**
+		/**
          * Properties of a PacketGossipResponse.
          * @memberof packets
          * @interface IPacketGossipResponse
@@ -3420,7 +3421,7 @@ $root.packets = (function() {
          * @property {string|null} [offline] PacketGossipResponse offline
          */
 
-        /**
+		/**
          * Constructs a new PacketGossipResponse.
          * @memberof packets
          * @classdesc Represents a PacketGossipResponse.
@@ -3428,46 +3429,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipResponse=} [properties] Properties to set
          */
-        function PacketGossipResponse(properties) {
-            if (properties)
-                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
+		function PacketGossipResponse(properties) {
+			if (properties)
+				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+					if (properties[keys[i]] != null)
+						this[keys[i]] = properties[keys[i]];
+		}
 
-        /**
+		/**
          * PacketGossipResponse ver.
          * @member {string} ver
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-        PacketGossipResponse.prototype.ver = "";
+		PacketGossipResponse.prototype.ver = "";
 
-        /**
+		/**
          * PacketGossipResponse sender.
          * @member {string} sender
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-        PacketGossipResponse.prototype.sender = "";
+		PacketGossipResponse.prototype.sender = "";
 
-        /**
+		/**
          * PacketGossipResponse online.
          * @member {string} online
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-        PacketGossipResponse.prototype.online = "";
+		PacketGossipResponse.prototype.online = "";
 
-        /**
+		/**
          * PacketGossipResponse offline.
          * @member {string} offline
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-        PacketGossipResponse.prototype.offline = "";
+		PacketGossipResponse.prototype.offline = "";
 
-        /**
+		/**
          * Creates a new PacketGossipResponse instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipResponse
@@ -3475,11 +3476,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipResponse=} [properties] Properties to set
          * @returns {packets.PacketGossipResponse} PacketGossipResponse instance
          */
-        PacketGossipResponse.create = function create(properties) {
-            return new PacketGossipResponse(properties);
-        };
+		PacketGossipResponse.create = function create(properties) {
+			return new PacketGossipResponse(properties);
+		};
 
-        /**
+		/**
          * Encodes the specified PacketGossipResponse message. Does not implicitly {@link packets.PacketGossipResponse.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipResponse
@@ -3488,19 +3489,19 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketGossipResponse.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-            if (message.online != null && message.hasOwnProperty("online"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
-            if (message.offline != null && message.hasOwnProperty("offline"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
-            return writer;
-        };
+		PacketGossipResponse.encode = function encode(message, writer) {
+			if (!writer)
+				writer = $Writer.create();
+			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+			if (message.online != null && message.hasOwnProperty("online"))
+				writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
+			if (message.offline != null && message.hasOwnProperty("offline"))
+				writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
+			return writer;
+		};
 
-        /**
+		/**
          * Encodes the specified PacketGossipResponse message, length delimited. Does not implicitly {@link packets.PacketGossipResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipResponse
@@ -3509,11 +3510,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        PacketGossipResponse.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
+		PacketGossipResponse.encodeDelimited = function encodeDelimited(message, writer) {
+			return this.encode(message, writer).ldelim();
+		};
 
-        /**
+		/**
          * Decodes a PacketGossipResponse message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipResponse
@@ -3524,38 +3525,38 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketGossipResponse.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipResponse();
-            while (reader.pos < end) {
-                var tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.ver = reader.string();
-                    break;
-                case 2:
-                    message.sender = reader.string();
-                    break;
-                case 3:
-                    message.online = reader.string();
-                    break;
-                case 4:
-                    message.offline = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            if (!message.hasOwnProperty("ver"))
-                throw $util.ProtocolError("missing required 'ver'", { instance: message });
-            if (!message.hasOwnProperty("sender"))
-                throw $util.ProtocolError("missing required 'sender'", { instance: message });
-            return message;
-        };
+		PacketGossipResponse.decode = function decode(reader, length) {
+			if (!(reader instanceof $Reader))
+				reader = $Reader.create(reader);
+			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipResponse();
+			while (reader.pos < end) {
+				var tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						message.ver = reader.string();
+						break;
+					case 2:
+						message.sender = reader.string();
+						break;
+					case 3:
+						message.online = reader.string();
+						break;
+					case 4:
+						message.offline = reader.string();
+						break;
+					default:
+						reader.skipType(tag & 7);
+						break;
+				}
+			}
+			if (!message.hasOwnProperty("ver"))
+				throw $util.ProtocolError("missing required 'ver'", { instance: message });
+			if (!message.hasOwnProperty("sender"))
+				throw $util.ProtocolError("missing required 'sender'", { instance: message });
+			return message;
+		};
 
-        /**
+		/**
          * Decodes a PacketGossipResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipResponse
@@ -3565,13 +3566,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PacketGossipResponse.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
+		PacketGossipResponse.decodeDelimited = function decodeDelimited(reader) {
+			if (!(reader instanceof $Reader))
+				reader = new $Reader(reader);
+			return this.decode(reader, reader.uint32());
+		};
 
-        /**
+		/**
          * Verifies a PacketGossipResponse message.
          * @function verify
          * @memberof packets.PacketGossipResponse
@@ -3579,23 +3580,23 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        PacketGossipResponse.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (!$util.isString(message.ver))
-                return "ver: string expected";
-            if (!$util.isString(message.sender))
-                return "sender: string expected";
-            if (message.online != null && message.hasOwnProperty("online"))
-                if (!$util.isString(message.online))
-                    return "online: string expected";
-            if (message.offline != null && message.hasOwnProperty("offline"))
-                if (!$util.isString(message.offline))
-                    return "offline: string expected";
-            return null;
-        };
+		PacketGossipResponse.verify = function verify(message) {
+			if (typeof message !== "object" || message === null)
+				return "object expected";
+			if (!$util.isString(message.ver))
+				return "ver: string expected";
+			if (!$util.isString(message.sender))
+				return "sender: string expected";
+			if (message.online != null && message.hasOwnProperty("online"))
+				if (!$util.isString(message.online))
+					return "online: string expected";
+			if (message.offline != null && message.hasOwnProperty("offline"))
+				if (!$util.isString(message.offline))
+					return "offline: string expected";
+			return null;
+		};
 
-        /**
+		/**
          * Creates a PacketGossipResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipResponse
@@ -3603,22 +3604,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipResponse} PacketGossipResponse
          */
-        PacketGossipResponse.fromObject = function fromObject(object) {
-            if (object instanceof $root.packets.PacketGossipResponse)
-                return object;
-            var message = new $root.packets.PacketGossipResponse();
-            if (object.ver != null)
-                message.ver = String(object.ver);
-            if (object.sender != null)
-                message.sender = String(object.sender);
-            if (object.online != null)
-                message.online = String(object.online);
-            if (object.offline != null)
-                message.offline = String(object.offline);
-            return message;
-        };
+		PacketGossipResponse.fromObject = function fromObject(object) {
+			if (object instanceof $root.packets.PacketGossipResponse)
+				return object;
+			var message = new $root.packets.PacketGossipResponse();
+			if (object.ver != null)
+				message.ver = String(object.ver);
+			if (object.sender != null)
+				message.sender = String(object.sender);
+			if (object.online != null)
+				message.online = String(object.online);
+			if (object.offline != null)
+				message.offline = String(object.offline);
+			return message;
+		};
 
-        /**
+		/**
          * Creates a plain object from a PacketGossipResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipResponse
@@ -3627,42 +3628,42 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        PacketGossipResponse.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            var object = {};
-            if (options.defaults) {
-                object.ver = "";
-                object.sender = "";
-                object.online = "";
-                object.offline = "";
-            }
-            if (message.ver != null && message.hasOwnProperty("ver"))
-                object.ver = message.ver;
-            if (message.sender != null && message.hasOwnProperty("sender"))
-                object.sender = message.sender;
-            if (message.online != null && message.hasOwnProperty("online"))
-                object.online = message.online;
-            if (message.offline != null && message.hasOwnProperty("offline"))
-                object.offline = message.offline;
-            return object;
-        };
+		PacketGossipResponse.toObject = function toObject(message, options) {
+			if (!options)
+				options = {};
+			var object = {};
+			if (options.defaults) {
+				object.ver = "";
+				object.sender = "";
+				object.online = "";
+				object.offline = "";
+			}
+			if (message.ver != null && message.hasOwnProperty("ver"))
+				object.ver = message.ver;
+			if (message.sender != null && message.hasOwnProperty("sender"))
+				object.sender = message.sender;
+			if (message.online != null && message.hasOwnProperty("online"))
+				object.online = message.online;
+			if (message.offline != null && message.hasOwnProperty("offline"))
+				object.offline = message.offline;
+			return object;
+		};
 
-        /**
+		/**
          * Converts this PacketGossipResponse to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        PacketGossipResponse.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
+		PacketGossipResponse.prototype.toJSON = function toJSON() {
+			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+		};
 
-        return PacketGossipResponse;
-    })();
+		return PacketGossipResponse;
+	})();
 
-    return packets;
+	return packets;
 })();
 
 module.exports = $root;

--- a/src/serializers/proto/packets.proto.js
+++ b/src/serializers/proto/packets.proto.js
@@ -1,27 +1,26 @@
-/*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 "use strict";
 
-let $protobuf = require("protobufjs/minimal");
+var $protobuf = require("protobufjs/minimal");
 
 // Common aliases
-let $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-let $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
 
-/* istanbul ignore next */
 $root.packets = (function() {
 
-	/**
+    /**
      * Namespace packets.
      * @exports packets
      * @namespace
      */
-	let packets = {};
+    var packets = {};
 
-	packets.PacketEvent = (function() {
+    packets.PacketEvent = (function() {
 
-		/**
+        /**
          * Properties of a PacketEvent.
          * @memberof packets
          * @interface IPacketEvent
@@ -33,7 +32,7 @@ $root.packets = (function() {
          * @property {boolean} broadcast PacketEvent broadcast
          */
 
-		/**
+        /**
          * Constructs a new PacketEvent.
          * @memberof packets
          * @classdesc Represents a PacketEvent.
@@ -41,63 +40,63 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketEvent=} [properties] Properties to set
          */
-		function PacketEvent(properties) {
-			this.groups = [];
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketEvent(properties) {
+            this.groups = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketEvent ver.
          * @member {string} ver
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.ver = "";
+        PacketEvent.prototype.ver = "";
 
-		/**
+        /**
          * PacketEvent sender.
          * @member {string} sender
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.sender = "";
+        PacketEvent.prototype.sender = "";
 
-		/**
+        /**
          * PacketEvent event.
          * @member {string} event
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.event = "";
+        PacketEvent.prototype.event = "";
 
-		/**
+        /**
          * PacketEvent data.
          * @member {string} data
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.data = "";
+        PacketEvent.prototype.data = "";
 
-		/**
+        /**
          * PacketEvent groups.
          * @member {Array.<string>} groups
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.groups = $util.emptyArray;
+        PacketEvent.prototype.groups = $util.emptyArray;
 
-		/**
+        /**
          * PacketEvent broadcast.
          * @member {boolean} broadcast
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.broadcast = false;
+        PacketEvent.prototype.broadcast = false;
 
-		/**
+        /**
          * Creates a new PacketEvent instance using the specified properties.
          * @function create
          * @memberof packets.PacketEvent
@@ -105,11 +104,11 @@ $root.packets = (function() {
          * @param {packets.IPacketEvent=} [properties] Properties to set
          * @returns {packets.PacketEvent} PacketEvent instance
          */
-		PacketEvent.create = function create(properties) {
-			return new PacketEvent(properties);
-		};
+        PacketEvent.create = function create(properties) {
+            return new PacketEvent(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketEvent message. Does not implicitly {@link packets.PacketEvent.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketEvent
@@ -118,22 +117,22 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketEvent.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.event);
-			if (message.data != null && message.hasOwnProperty("data"))
-				writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
-			if (message.groups != null && message.groups.length)
-				for (let i = 0; i < message.groups.length; ++i)
-					writer.uint32(/* id 5, wireType 2 =*/42).string(message.groups[i]);
-			writer.uint32(/* id 6, wireType 0 =*/48).bool(message.broadcast);
-			return writer;
-		};
+        PacketEvent.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 2 =*/26).string(message.event);
+            if (message.data != null && message.hasOwnProperty("data"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
+            if (message.groups != null && message.groups.length)
+                for (var i = 0; i < message.groups.length; ++i)
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.groups[i]);
+            writer.uint32(/* id 6, wireType 0 =*/48).bool(message.broadcast);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketEvent message, length delimited. Does not implicitly {@link packets.PacketEvent.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketEvent
@@ -142,11 +141,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketEvent.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketEvent.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketEvent message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketEvent
@@ -157,50 +156,50 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketEvent.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketEvent();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.event = reader.string();
-						break;
-					case 4:
-						message.data = reader.string();
-						break;
-					case 5:
-						if (!(message.groups && message.groups.length))
-							message.groups = [];
-						message.groups.push(reader.string());
-						break;
-					case 6:
-						message.broadcast = reader.bool();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("event"))
-				throw $util.ProtocolError("missing required 'event'", { instance: message });
-			if (!message.hasOwnProperty("broadcast"))
-				throw $util.ProtocolError("missing required 'broadcast'", { instance: message });
-			return message;
-		};
+        PacketEvent.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketEvent();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.event = reader.string();
+                    break;
+                case 4:
+                    message.data = reader.string();
+                    break;
+                case 5:
+                    if (!(message.groups && message.groups.length))
+                        message.groups = [];
+                    message.groups.push(reader.string());
+                    break;
+                case 6:
+                    message.broadcast = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("event"))
+                throw $util.ProtocolError("missing required 'event'", { instance: message });
+            if (!message.hasOwnProperty("broadcast"))
+                throw $util.ProtocolError("missing required 'broadcast'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketEvent message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketEvent
@@ -210,13 +209,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketEvent.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketEvent.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketEvent message.
          * @function verify
          * @memberof packets.PacketEvent
@@ -224,31 +223,31 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketEvent.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.event))
-				return "event: string expected";
-			if (message.data != null && message.hasOwnProperty("data"))
-				if (!$util.isString(message.data))
-					return "data: string expected";
-			if (message.groups != null && message.hasOwnProperty("groups")) {
-				if (!Array.isArray(message.groups))
-					return "groups: array expected";
-				for (let i = 0; i < message.groups.length; ++i)
-					if (!$util.isString(message.groups[i]))
-						return "groups: string[] expected";
-			}
-			if (typeof message.broadcast !== "boolean")
-				return "broadcast: boolean expected";
-			return null;
-		};
+        PacketEvent.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isString(message.event))
+                return "event: string expected";
+            if (message.data != null && message.hasOwnProperty("data"))
+                if (!$util.isString(message.data))
+                    return "data: string expected";
+            if (message.groups != null && message.hasOwnProperty("groups")) {
+                if (!Array.isArray(message.groups))
+                    return "groups: array expected";
+                for (var i = 0; i < message.groups.length; ++i)
+                    if (!$util.isString(message.groups[i]))
+                        return "groups: string[] expected";
+            }
+            if (typeof message.broadcast !== "boolean")
+                return "broadcast: boolean expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketEvent message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketEvent
@@ -256,31 +255,31 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketEvent} PacketEvent
          */
-		PacketEvent.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketEvent)
-				return object;
-			let message = new $root.packets.PacketEvent();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.event != null)
-				message.event = String(object.event);
-			if (object.data != null)
-				message.data = String(object.data);
-			if (object.groups) {
-				if (!Array.isArray(object.groups))
-					throw TypeError(".packets.PacketEvent.groups: array expected");
-				message.groups = [];
-				for (let i = 0; i < object.groups.length; ++i)
-					message.groups[i] = String(object.groups[i]);
-			}
-			if (object.broadcast != null)
-				message.broadcast = Boolean(object.broadcast);
-			return message;
-		};
+        PacketEvent.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketEvent)
+                return object;
+            var message = new $root.packets.PacketEvent();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.event != null)
+                message.event = String(object.event);
+            if (object.data != null)
+                message.data = String(object.data);
+            if (object.groups) {
+                if (!Array.isArray(object.groups))
+                    throw TypeError(".packets.PacketEvent.groups: array expected");
+                message.groups = [];
+                for (var i = 0; i < object.groups.length; ++i)
+                    message.groups[i] = String(object.groups[i]);
+            }
+            if (object.broadcast != null)
+                message.broadcast = Boolean(object.broadcast);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketEvent message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketEvent
@@ -289,54 +288,54 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketEvent.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.arrays || options.defaults)
-				object.groups = [];
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.event = "";
-				object.data = "";
-				object.broadcast = false;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.event != null && message.hasOwnProperty("event"))
-				object.event = message.event;
-			if (message.data != null && message.hasOwnProperty("data"))
-				object.data = message.data;
-			if (message.groups && message.groups.length) {
-				object.groups = [];
-				for (let j = 0; j < message.groups.length; ++j)
-					object.groups[j] = message.groups[j];
-			}
-			if (message.broadcast != null && message.hasOwnProperty("broadcast"))
-				object.broadcast = message.broadcast;
-			return object;
-		};
+        PacketEvent.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.groups = [];
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.event = "";
+                object.data = "";
+                object.broadcast = false;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.event != null && message.hasOwnProperty("event"))
+                object.event = message.event;
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = message.data;
+            if (message.groups && message.groups.length) {
+                object.groups = [];
+                for (var j = 0; j < message.groups.length; ++j)
+                    object.groups[j] = message.groups[j];
+            }
+            if (message.broadcast != null && message.hasOwnProperty("broadcast"))
+                object.broadcast = message.broadcast;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketEvent to JSON.
          * @function toJSON
          * @memberof packets.PacketEvent
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketEvent.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketEvent.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketEvent;
-	})();
+        return PacketEvent;
+    })();
 
-	packets.PacketRequest = (function() {
+    packets.PacketRequest = (function() {
 
-		/**
+        /**
          * Properties of a PacketRequest.
          * @memberof packets
          * @interface IPacketRequest
@@ -354,7 +353,7 @@ $root.packets = (function() {
          * @property {boolean|null} [stream] PacketRequest stream
          */
 
-		/**
+        /**
          * Constructs a new PacketRequest.
          * @memberof packets
          * @classdesc Represents a PacketRequest.
@@ -362,110 +361,110 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketRequest=} [properties] Properties to set
          */
-		function PacketRequest(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketRequest ver.
          * @member {string} ver
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.ver = "";
+        PacketRequest.prototype.ver = "";
 
-		/**
+        /**
          * PacketRequest sender.
          * @member {string} sender
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.sender = "";
+        PacketRequest.prototype.sender = "";
 
-		/**
+        /**
          * PacketRequest id.
          * @member {string} id
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.id = "";
+        PacketRequest.prototype.id = "";
 
-		/**
+        /**
          * PacketRequest action.
          * @member {string} action
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.action = "";
+        PacketRequest.prototype.action = "";
 
-		/**
+        /**
          * PacketRequest params.
          * @member {Uint8Array} params
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.params = $util.newBuffer([]);
+        PacketRequest.prototype.params = $util.newBuffer([]);
 
-		/**
+        /**
          * PacketRequest meta.
          * @member {string} meta
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.meta = "";
+        PacketRequest.prototype.meta = "";
 
-		/**
+        /**
          * PacketRequest timeout.
          * @member {number} timeout
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.timeout = 0;
+        PacketRequest.prototype.timeout = 0;
 
-		/**
+        /**
          * PacketRequest level.
          * @member {number} level
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.level = 0;
+        PacketRequest.prototype.level = 0;
 
-		/**
+        /**
          * PacketRequest metrics.
          * @member {boolean} metrics
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.metrics = false;
+        PacketRequest.prototype.metrics = false;
 
-		/**
+        /**
          * PacketRequest parentID.
          * @member {string} parentID
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.parentID = "";
+        PacketRequest.prototype.parentID = "";
 
-		/**
+        /**
          * PacketRequest requestID.
          * @member {string} requestID
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.requestID = "";
+        PacketRequest.prototype.requestID = "";
 
-		/**
+        /**
          * PacketRequest stream.
          * @member {boolean} stream
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.stream = false;
+        PacketRequest.prototype.stream = false;
 
-		/**
+        /**
          * Creates a new PacketRequest instance using the specified properties.
          * @function create
          * @memberof packets.PacketRequest
@@ -473,11 +472,11 @@ $root.packets = (function() {
          * @param {packets.IPacketRequest=} [properties] Properties to set
          * @returns {packets.PacketRequest} PacketRequest instance
          */
-		PacketRequest.create = function create(properties) {
-			return new PacketRequest(properties);
-		};
+        PacketRequest.create = function create(properties) {
+            return new PacketRequest(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketRequest message. Does not implicitly {@link packets.PacketRequest.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketRequest
@@ -486,30 +485,30 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketRequest.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
-			writer.uint32(/* id 4, wireType 2 =*/34).string(message.action);
-			if (message.params != null && message.hasOwnProperty("params"))
-				writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.params);
-			writer.uint32(/* id 6, wireType 2 =*/50).string(message.meta);
-			writer.uint32(/* id 7, wireType 1 =*/57).double(message.timeout);
-			writer.uint32(/* id 8, wireType 0 =*/64).int32(message.level);
-			if (message.metrics != null && message.hasOwnProperty("metrics"))
-				writer.uint32(/* id 9, wireType 0 =*/72).bool(message.metrics);
-			if (message.parentID != null && message.hasOwnProperty("parentID"))
-				writer.uint32(/* id 10, wireType 2 =*/82).string(message.parentID);
-			if (message.requestID != null && message.hasOwnProperty("requestID"))
-				writer.uint32(/* id 11, wireType 2 =*/90).string(message.requestID);
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				writer.uint32(/* id 12, wireType 0 =*/96).bool(message.stream);
-			return writer;
-		};
+        PacketRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
+            writer.uint32(/* id 4, wireType 2 =*/34).string(message.action);
+            if (message.params != null && message.hasOwnProperty("params"))
+                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.params);
+            writer.uint32(/* id 6, wireType 2 =*/50).string(message.meta);
+            writer.uint32(/* id 7, wireType 1 =*/57).double(message.timeout);
+            writer.uint32(/* id 8, wireType 0 =*/64).int32(message.level);
+            if (message.metrics != null && message.hasOwnProperty("metrics"))
+                writer.uint32(/* id 9, wireType 0 =*/72).bool(message.metrics);
+            if (message.parentID != null && message.hasOwnProperty("parentID"))
+                writer.uint32(/* id 10, wireType 2 =*/82).string(message.parentID);
+            if (message.requestID != null && message.hasOwnProperty("requestID"))
+                writer.uint32(/* id 11, wireType 2 =*/90).string(message.requestID);
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                writer.uint32(/* id 12, wireType 0 =*/96).bool(message.stream);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketRequest message, length delimited. Does not implicitly {@link packets.PacketRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketRequest
@@ -518,11 +517,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketRequest.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketRequest message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketRequest
@@ -533,72 +532,72 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketRequest.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketRequest();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.id = reader.string();
-						break;
-					case 4:
-						message.action = reader.string();
-						break;
-					case 5:
-						message.params = reader.bytes();
-						break;
-					case 6:
-						message.meta = reader.string();
-						break;
-					case 7:
-						message.timeout = reader.double();
-						break;
-					case 8:
-						message.level = reader.int32();
-						break;
-					case 9:
-						message.metrics = reader.bool();
-						break;
-					case 10:
-						message.parentID = reader.string();
-						break;
-					case 11:
-						message.requestID = reader.string();
-						break;
-					case 12:
-						message.stream = reader.bool();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("id"))
-				throw $util.ProtocolError("missing required 'id'", { instance: message });
-			if (!message.hasOwnProperty("action"))
-				throw $util.ProtocolError("missing required 'action'", { instance: message });
-			if (!message.hasOwnProperty("meta"))
-				throw $util.ProtocolError("missing required 'meta'", { instance: message });
-			if (!message.hasOwnProperty("timeout"))
-				throw $util.ProtocolError("missing required 'timeout'", { instance: message });
-			if (!message.hasOwnProperty("level"))
-				throw $util.ProtocolError("missing required 'level'", { instance: message });
-			return message;
-		};
+        PacketRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.id = reader.string();
+                    break;
+                case 4:
+                    message.action = reader.string();
+                    break;
+                case 5:
+                    message.params = reader.bytes();
+                    break;
+                case 6:
+                    message.meta = reader.string();
+                    break;
+                case 7:
+                    message.timeout = reader.double();
+                    break;
+                case 8:
+                    message.level = reader.int32();
+                    break;
+                case 9:
+                    message.metrics = reader.bool();
+                    break;
+                case 10:
+                    message.parentID = reader.string();
+                    break;
+                case 11:
+                    message.requestID = reader.string();
+                    break;
+                case 12:
+                    message.stream = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("id"))
+                throw $util.ProtocolError("missing required 'id'", { instance: message });
+            if (!message.hasOwnProperty("action"))
+                throw $util.ProtocolError("missing required 'action'", { instance: message });
+            if (!message.hasOwnProperty("meta"))
+                throw $util.ProtocolError("missing required 'meta'", { instance: message });
+            if (!message.hasOwnProperty("timeout"))
+                throw $util.ProtocolError("missing required 'timeout'", { instance: message });
+            if (!message.hasOwnProperty("level"))
+                throw $util.ProtocolError("missing required 'level'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketRequest
@@ -608,13 +607,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketRequest.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketRequest message.
          * @function verify
          * @memberof packets.PacketRequest
@@ -622,42 +621,42 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketRequest.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.id))
-				return "id: string expected";
-			if (!$util.isString(message.action))
-				return "action: string expected";
-			if (message.params != null && message.hasOwnProperty("params"))
-				if (!(message.params && typeof message.params.length === "number" || $util.isString(message.params)))
-					return "params: buffer expected";
-			if (!$util.isString(message.meta))
-				return "meta: string expected";
-			if (typeof message.timeout !== "number")
-				return "timeout: number expected";
-			if (!$util.isInteger(message.level))
-				return "level: integer expected";
-			if (message.metrics != null && message.hasOwnProperty("metrics"))
-				if (typeof message.metrics !== "boolean")
-					return "metrics: boolean expected";
-			if (message.parentID != null && message.hasOwnProperty("parentID"))
-				if (!$util.isString(message.parentID))
-					return "parentID: string expected";
-			if (message.requestID != null && message.hasOwnProperty("requestID"))
-				if (!$util.isString(message.requestID))
-					return "requestID: string expected";
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				if (typeof message.stream !== "boolean")
-					return "stream: boolean expected";
-			return null;
-		};
+        PacketRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isString(message.id))
+                return "id: string expected";
+            if (!$util.isString(message.action))
+                return "action: string expected";
+            if (message.params != null && message.hasOwnProperty("params"))
+                if (!(message.params && typeof message.params.length === "number" || $util.isString(message.params)))
+                    return "params: buffer expected";
+            if (!$util.isString(message.meta))
+                return "meta: string expected";
+            if (typeof message.timeout !== "number")
+                return "timeout: number expected";
+            if (!$util.isInteger(message.level))
+                return "level: integer expected";
+            if (message.metrics != null && message.hasOwnProperty("metrics"))
+                if (typeof message.metrics !== "boolean")
+                    return "metrics: boolean expected";
+            if (message.parentID != null && message.hasOwnProperty("parentID"))
+                if (!$util.isString(message.parentID))
+                    return "parentID: string expected";
+            if (message.requestID != null && message.hasOwnProperty("requestID"))
+                if (!$util.isString(message.requestID))
+                    return "requestID: string expected";
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                if (typeof message.stream !== "boolean")
+                    return "stream: boolean expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketRequest
@@ -665,41 +664,41 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketRequest} PacketRequest
          */
-		PacketRequest.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketRequest)
-				return object;
-			let message = new $root.packets.PacketRequest();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.id != null)
-				message.id = String(object.id);
-			if (object.action != null)
-				message.action = String(object.action);
-			if (object.params != null)
-				if (typeof object.params === "string")
-					$util.base64.decode(object.params, message.params = $util.newBuffer($util.base64.length(object.params)), 0);
-				else if (object.params.length)
-					message.params = object.params;
-			if (object.meta != null)
-				message.meta = String(object.meta);
-			if (object.timeout != null)
-				message.timeout = Number(object.timeout);
-			if (object.level != null)
-				message.level = object.level | 0;
-			if (object.metrics != null)
-				message.metrics = Boolean(object.metrics);
-			if (object.parentID != null)
-				message.parentID = String(object.parentID);
-			if (object.requestID != null)
-				message.requestID = String(object.requestID);
-			if (object.stream != null)
-				message.stream = Boolean(object.stream);
-			return message;
-		};
+        PacketRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketRequest)
+                return object;
+            var message = new $root.packets.PacketRequest();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.action != null)
+                message.action = String(object.action);
+            if (object.params != null)
+                if (typeof object.params === "string")
+                    $util.base64.decode(object.params, message.params = $util.newBuffer($util.base64.length(object.params)), 0);
+                else if (object.params.length)
+                    message.params = object.params;
+            if (object.meta != null)
+                message.meta = String(object.meta);
+            if (object.timeout != null)
+                message.timeout = Number(object.timeout);
+            if (object.level != null)
+                message.level = object.level | 0;
+            if (object.metrics != null)
+                message.metrics = Boolean(object.metrics);
+            if (object.parentID != null)
+                message.parentID = String(object.parentID);
+            if (object.requestID != null)
+                message.requestID = String(object.requestID);
+            if (object.stream != null)
+                message.stream = Boolean(object.stream);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketRequest
@@ -708,68 +707,74 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketRequest.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.id = "";
-				object.action = "";
-				object.params = options.bytes === String ? "" : [];
-				object.meta = "";
-				object.timeout = 0;
-				object.level = 0;
-				object.metrics = false;
-				object.parentID = "";
-				object.requestID = "";
-				object.stream = false;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.id != null && message.hasOwnProperty("id"))
-				object.id = message.id;
-			if (message.action != null && message.hasOwnProperty("action"))
-				object.action = message.action;
-			if (message.params != null && message.hasOwnProperty("params"))
-				object.params = options.bytes === String ? $util.base64.encode(message.params, 0, message.params.length) : options.bytes === Array ? Array.prototype.slice.call(message.params) : message.params;
-			if (message.meta != null && message.hasOwnProperty("meta"))
-				object.meta = message.meta;
-			if (message.timeout != null && message.hasOwnProperty("timeout"))
-				object.timeout = options.json && !isFinite(message.timeout) ? String(message.timeout) : message.timeout;
-			if (message.level != null && message.hasOwnProperty("level"))
-				object.level = message.level;
-			if (message.metrics != null && message.hasOwnProperty("metrics"))
-				object.metrics = message.metrics;
-			if (message.parentID != null && message.hasOwnProperty("parentID"))
-				object.parentID = message.parentID;
-			if (message.requestID != null && message.hasOwnProperty("requestID"))
-				object.requestID = message.requestID;
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				object.stream = message.stream;
-			return object;
-		};
+        PacketRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.id = "";
+                object.action = "";
+                if (options.bytes === String)
+                    object.params = "";
+                else {
+                    object.params = [];
+                    if (options.bytes !== Array)
+                        object.params = $util.newBuffer(object.params);
+                }
+                object.meta = "";
+                object.timeout = 0;
+                object.level = 0;
+                object.metrics = false;
+                object.parentID = "";
+                object.requestID = "";
+                object.stream = false;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.action != null && message.hasOwnProperty("action"))
+                object.action = message.action;
+            if (message.params != null && message.hasOwnProperty("params"))
+                object.params = options.bytes === String ? $util.base64.encode(message.params, 0, message.params.length) : options.bytes === Array ? Array.prototype.slice.call(message.params) : message.params;
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                object.meta = message.meta;
+            if (message.timeout != null && message.hasOwnProperty("timeout"))
+                object.timeout = options.json && !isFinite(message.timeout) ? String(message.timeout) : message.timeout;
+            if (message.level != null && message.hasOwnProperty("level"))
+                object.level = message.level;
+            if (message.metrics != null && message.hasOwnProperty("metrics"))
+                object.metrics = message.metrics;
+            if (message.parentID != null && message.hasOwnProperty("parentID"))
+                object.parentID = message.parentID;
+            if (message.requestID != null && message.hasOwnProperty("requestID"))
+                object.requestID = message.requestID;
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                object.stream = message.stream;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketRequest to JSON.
          * @function toJSON
          * @memberof packets.PacketRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketRequest.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketRequest;
-	})();
+        return PacketRequest;
+    })();
 
-	packets.PacketResponse = (function() {
+    packets.PacketResponse = (function() {
 
-		/**
+        /**
          * Properties of a PacketResponse.
          * @memberof packets
          * @interface IPacketResponse
@@ -783,7 +788,7 @@ $root.packets = (function() {
          * @property {boolean|null} [stream] PacketResponse stream
          */
 
-		/**
+        /**
          * Constructs a new PacketResponse.
          * @memberof packets
          * @classdesc Represents a PacketResponse.
@@ -791,78 +796,78 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketResponse=} [properties] Properties to set
          */
-		function PacketResponse(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketResponse ver.
          * @member {string} ver
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.ver = "";
+        PacketResponse.prototype.ver = "";
 
-		/**
+        /**
          * PacketResponse sender.
          * @member {string} sender
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.sender = "";
+        PacketResponse.prototype.sender = "";
 
-		/**
+        /**
          * PacketResponse id.
          * @member {string} id
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.id = "";
+        PacketResponse.prototype.id = "";
 
-		/**
+        /**
          * PacketResponse success.
          * @member {boolean} success
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.success = false;
+        PacketResponse.prototype.success = false;
 
-		/**
+        /**
          * PacketResponse data.
          * @member {Uint8Array} data
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.data = $util.newBuffer([]);
+        PacketResponse.prototype.data = $util.newBuffer([]);
 
-		/**
+        /**
          * PacketResponse error.
          * @member {string} error
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.error = "";
+        PacketResponse.prototype.error = "";
 
-		/**
+        /**
          * PacketResponse meta.
          * @member {string} meta
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.meta = "";
+        PacketResponse.prototype.meta = "";
 
-		/**
+        /**
          * PacketResponse stream.
          * @member {boolean} stream
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.stream = false;
+        PacketResponse.prototype.stream = false;
 
-		/**
+        /**
          * Creates a new PacketResponse instance using the specified properties.
          * @function create
          * @memberof packets.PacketResponse
@@ -870,11 +875,11 @@ $root.packets = (function() {
          * @param {packets.IPacketResponse=} [properties] Properties to set
          * @returns {packets.PacketResponse} PacketResponse instance
          */
-		PacketResponse.create = function create(properties) {
-			return new PacketResponse(properties);
-		};
+        PacketResponse.create = function create(properties) {
+            return new PacketResponse(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketResponse message. Does not implicitly {@link packets.PacketResponse.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketResponse
@@ -883,24 +888,24 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketResponse.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
-			writer.uint32(/* id 4, wireType 0 =*/32).bool(message.success);
-			if (message.data != null && message.hasOwnProperty("data"))
-				writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.data);
-			if (message.error != null && message.hasOwnProperty("error"))
-				writer.uint32(/* id 6, wireType 2 =*/50).string(message.error);
-			writer.uint32(/* id 7, wireType 2 =*/58).string(message.meta);
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				writer.uint32(/* id 8, wireType 0 =*/64).bool(message.stream);
-			return writer;
-		};
+        PacketResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
+            writer.uint32(/* id 4, wireType 0 =*/32).bool(message.success);
+            if (message.data != null && message.hasOwnProperty("data"))
+                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.data);
+            if (message.error != null && message.hasOwnProperty("error"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.error);
+            writer.uint32(/* id 7, wireType 2 =*/58).string(message.meta);
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.stream);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketResponse message, length delimited. Does not implicitly {@link packets.PacketResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketResponse
@@ -909,11 +914,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketResponse.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketResponse message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketResponse
@@ -924,56 +929,56 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketResponse.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketResponse();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.id = reader.string();
-						break;
-					case 4:
-						message.success = reader.bool();
-						break;
-					case 5:
-						message.data = reader.bytes();
-						break;
-					case 6:
-						message.error = reader.string();
-						break;
-					case 7:
-						message.meta = reader.string();
-						break;
-					case 8:
-						message.stream = reader.bool();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("id"))
-				throw $util.ProtocolError("missing required 'id'", { instance: message });
-			if (!message.hasOwnProperty("success"))
-				throw $util.ProtocolError("missing required 'success'", { instance: message });
-			if (!message.hasOwnProperty("meta"))
-				throw $util.ProtocolError("missing required 'meta'", { instance: message });
-			return message;
-		};
+        PacketResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.id = reader.string();
+                    break;
+                case 4:
+                    message.success = reader.bool();
+                    break;
+                case 5:
+                    message.data = reader.bytes();
+                    break;
+                case 6:
+                    message.error = reader.string();
+                    break;
+                case 7:
+                    message.meta = reader.string();
+                    break;
+                case 8:
+                    message.stream = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("id"))
+                throw $util.ProtocolError("missing required 'id'", { instance: message });
+            if (!message.hasOwnProperty("success"))
+                throw $util.ProtocolError("missing required 'success'", { instance: message });
+            if (!message.hasOwnProperty("meta"))
+                throw $util.ProtocolError("missing required 'meta'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketResponse
@@ -983,13 +988,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketResponse.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketResponse message.
          * @function verify
          * @memberof packets.PacketResponse
@@ -997,32 +1002,32 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketResponse.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.id))
-				return "id: string expected";
-			if (typeof message.success !== "boolean")
-				return "success: boolean expected";
-			if (message.data != null && message.hasOwnProperty("data"))
-				if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
-					return "data: buffer expected";
-			if (message.error != null && message.hasOwnProperty("error"))
-				if (!$util.isString(message.error))
-					return "error: string expected";
-			if (!$util.isString(message.meta))
-				return "meta: string expected";
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				if (typeof message.stream !== "boolean")
-					return "stream: boolean expected";
-			return null;
-		};
+        PacketResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isString(message.id))
+                return "id: string expected";
+            if (typeof message.success !== "boolean")
+                return "success: boolean expected";
+            if (message.data != null && message.hasOwnProperty("data"))
+                if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
+                    return "data: buffer expected";
+            if (message.error != null && message.hasOwnProperty("error"))
+                if (!$util.isString(message.error))
+                    return "error: string expected";
+            if (!$util.isString(message.meta))
+                return "meta: string expected";
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                if (typeof message.stream !== "boolean")
+                    return "stream: boolean expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketResponse
@@ -1030,33 +1035,33 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketResponse} PacketResponse
          */
-		PacketResponse.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketResponse)
-				return object;
-			let message = new $root.packets.PacketResponse();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.id != null)
-				message.id = String(object.id);
-			if (object.success != null)
-				message.success = Boolean(object.success);
-			if (object.data != null)
-				if (typeof object.data === "string")
-					$util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
-				else if (object.data.length)
-					message.data = object.data;
-			if (object.error != null)
-				message.error = String(object.error);
-			if (object.meta != null)
-				message.meta = String(object.meta);
-			if (object.stream != null)
-				message.stream = Boolean(object.stream);
-			return message;
-		};
+        PacketResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketResponse)
+                return object;
+            var message = new $root.packets.PacketResponse();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.success != null)
+                message.success = Boolean(object.success);
+            if (object.data != null)
+                if (typeof object.data === "string")
+                    $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
+                else if (object.data.length)
+                    message.data = object.data;
+            if (object.error != null)
+                message.error = String(object.error);
+            if (object.meta != null)
+                message.meta = String(object.meta);
+            if (object.stream != null)
+                message.stream = Boolean(object.stream);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketResponse
@@ -1065,56 +1070,62 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketResponse.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.id = "";
-				object.success = false;
-				object.data = options.bytes === String ? "" : [];
-				object.error = "";
-				object.meta = "";
-				object.stream = false;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.id != null && message.hasOwnProperty("id"))
-				object.id = message.id;
-			if (message.success != null && message.hasOwnProperty("success"))
-				object.success = message.success;
-			if (message.data != null && message.hasOwnProperty("data"))
-				object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
-			if (message.error != null && message.hasOwnProperty("error"))
-				object.error = message.error;
-			if (message.meta != null && message.hasOwnProperty("meta"))
-				object.meta = message.meta;
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				object.stream = message.stream;
-			return object;
-		};
+        PacketResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.id = "";
+                object.success = false;
+                if (options.bytes === String)
+                    object.data = "";
+                else {
+                    object.data = [];
+                    if (options.bytes !== Array)
+                        object.data = $util.newBuffer(object.data);
+                }
+                object.error = "";
+                object.meta = "";
+                object.stream = false;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.success != null && message.hasOwnProperty("success"))
+                object.success = message.success;
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
+            if (message.error != null && message.hasOwnProperty("error"))
+                object.error = message.error;
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                object.meta = message.meta;
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                object.stream = message.stream;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketResponse to JSON.
          * @function toJSON
          * @memberof packets.PacketResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketResponse.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketResponse;
-	})();
+        return PacketResponse;
+    })();
 
-	packets.PacketDiscover = (function() {
+    packets.PacketDiscover = (function() {
 
-		/**
+        /**
          * Properties of a PacketDiscover.
          * @memberof packets
          * @interface IPacketDiscover
@@ -1122,7 +1133,7 @@ $root.packets = (function() {
          * @property {string} sender PacketDiscover sender
          */
 
-		/**
+        /**
          * Constructs a new PacketDiscover.
          * @memberof packets
          * @classdesc Represents a PacketDiscover.
@@ -1130,30 +1141,30 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketDiscover=} [properties] Properties to set
          */
-		function PacketDiscover(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketDiscover(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketDiscover ver.
          * @member {string} ver
          * @memberof packets.PacketDiscover
          * @instance
          */
-		PacketDiscover.prototype.ver = "";
+        PacketDiscover.prototype.ver = "";
 
-		/**
+        /**
          * PacketDiscover sender.
          * @member {string} sender
          * @memberof packets.PacketDiscover
          * @instance
          */
-		PacketDiscover.prototype.sender = "";
+        PacketDiscover.prototype.sender = "";
 
-		/**
+        /**
          * Creates a new PacketDiscover instance using the specified properties.
          * @function create
          * @memberof packets.PacketDiscover
@@ -1161,11 +1172,11 @@ $root.packets = (function() {
          * @param {packets.IPacketDiscover=} [properties] Properties to set
          * @returns {packets.PacketDiscover} PacketDiscover instance
          */
-		PacketDiscover.create = function create(properties) {
-			return new PacketDiscover(properties);
-		};
+        PacketDiscover.create = function create(properties) {
+            return new PacketDiscover(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDiscover message. Does not implicitly {@link packets.PacketDiscover.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketDiscover
@@ -1174,15 +1185,15 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDiscover.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			return writer;
-		};
+        PacketDiscover.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDiscover message, length delimited. Does not implicitly {@link packets.PacketDiscover.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketDiscover
@@ -1191,11 +1202,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDiscover.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketDiscover.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketDiscover message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketDiscover
@@ -1206,32 +1217,32 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDiscover.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDiscover();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketDiscover.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDiscover();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketDiscover message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketDiscover
@@ -1241,13 +1252,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDiscover.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketDiscover.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketDiscover message.
          * @function verify
          * @memberof packets.PacketDiscover
@@ -1255,17 +1266,17 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketDiscover.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			return null;
-		};
+        PacketDiscover.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketDiscover message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketDiscover
@@ -1273,18 +1284,18 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketDiscover} PacketDiscover
          */
-		PacketDiscover.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketDiscover)
-				return object;
-			let message = new $root.packets.PacketDiscover();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			return message;
-		};
+        PacketDiscover.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketDiscover)
+                return object;
+            var message = new $root.packets.PacketDiscover();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketDiscover message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketDiscover
@@ -1293,38 +1304,38 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketDiscover.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			return object;
-		};
+        PacketDiscover.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketDiscover to JSON.
          * @function toJSON
          * @memberof packets.PacketDiscover
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketDiscover.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketDiscover.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketDiscover;
-	})();
+        return PacketDiscover;
+    })();
 
-	packets.PacketInfo = (function() {
+    packets.PacketInfo = (function() {
 
-		/**
+        /**
          * Properties of a PacketInfo.
          * @memberof packets
          * @interface IPacketInfo
@@ -1335,9 +1346,10 @@ $root.packets = (function() {
          * @property {Array.<string>|null} [ipList] PacketInfo ipList
          * @property {string} hostname PacketInfo hostname
          * @property {packets.PacketInfo.IClient} client PacketInfo client
+         * @property {number} seq PacketInfo seq
          */
 
-		/**
+        /**
          * Constructs a new PacketInfo.
          * @memberof packets
          * @classdesc Represents a PacketInfo.
@@ -1345,71 +1357,79 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketInfo=} [properties] Properties to set
          */
-		function PacketInfo(properties) {
-			this.ipList = [];
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketInfo(properties) {
+            this.ipList = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketInfo ver.
          * @member {string} ver
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.ver = "";
+        PacketInfo.prototype.ver = "";
 
-		/**
+        /**
          * PacketInfo sender.
          * @member {string} sender
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.sender = "";
+        PacketInfo.prototype.sender = "";
 
-		/**
+        /**
          * PacketInfo services.
          * @member {string} services
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.services = "";
+        PacketInfo.prototype.services = "";
 
-		/**
+        /**
          * PacketInfo config.
          * @member {string} config
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.config = "";
+        PacketInfo.prototype.config = "";
 
-		/**
+        /**
          * PacketInfo ipList.
          * @member {Array.<string>} ipList
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.ipList = $util.emptyArray;
+        PacketInfo.prototype.ipList = $util.emptyArray;
 
-		/**
+        /**
          * PacketInfo hostname.
          * @member {string} hostname
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.hostname = "";
+        PacketInfo.prototype.hostname = "";
 
-		/**
+        /**
          * PacketInfo client.
          * @member {packets.PacketInfo.IClient} client
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.client = null;
+        PacketInfo.prototype.client = null;
 
-		/**
+        /**
+         * PacketInfo seq.
+         * @member {number} seq
+         * @memberof packets.PacketInfo
+         * @instance
+         */
+        PacketInfo.prototype.seq = 0;
+
+        /**
          * Creates a new PacketInfo instance using the specified properties.
          * @function create
          * @memberof packets.PacketInfo
@@ -1417,11 +1437,11 @@ $root.packets = (function() {
          * @param {packets.IPacketInfo=} [properties] Properties to set
          * @returns {packets.PacketInfo} PacketInfo instance
          */
-		PacketInfo.create = function create(properties) {
-			return new PacketInfo(properties);
-		};
+        PacketInfo.create = function create(properties) {
+            return new PacketInfo(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketInfo message. Does not implicitly {@link packets.PacketInfo.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketInfo
@@ -1430,22 +1450,23 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketInfo.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.services);
-			writer.uint32(/* id 4, wireType 2 =*/34).string(message.config);
-			if (message.ipList != null && message.ipList.length)
-				for (let i = 0; i < message.ipList.length; ++i)
-					writer.uint32(/* id 5, wireType 2 =*/42).string(message.ipList[i]);
-			writer.uint32(/* id 6, wireType 2 =*/50).string(message.hostname);
-			$root.packets.PacketInfo.Client.encode(message.client, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
-			return writer;
-		};
+        PacketInfo.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 2 =*/26).string(message.services);
+            writer.uint32(/* id 4, wireType 2 =*/34).string(message.config);
+            if (message.ipList != null && message.ipList.length)
+                for (var i = 0; i < message.ipList.length; ++i)
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.ipList[i]);
+            writer.uint32(/* id 6, wireType 2 =*/50).string(message.hostname);
+            $root.packets.PacketInfo.Client.encode(message.client, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+            writer.uint32(/* id 8, wireType 0 =*/64).int32(message.seq);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketInfo message, length delimited. Does not implicitly {@link packets.PacketInfo.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketInfo
@@ -1454,11 +1475,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketInfo.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketInfo.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketInfo message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketInfo
@@ -1469,57 +1490,62 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketInfo.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.services = reader.string();
-						break;
-					case 4:
-						message.config = reader.string();
-						break;
-					case 5:
-						if (!(message.ipList && message.ipList.length))
-							message.ipList = [];
-						message.ipList.push(reader.string());
-						break;
-					case 6:
-						message.hostname = reader.string();
-						break;
-					case 7:
-						message.client = $root.packets.PacketInfo.Client.decode(reader, reader.uint32());
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("services"))
-				throw $util.ProtocolError("missing required 'services'", { instance: message });
-			if (!message.hasOwnProperty("config"))
-				throw $util.ProtocolError("missing required 'config'", { instance: message });
-			if (!message.hasOwnProperty("hostname"))
-				throw $util.ProtocolError("missing required 'hostname'", { instance: message });
-			if (!message.hasOwnProperty("client"))
-				throw $util.ProtocolError("missing required 'client'", { instance: message });
-			return message;
-		};
+        PacketInfo.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.services = reader.string();
+                    break;
+                case 4:
+                    message.config = reader.string();
+                    break;
+                case 5:
+                    if (!(message.ipList && message.ipList.length))
+                        message.ipList = [];
+                    message.ipList.push(reader.string());
+                    break;
+                case 6:
+                    message.hostname = reader.string();
+                    break;
+                case 7:
+                    message.client = $root.packets.PacketInfo.Client.decode(reader, reader.uint32());
+                    break;
+                case 8:
+                    message.seq = reader.int32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("services"))
+                throw $util.ProtocolError("missing required 'services'", { instance: message });
+            if (!message.hasOwnProperty("config"))
+                throw $util.ProtocolError("missing required 'config'", { instance: message });
+            if (!message.hasOwnProperty("hostname"))
+                throw $util.ProtocolError("missing required 'hostname'", { instance: message });
+            if (!message.hasOwnProperty("client"))
+                throw $util.ProtocolError("missing required 'client'", { instance: message });
+            if (!message.hasOwnProperty("seq"))
+                throw $util.ProtocolError("missing required 'seq'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketInfo message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketInfo
@@ -1529,13 +1555,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketInfo.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketInfo.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketInfo message.
          * @function verify
          * @memberof packets.PacketInfo
@@ -1543,35 +1569,37 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketInfo.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.services))
-				return "services: string expected";
-			if (!$util.isString(message.config))
-				return "config: string expected";
-			if (message.ipList != null && message.hasOwnProperty("ipList")) {
-				if (!Array.isArray(message.ipList))
-					return "ipList: array expected";
-				for (let i = 0; i < message.ipList.length; ++i)
-					if (!$util.isString(message.ipList[i]))
-						return "ipList: string[] expected";
-			}
-			if (!$util.isString(message.hostname))
-				return "hostname: string expected";
-			{
-				let error = $root.packets.PacketInfo.Client.verify(message.client);
-				if (error)
-					return "client." + error;
-			}
-			return null;
-		};
+        PacketInfo.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isString(message.services))
+                return "services: string expected";
+            if (!$util.isString(message.config))
+                return "config: string expected";
+            if (message.ipList != null && message.hasOwnProperty("ipList")) {
+                if (!Array.isArray(message.ipList))
+                    return "ipList: array expected";
+                for (var i = 0; i < message.ipList.length; ++i)
+                    if (!$util.isString(message.ipList[i]))
+                        return "ipList: string[] expected";
+            }
+            if (!$util.isString(message.hostname))
+                return "hostname: string expected";
+            {
+                var error = $root.packets.PacketInfo.Client.verify(message.client);
+                if (error)
+                    return "client." + error;
+            }
+            if (!$util.isInteger(message.seq))
+                return "seq: integer expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketInfo message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketInfo
@@ -1579,36 +1607,38 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketInfo} PacketInfo
          */
-		PacketInfo.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketInfo)
-				return object;
-			let message = new $root.packets.PacketInfo();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.services != null)
-				message.services = String(object.services);
-			if (object.config != null)
-				message.config = String(object.config);
-			if (object.ipList) {
-				if (!Array.isArray(object.ipList))
-					throw TypeError(".packets.PacketInfo.ipList: array expected");
-				message.ipList = [];
-				for (let i = 0; i < object.ipList.length; ++i)
-					message.ipList[i] = String(object.ipList[i]);
-			}
-			if (object.hostname != null)
-				message.hostname = String(object.hostname);
-			if (object.client != null) {
-				if (typeof object.client !== "object")
-					throw TypeError(".packets.PacketInfo.client: object expected");
-				message.client = $root.packets.PacketInfo.Client.fromObject(object.client);
-			}
-			return message;
-		};
+        PacketInfo.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketInfo)
+                return object;
+            var message = new $root.packets.PacketInfo();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.services != null)
+                message.services = String(object.services);
+            if (object.config != null)
+                message.config = String(object.config);
+            if (object.ipList) {
+                if (!Array.isArray(object.ipList))
+                    throw TypeError(".packets.PacketInfo.ipList: array expected");
+                message.ipList = [];
+                for (var i = 0; i < object.ipList.length; ++i)
+                    message.ipList[i] = String(object.ipList[i]);
+            }
+            if (object.hostname != null)
+                message.hostname = String(object.hostname);
+            if (object.client != null) {
+                if (typeof object.client !== "object")
+                    throw TypeError(".packets.PacketInfo.client: object expected");
+                message.client = $root.packets.PacketInfo.Client.fromObject(object.client);
+            }
+            if (object.seq != null)
+                message.seq = object.seq | 0;
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketInfo message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketInfo
@@ -1617,54 +1647,57 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketInfo.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.arrays || options.defaults)
-				object.ipList = [];
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.services = "";
-				object.config = "";
-				object.hostname = "";
-				object.client = null;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.services != null && message.hasOwnProperty("services"))
-				object.services = message.services;
-			if (message.config != null && message.hasOwnProperty("config"))
-				object.config = message.config;
-			if (message.ipList && message.ipList.length) {
-				object.ipList = [];
-				for (let j = 0; j < message.ipList.length; ++j)
-					object.ipList[j] = message.ipList[j];
-			}
-			if (message.hostname != null && message.hasOwnProperty("hostname"))
-				object.hostname = message.hostname;
-			if (message.client != null && message.hasOwnProperty("client"))
-				object.client = $root.packets.PacketInfo.Client.toObject(message.client, options);
-			return object;
-		};
+        PacketInfo.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.ipList = [];
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.services = "";
+                object.config = "";
+                object.hostname = "";
+                object.client = null;
+                object.seq = 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.services != null && message.hasOwnProperty("services"))
+                object.services = message.services;
+            if (message.config != null && message.hasOwnProperty("config"))
+                object.config = message.config;
+            if (message.ipList && message.ipList.length) {
+                object.ipList = [];
+                for (var j = 0; j < message.ipList.length; ++j)
+                    object.ipList[j] = message.ipList[j];
+            }
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                object.hostname = message.hostname;
+            if (message.client != null && message.hasOwnProperty("client"))
+                object.client = $root.packets.PacketInfo.Client.toObject(message.client, options);
+            if (message.seq != null && message.hasOwnProperty("seq"))
+                object.seq = message.seq;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketInfo to JSON.
          * @function toJSON
          * @memberof packets.PacketInfo
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketInfo.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketInfo.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		PacketInfo.Client = (function() {
+        PacketInfo.Client = (function() {
 
-			/**
+            /**
              * Properties of a Client.
              * @memberof packets.PacketInfo
              * @interface IClient
@@ -1673,7 +1706,7 @@ $root.packets = (function() {
              * @property {string} langVersion Client langVersion
              */
 
-			/**
+            /**
              * Constructs a new Client.
              * @memberof packets.PacketInfo
              * @classdesc Represents a Client.
@@ -1681,38 +1714,38 @@ $root.packets = (function() {
              * @constructor
              * @param {packets.PacketInfo.IClient=} [properties] Properties to set
              */
-			function Client(properties) {
-				if (properties)
-					for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-						if (properties[keys[i]] != null)
-							this[keys[i]] = properties[keys[i]];
-			}
+            function Client(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
 
-			/**
+            /**
              * Client type.
              * @member {string} type
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-			Client.prototype.type = "";
+            Client.prototype.type = "";
 
-			/**
+            /**
              * Client version.
              * @member {string} version
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-			Client.prototype.version = "";
+            Client.prototype.version = "";
 
-			/**
+            /**
              * Client langVersion.
              * @member {string} langVersion
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-			Client.prototype.langVersion = "";
+            Client.prototype.langVersion = "";
 
-			/**
+            /**
              * Creates a new Client instance using the specified properties.
              * @function create
              * @memberof packets.PacketInfo.Client
@@ -1720,11 +1753,11 @@ $root.packets = (function() {
              * @param {packets.PacketInfo.IClient=} [properties] Properties to set
              * @returns {packets.PacketInfo.Client} Client instance
              */
-			Client.create = function create(properties) {
-				return new Client(properties);
-			};
+            Client.create = function create(properties) {
+                return new Client(properties);
+            };
 
-			/**
+            /**
              * Encodes the specified Client message. Does not implicitly {@link packets.PacketInfo.Client.verify|verify} messages.
              * @function encode
              * @memberof packets.PacketInfo.Client
@@ -1733,16 +1766,16 @@ $root.packets = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-			Client.encode = function encode(message, writer) {
-				if (!writer)
-					writer = $Writer.create();
-				writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-				writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
-				writer.uint32(/* id 3, wireType 2 =*/26).string(message.langVersion);
-				return writer;
-			};
+            Client.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.langVersion);
+                return writer;
+            };
 
-			/**
+            /**
              * Encodes the specified Client message, length delimited. Does not implicitly {@link packets.PacketInfo.Client.verify|verify} messages.
              * @function encodeDelimited
              * @memberof packets.PacketInfo.Client
@@ -1751,11 +1784,11 @@ $root.packets = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-			Client.encodeDelimited = function encodeDelimited(message, writer) {
-				return this.encode(message, writer).ldelim();
-			};
+            Client.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
 
-			/**
+            /**
              * Decodes a Client message from the specified reader or buffer.
              * @function decode
              * @memberof packets.PacketInfo.Client
@@ -1766,37 +1799,37 @@ $root.packets = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-			Client.decode = function decode(reader, length) {
-				if (!(reader instanceof $Reader))
-					reader = $Reader.create(reader);
-				let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo.Client();
-				while (reader.pos < end) {
-					let tag = reader.uint32();
-					switch (tag >>> 3) {
-						case 1:
-							message.type = reader.string();
-							break;
-						case 2:
-							message.version = reader.string();
-							break;
-						case 3:
-							message.langVersion = reader.string();
-							break;
-						default:
-							reader.skipType(tag & 7);
-							break;
-					}
-				}
-				if (!message.hasOwnProperty("type"))
-					throw $util.ProtocolError("missing required 'type'", { instance: message });
-				if (!message.hasOwnProperty("version"))
-					throw $util.ProtocolError("missing required 'version'", { instance: message });
-				if (!message.hasOwnProperty("langVersion"))
-					throw $util.ProtocolError("missing required 'langVersion'", { instance: message });
-				return message;
-			};
+            Client.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo.Client();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.type = reader.string();
+                        break;
+                    case 2:
+                        message.version = reader.string();
+                        break;
+                    case 3:
+                        message.langVersion = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                if (!message.hasOwnProperty("type"))
+                    throw $util.ProtocolError("missing required 'type'", { instance: message });
+                if (!message.hasOwnProperty("version"))
+                    throw $util.ProtocolError("missing required 'version'", { instance: message });
+                if (!message.hasOwnProperty("langVersion"))
+                    throw $util.ProtocolError("missing required 'langVersion'", { instance: message });
+                return message;
+            };
 
-			/**
+            /**
              * Decodes a Client message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
              * @memberof packets.PacketInfo.Client
@@ -1806,13 +1839,13 @@ $root.packets = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-			Client.decodeDelimited = function decodeDelimited(reader) {
-				if (!(reader instanceof $Reader))
-					reader = new $Reader(reader);
-				return this.decode(reader, reader.uint32());
-			};
+            Client.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
 
-			/**
+            /**
              * Verifies a Client message.
              * @function verify
              * @memberof packets.PacketInfo.Client
@@ -1820,19 +1853,19 @@ $root.packets = (function() {
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-			Client.verify = function verify(message) {
-				if (typeof message !== "object" || message === null)
-					return "object expected";
-				if (!$util.isString(message.type))
-					return "type: string expected";
-				if (!$util.isString(message.version))
-					return "version: string expected";
-				if (!$util.isString(message.langVersion))
-					return "langVersion: string expected";
-				return null;
-			};
+            Client.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (!$util.isString(message.type))
+                    return "type: string expected";
+                if (!$util.isString(message.version))
+                    return "version: string expected";
+                if (!$util.isString(message.langVersion))
+                    return "langVersion: string expected";
+                return null;
+            };
 
-			/**
+            /**
              * Creates a Client message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
              * @memberof packets.PacketInfo.Client
@@ -1840,20 +1873,20 @@ $root.packets = (function() {
              * @param {Object.<string,*>} object Plain object
              * @returns {packets.PacketInfo.Client} Client
              */
-			Client.fromObject = function fromObject(object) {
-				if (object instanceof $root.packets.PacketInfo.Client)
-					return object;
-				let message = new $root.packets.PacketInfo.Client();
-				if (object.type != null)
-					message.type = String(object.type);
-				if (object.version != null)
-					message.version = String(object.version);
-				if (object.langVersion != null)
-					message.langVersion = String(object.langVersion);
-				return message;
-			};
+            Client.fromObject = function fromObject(object) {
+                if (object instanceof $root.packets.PacketInfo.Client)
+                    return object;
+                var message = new $root.packets.PacketInfo.Client();
+                if (object.type != null)
+                    message.type = String(object.type);
+                if (object.version != null)
+                    message.version = String(object.version);
+                if (object.langVersion != null)
+                    message.langVersion = String(object.langVersion);
+                return message;
+            };
 
-			/**
+            /**
              * Creates a plain object from a Client message. Also converts values to other types if specified.
              * @function toObject
              * @memberof packets.PacketInfo.Client
@@ -1862,44 +1895,44 @@ $root.packets = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-			Client.toObject = function toObject(message, options) {
-				if (!options)
-					options = {};
-				let object = {};
-				if (options.defaults) {
-					object.type = "";
-					object.version = "";
-					object.langVersion = "";
-				}
-				if (message.type != null && message.hasOwnProperty("type"))
-					object.type = message.type;
-				if (message.version != null && message.hasOwnProperty("version"))
-					object.version = message.version;
-				if (message.langVersion != null && message.hasOwnProperty("langVersion"))
-					object.langVersion = message.langVersion;
-				return object;
-			};
+            Client.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.type = "";
+                    object.version = "";
+                    object.langVersion = "";
+                }
+                if (message.type != null && message.hasOwnProperty("type"))
+                    object.type = message.type;
+                if (message.version != null && message.hasOwnProperty("version"))
+                    object.version = message.version;
+                if (message.langVersion != null && message.hasOwnProperty("langVersion"))
+                    object.langVersion = message.langVersion;
+                return object;
+            };
 
-			/**
+            /**
              * Converts this Client to JSON.
              * @function toJSON
              * @memberof packets.PacketInfo.Client
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-			Client.prototype.toJSON = function toJSON() {
-				return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-			};
+            Client.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
 
-			return Client;
-		})();
+            return Client;
+        })();
 
-		return PacketInfo;
-	})();
+        return PacketInfo;
+    })();
 
-	packets.PacketDisconnect = (function() {
+    packets.PacketDisconnect = (function() {
 
-		/**
+        /**
          * Properties of a PacketDisconnect.
          * @memberof packets
          * @interface IPacketDisconnect
@@ -1907,7 +1940,7 @@ $root.packets = (function() {
          * @property {string} sender PacketDisconnect sender
          */
 
-		/**
+        /**
          * Constructs a new PacketDisconnect.
          * @memberof packets
          * @classdesc Represents a PacketDisconnect.
@@ -1915,30 +1948,30 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketDisconnect=} [properties] Properties to set
          */
-		function PacketDisconnect(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketDisconnect(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketDisconnect ver.
          * @member {string} ver
          * @memberof packets.PacketDisconnect
          * @instance
          */
-		PacketDisconnect.prototype.ver = "";
+        PacketDisconnect.prototype.ver = "";
 
-		/**
+        /**
          * PacketDisconnect sender.
          * @member {string} sender
          * @memberof packets.PacketDisconnect
          * @instance
          */
-		PacketDisconnect.prototype.sender = "";
+        PacketDisconnect.prototype.sender = "";
 
-		/**
+        /**
          * Creates a new PacketDisconnect instance using the specified properties.
          * @function create
          * @memberof packets.PacketDisconnect
@@ -1946,11 +1979,11 @@ $root.packets = (function() {
          * @param {packets.IPacketDisconnect=} [properties] Properties to set
          * @returns {packets.PacketDisconnect} PacketDisconnect instance
          */
-		PacketDisconnect.create = function create(properties) {
-			return new PacketDisconnect(properties);
-		};
+        PacketDisconnect.create = function create(properties) {
+            return new PacketDisconnect(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDisconnect message. Does not implicitly {@link packets.PacketDisconnect.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketDisconnect
@@ -1959,15 +1992,15 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDisconnect.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			return writer;
-		};
+        PacketDisconnect.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDisconnect message, length delimited. Does not implicitly {@link packets.PacketDisconnect.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketDisconnect
@@ -1976,11 +2009,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDisconnect.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketDisconnect.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketDisconnect message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketDisconnect
@@ -1991,32 +2024,32 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDisconnect.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDisconnect();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketDisconnect.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDisconnect();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketDisconnect message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketDisconnect
@@ -2026,13 +2059,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDisconnect.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketDisconnect.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketDisconnect message.
          * @function verify
          * @memberof packets.PacketDisconnect
@@ -2040,17 +2073,17 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketDisconnect.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			return null;
-		};
+        PacketDisconnect.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketDisconnect message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketDisconnect
@@ -2058,18 +2091,18 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketDisconnect} PacketDisconnect
          */
-		PacketDisconnect.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketDisconnect)
-				return object;
-			let message = new $root.packets.PacketDisconnect();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			return message;
-		};
+        PacketDisconnect.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketDisconnect)
+                return object;
+            var message = new $root.packets.PacketDisconnect();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketDisconnect message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketDisconnect
@@ -2078,38 +2111,38 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketDisconnect.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			return object;
-		};
+        PacketDisconnect.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketDisconnect to JSON.
          * @function toJSON
          * @memberof packets.PacketDisconnect
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketDisconnect.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketDisconnect.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketDisconnect;
-	})();
+        return PacketDisconnect;
+    })();
 
-	packets.PacketHeartbeat = (function() {
+    packets.PacketHeartbeat = (function() {
 
-		/**
+        /**
          * Properties of a PacketHeartbeat.
          * @memberof packets
          * @interface IPacketHeartbeat
@@ -2118,7 +2151,7 @@ $root.packets = (function() {
          * @property {number} cpu PacketHeartbeat cpu
          */
 
-		/**
+        /**
          * Constructs a new PacketHeartbeat.
          * @memberof packets
          * @classdesc Represents a PacketHeartbeat.
@@ -2126,38 +2159,38 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketHeartbeat=} [properties] Properties to set
          */
-		function PacketHeartbeat(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketHeartbeat(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketHeartbeat ver.
          * @member {string} ver
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-		PacketHeartbeat.prototype.ver = "";
+        PacketHeartbeat.prototype.ver = "";
 
-		/**
+        /**
          * PacketHeartbeat sender.
          * @member {string} sender
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-		PacketHeartbeat.prototype.sender = "";
+        PacketHeartbeat.prototype.sender = "";
 
-		/**
+        /**
          * PacketHeartbeat cpu.
          * @member {number} cpu
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-		PacketHeartbeat.prototype.cpu = 0;
+        PacketHeartbeat.prototype.cpu = 0;
 
-		/**
+        /**
          * Creates a new PacketHeartbeat instance using the specified properties.
          * @function create
          * @memberof packets.PacketHeartbeat
@@ -2165,11 +2198,11 @@ $root.packets = (function() {
          * @param {packets.IPacketHeartbeat=} [properties] Properties to set
          * @returns {packets.PacketHeartbeat} PacketHeartbeat instance
          */
-		PacketHeartbeat.create = function create(properties) {
-			return new PacketHeartbeat(properties);
-		};
+        PacketHeartbeat.create = function create(properties) {
+            return new PacketHeartbeat(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketHeartbeat message. Does not implicitly {@link packets.PacketHeartbeat.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketHeartbeat
@@ -2178,16 +2211,16 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketHeartbeat.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 1 =*/25).double(message.cpu);
-			return writer;
-		};
+        PacketHeartbeat.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 1 =*/25).double(message.cpu);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketHeartbeat message, length delimited. Does not implicitly {@link packets.PacketHeartbeat.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketHeartbeat
@@ -2196,11 +2229,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketHeartbeat.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketHeartbeat.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketHeartbeat message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketHeartbeat
@@ -2211,37 +2244,37 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketHeartbeat.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketHeartbeat();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.cpu = reader.double();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("cpu"))
-				throw $util.ProtocolError("missing required 'cpu'", { instance: message });
-			return message;
-		};
+        PacketHeartbeat.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketHeartbeat();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.cpu = reader.double();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("cpu"))
+                throw $util.ProtocolError("missing required 'cpu'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketHeartbeat message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketHeartbeat
@@ -2251,13 +2284,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketHeartbeat.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketHeartbeat.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketHeartbeat message.
          * @function verify
          * @memberof packets.PacketHeartbeat
@@ -2265,19 +2298,19 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketHeartbeat.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (typeof message.cpu !== "number")
-				return "cpu: number expected";
-			return null;
-		};
+        PacketHeartbeat.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (typeof message.cpu !== "number")
+                return "cpu: number expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketHeartbeat message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketHeartbeat
@@ -2285,20 +2318,20 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketHeartbeat} PacketHeartbeat
          */
-		PacketHeartbeat.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketHeartbeat)
-				return object;
-			let message = new $root.packets.PacketHeartbeat();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.cpu != null)
-				message.cpu = Number(object.cpu);
-			return message;
-		};
+        PacketHeartbeat.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketHeartbeat)
+                return object;
+            var message = new $root.packets.PacketHeartbeat();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.cpu != null)
+                message.cpu = Number(object.cpu);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketHeartbeat message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketHeartbeat
@@ -2307,41 +2340,41 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketHeartbeat.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.cpu = 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.cpu != null && message.hasOwnProperty("cpu"))
-				object.cpu = options.json && !isFinite(message.cpu) ? String(message.cpu) : message.cpu;
-			return object;
-		};
+        PacketHeartbeat.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.cpu = 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.cpu != null && message.hasOwnProperty("cpu"))
+                object.cpu = options.json && !isFinite(message.cpu) ? String(message.cpu) : message.cpu;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketHeartbeat to JSON.
          * @function toJSON
          * @memberof packets.PacketHeartbeat
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketHeartbeat.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketHeartbeat.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketHeartbeat;
-	})();
+        return PacketHeartbeat;
+    })();
 
-	packets.PacketPing = (function() {
+    packets.PacketPing = (function() {
 
-		/**
+        /**
          * Properties of a PacketPing.
          * @memberof packets
          * @interface IPacketPing
@@ -2350,7 +2383,7 @@ $root.packets = (function() {
          * @property {number|Long} time PacketPing time
          */
 
-		/**
+        /**
          * Constructs a new PacketPing.
          * @memberof packets
          * @classdesc Represents a PacketPing.
@@ -2358,38 +2391,38 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketPing=} [properties] Properties to set
          */
-		function PacketPing(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketPing(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketPing ver.
          * @member {string} ver
          * @memberof packets.PacketPing
          * @instance
          */
-		PacketPing.prototype.ver = "";
+        PacketPing.prototype.ver = "";
 
-		/**
+        /**
          * PacketPing sender.
          * @member {string} sender
          * @memberof packets.PacketPing
          * @instance
          */
-		PacketPing.prototype.sender = "";
+        PacketPing.prototype.sender = "";
 
-		/**
+        /**
          * PacketPing time.
          * @member {number|Long} time
          * @memberof packets.PacketPing
          * @instance
          */
-		PacketPing.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        PacketPing.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-		/**
+        /**
          * Creates a new PacketPing instance using the specified properties.
          * @function create
          * @memberof packets.PacketPing
@@ -2397,11 +2430,11 @@ $root.packets = (function() {
          * @param {packets.IPacketPing=} [properties] Properties to set
          * @returns {packets.PacketPing} PacketPing instance
          */
-		PacketPing.create = function create(properties) {
-			return new PacketPing(properties);
-		};
+        PacketPing.create = function create(properties) {
+            return new PacketPing(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPing message. Does not implicitly {@link packets.PacketPing.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketPing
@@ -2410,16 +2443,16 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPing.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
-			return writer;
-		};
+        PacketPing.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPing message, length delimited. Does not implicitly {@link packets.PacketPing.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketPing
@@ -2428,11 +2461,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPing.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketPing.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketPing message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketPing
@@ -2443,37 +2476,37 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPing.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPing();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.time = reader.int64();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("time"))
-				throw $util.ProtocolError("missing required 'time'", { instance: message });
-			return message;
-		};
+        PacketPing.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPing();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.time = reader.int64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("time"))
+                throw $util.ProtocolError("missing required 'time'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketPing message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketPing
@@ -2483,13 +2516,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPing.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketPing.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketPing message.
          * @function verify
          * @memberof packets.PacketPing
@@ -2497,19 +2530,19 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketPing.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
-				return "time: integer|Long expected";
-			return null;
-		};
+        PacketPing.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
+                return "time: integer|Long expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketPing message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketPing
@@ -2517,27 +2550,27 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketPing} PacketPing
          */
-		PacketPing.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketPing)
-				return object;
-			let message = new $root.packets.PacketPing();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.time != null)
-				if ($util.Long)
-					(message.time = $util.Long.fromValue(object.time)).unsigned = false;
-				else if (typeof object.time === "string")
-					message.time = parseInt(object.time, 10);
-				else if (typeof object.time === "number")
-					message.time = object.time;
-				else if (typeof object.time === "object")
-					message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
-			return message;
-		};
+        PacketPing.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketPing)
+                return object;
+            var message = new $root.packets.PacketPing();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.time != null)
+                if ($util.Long)
+                    (message.time = $util.Long.fromValue(object.time)).unsigned = false;
+                else if (typeof object.time === "string")
+                    message.time = parseInt(object.time, 10);
+                else if (typeof object.time === "number")
+                    message.time = object.time;
+                else if (typeof object.time === "object")
+                    message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketPing message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketPing
@@ -2546,48 +2579,48 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketPing.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				if ($util.Long) {
-					let long = new $util.Long(0, 0, false);
-					object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-				} else
-					object.time = options.longs === String ? "0" : 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.time != null && message.hasOwnProperty("time"))
-				if (typeof message.time === "number")
-					object.time = options.longs === String ? String(message.time) : message.time;
-				else
-					object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
-			return object;
-		};
+        PacketPing.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.time = options.longs === String ? "0" : 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.time != null && message.hasOwnProperty("time"))
+                if (typeof message.time === "number")
+                    object.time = options.longs === String ? String(message.time) : message.time;
+                else
+                    object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketPing to JSON.
          * @function toJSON
          * @memberof packets.PacketPing
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketPing.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketPing.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketPing;
-	})();
+        return PacketPing;
+    })();
 
-	packets.PacketPong = (function() {
+    packets.PacketPong = (function() {
 
-		/**
+        /**
          * Properties of a PacketPong.
          * @memberof packets
          * @interface IPacketPong
@@ -2597,7 +2630,7 @@ $root.packets = (function() {
          * @property {number|Long} arrived PacketPong arrived
          */
 
-		/**
+        /**
          * Constructs a new PacketPong.
          * @memberof packets
          * @classdesc Represents a PacketPong.
@@ -2605,46 +2638,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketPong=} [properties] Properties to set
          */
-		function PacketPong(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketPong(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketPong ver.
          * @member {string} ver
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.ver = "";
+        PacketPong.prototype.ver = "";
 
-		/**
+        /**
          * PacketPong sender.
          * @member {string} sender
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.sender = "";
+        PacketPong.prototype.sender = "";
 
-		/**
+        /**
          * PacketPong time.
          * @member {number|Long} time
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        PacketPong.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-		/**
+        /**
          * PacketPong arrived.
          * @member {number|Long} arrived
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.arrived = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        PacketPong.prototype.arrived = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-		/**
+        /**
          * Creates a new PacketPong instance using the specified properties.
          * @function create
          * @memberof packets.PacketPong
@@ -2652,11 +2685,11 @@ $root.packets = (function() {
          * @param {packets.IPacketPong=} [properties] Properties to set
          * @returns {packets.PacketPong} PacketPong instance
          */
-		PacketPong.create = function create(properties) {
-			return new PacketPong(properties);
-		};
+        PacketPong.create = function create(properties) {
+            return new PacketPong(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPong message. Does not implicitly {@link packets.PacketPong.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketPong
@@ -2665,17 +2698,17 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPong.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
-			writer.uint32(/* id 4, wireType 0 =*/32).int64(message.arrived);
-			return writer;
-		};
+        PacketPong.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
+            writer.uint32(/* id 4, wireType 0 =*/32).int64(message.arrived);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPong message, length delimited. Does not implicitly {@link packets.PacketPong.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketPong
@@ -2684,11 +2717,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPong.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketPong.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketPong message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketPong
@@ -2699,42 +2732,42 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPong.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPong();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.time = reader.int64();
-						break;
-					case 4:
-						message.arrived = reader.int64();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("time"))
-				throw $util.ProtocolError("missing required 'time'", { instance: message });
-			if (!message.hasOwnProperty("arrived"))
-				throw $util.ProtocolError("missing required 'arrived'", { instance: message });
-			return message;
-		};
+        PacketPong.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPong();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.time = reader.int64();
+                    break;
+                case 4:
+                    message.arrived = reader.int64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("time"))
+                throw $util.ProtocolError("missing required 'time'", { instance: message });
+            if (!message.hasOwnProperty("arrived"))
+                throw $util.ProtocolError("missing required 'arrived'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketPong message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketPong
@@ -2744,13 +2777,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPong.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketPong.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketPong message.
          * @function verify
          * @memberof packets.PacketPong
@@ -2758,21 +2791,21 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketPong.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
-				return "time: integer|Long expected";
-			if (!$util.isInteger(message.arrived) && !(message.arrived && $util.isInteger(message.arrived.low) && $util.isInteger(message.arrived.high)))
-				return "arrived: integer|Long expected";
-			return null;
-		};
+        PacketPong.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
+                return "time: integer|Long expected";
+            if (!$util.isInteger(message.arrived) && !(message.arrived && $util.isInteger(message.arrived.low) && $util.isInteger(message.arrived.high)))
+                return "arrived: integer|Long expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketPong message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketPong
@@ -2780,36 +2813,36 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketPong} PacketPong
          */
-		PacketPong.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketPong)
-				return object;
-			let message = new $root.packets.PacketPong();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.time != null)
-				if ($util.Long)
-					(message.time = $util.Long.fromValue(object.time)).unsigned = false;
-				else if (typeof object.time === "string")
-					message.time = parseInt(object.time, 10);
-				else if (typeof object.time === "number")
-					message.time = object.time;
-				else if (typeof object.time === "object")
-					message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
-			if (object.arrived != null)
-				if ($util.Long)
-					(message.arrived = $util.Long.fromValue(object.arrived)).unsigned = false;
-				else if (typeof object.arrived === "string")
-					message.arrived = parseInt(object.arrived, 10);
-				else if (typeof object.arrived === "number")
-					message.arrived = object.arrived;
-				else if (typeof object.arrived === "object")
-					message.arrived = new $util.LongBits(object.arrived.low >>> 0, object.arrived.high >>> 0).toNumber();
-			return message;
-		};
+        PacketPong.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketPong)
+                return object;
+            var message = new $root.packets.PacketPong();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.time != null)
+                if ($util.Long)
+                    (message.time = $util.Long.fromValue(object.time)).unsigned = false;
+                else if (typeof object.time === "string")
+                    message.time = parseInt(object.time, 10);
+                else if (typeof object.time === "number")
+                    message.time = object.time;
+                else if (typeof object.time === "object")
+                    message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
+            if (object.arrived != null)
+                if ($util.Long)
+                    (message.arrived = $util.Long.fromValue(object.arrived)).unsigned = false;
+                else if (typeof object.arrived === "string")
+                    message.arrived = parseInt(object.arrived, 10);
+                else if (typeof object.arrived === "number")
+                    message.arrived = object.arrived;
+                else if (typeof object.arrived === "object")
+                    message.arrived = new $util.LongBits(object.arrived.low >>> 0, object.arrived.high >>> 0).toNumber();
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketPong message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketPong
@@ -2818,58 +2851,58 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketPong.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				if ($util.Long) {
-					let long = new $util.Long(0, 0, false);
-					object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-				} else
-					object.time = options.longs === String ? "0" : 0;
-				if ($util.Long) {
-					let long = new $util.Long(0, 0, false);
-					object.arrived = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-				} else
-					object.arrived = options.longs === String ? "0" : 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.time != null && message.hasOwnProperty("time"))
-				if (typeof message.time === "number")
-					object.time = options.longs === String ? String(message.time) : message.time;
-				else
-					object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
-			if (message.arrived != null && message.hasOwnProperty("arrived"))
-				if (typeof message.arrived === "number")
-					object.arrived = options.longs === String ? String(message.arrived) : message.arrived;
-				else
-					object.arrived = options.longs === String ? $util.Long.prototype.toString.call(message.arrived) : options.longs === Number ? new $util.LongBits(message.arrived.low >>> 0, message.arrived.high >>> 0).toNumber() : message.arrived;
-			return object;
-		};
+        PacketPong.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.time = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.arrived = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.arrived = options.longs === String ? "0" : 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.time != null && message.hasOwnProperty("time"))
+                if (typeof message.time === "number")
+                    object.time = options.longs === String ? String(message.time) : message.time;
+                else
+                    object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
+            if (message.arrived != null && message.hasOwnProperty("arrived"))
+                if (typeof message.arrived === "number")
+                    object.arrived = options.longs === String ? String(message.arrived) : message.arrived;
+                else
+                    object.arrived = options.longs === String ? $util.Long.prototype.toString.call(message.arrived) : options.longs === Number ? new $util.LongBits(message.arrived.low >>> 0, message.arrived.high >>> 0).toNumber() : message.arrived;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketPong to JSON.
          * @function toJSON
          * @memberof packets.PacketPong
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketPong.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketPong.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketPong;
-	})();
+        return PacketPong;
+    })();
 
-	packets.PacketGossipHello = (function() {
+    packets.PacketGossipHello = (function() {
 
-		/**
+        /**
          * Properties of a PacketGossipHello.
          * @memberof packets
          * @interface IPacketGossipHello
@@ -2879,7 +2912,7 @@ $root.packets = (function() {
          * @property {number} port PacketGossipHello port
          */
 
-		/**
+        /**
          * Constructs a new PacketGossipHello.
          * @memberof packets
          * @classdesc Represents a PacketGossipHello.
@@ -2887,46 +2920,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipHello=} [properties] Properties to set
          */
-		function PacketGossipHello(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketGossipHello(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketGossipHello ver.
          * @member {string} ver
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.ver = "";
+        PacketGossipHello.prototype.ver = "";
 
-		/**
+        /**
          * PacketGossipHello sender.
          * @member {string} sender
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.sender = "";
+        PacketGossipHello.prototype.sender = "";
 
-		/**
+        /**
          * PacketGossipHello host.
          * @member {string} host
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.host = "";
+        PacketGossipHello.prototype.host = "";
 
-		/**
+        /**
          * PacketGossipHello port.
          * @member {number} port
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.port = 0;
+        PacketGossipHello.prototype.port = 0;
 
-		/**
+        /**
          * Creates a new PacketGossipHello instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipHello
@@ -2934,11 +2967,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipHello=} [properties] Properties to set
          * @returns {packets.PacketGossipHello} PacketGossipHello instance
          */
-		PacketGossipHello.create = function create(properties) {
-			return new PacketGossipHello(properties);
-		};
+        PacketGossipHello.create = function create(properties) {
+            return new PacketGossipHello(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipHello message. Does not implicitly {@link packets.PacketGossipHello.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipHello
@@ -2947,17 +2980,17 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipHello.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.host);
-			writer.uint32(/* id 4, wireType 0 =*/32).int32(message.port);
-			return writer;
-		};
+        PacketGossipHello.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            writer.uint32(/* id 3, wireType 2 =*/26).string(message.host);
+            writer.uint32(/* id 4, wireType 0 =*/32).int32(message.port);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipHello message, length delimited. Does not implicitly {@link packets.PacketGossipHello.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipHello
@@ -2966,11 +2999,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipHello.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketGossipHello.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipHello message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipHello
@@ -2981,42 +3014,42 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipHello.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipHello();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.host = reader.string();
-						break;
-					case 4:
-						message.port = reader.int32();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("host"))
-				throw $util.ProtocolError("missing required 'host'", { instance: message });
-			if (!message.hasOwnProperty("port"))
-				throw $util.ProtocolError("missing required 'port'", { instance: message });
-			return message;
-		};
+        PacketGossipHello.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipHello();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.host = reader.string();
+                    break;
+                case 4:
+                    message.port = reader.int32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            if (!message.hasOwnProperty("host"))
+                throw $util.ProtocolError("missing required 'host'", { instance: message });
+            if (!message.hasOwnProperty("port"))
+                throw $util.ProtocolError("missing required 'port'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipHello message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipHello
@@ -3026,13 +3059,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipHello.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketGossipHello.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketGossipHello message.
          * @function verify
          * @memberof packets.PacketGossipHello
@@ -3040,21 +3073,21 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketGossipHello.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.host))
-				return "host: string expected";
-			if (!$util.isInteger(message.port))
-				return "port: integer expected";
-			return null;
-		};
+        PacketGossipHello.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (!$util.isString(message.host))
+                return "host: string expected";
+            if (!$util.isInteger(message.port))
+                return "port: integer expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketGossipHello message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipHello
@@ -3062,22 +3095,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipHello} PacketGossipHello
          */
-		PacketGossipHello.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketGossipHello)
-				return object;
-			let message = new $root.packets.PacketGossipHello();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.host != null)
-				message.host = String(object.host);
-			if (object.port != null)
-				message.port = object.port | 0;
-			return message;
-		};
+        PacketGossipHello.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketGossipHello)
+                return object;
+            var message = new $root.packets.PacketGossipHello();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.host != null)
+                message.host = String(object.host);
+            if (object.port != null)
+                message.port = object.port | 0;
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketGossipHello message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipHello
@@ -3086,44 +3119,44 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketGossipHello.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.host = "";
-				object.port = 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.host != null && message.hasOwnProperty("host"))
-				object.host = message.host;
-			if (message.port != null && message.hasOwnProperty("port"))
-				object.port = message.port;
-			return object;
-		};
+        PacketGossipHello.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.host = "";
+                object.port = 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.host != null && message.hasOwnProperty("host"))
+                object.host = message.host;
+            if (message.port != null && message.hasOwnProperty("port"))
+                object.port = message.port;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketGossipHello to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipHello
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketGossipHello.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketGossipHello.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketGossipHello;
-	})();
+        return PacketGossipHello;
+    })();
 
-	packets.PacketGossipRequest = (function() {
+    packets.PacketGossipRequest = (function() {
 
-		/**
+        /**
          * Properties of a PacketGossipRequest.
          * @memberof packets
          * @interface IPacketGossipRequest
@@ -3133,7 +3166,7 @@ $root.packets = (function() {
          * @property {string|null} [offline] PacketGossipRequest offline
          */
 
-		/**
+        /**
          * Constructs a new PacketGossipRequest.
          * @memberof packets
          * @classdesc Represents a PacketGossipRequest.
@@ -3141,46 +3174,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipRequest=} [properties] Properties to set
          */
-		function PacketGossipRequest(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketGossipRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketGossipRequest ver.
          * @member {string} ver
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.ver = "";
+        PacketGossipRequest.prototype.ver = "";
 
-		/**
+        /**
          * PacketGossipRequest sender.
          * @member {string} sender
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.sender = "";
+        PacketGossipRequest.prototype.sender = "";
 
-		/**
+        /**
          * PacketGossipRequest online.
          * @member {string} online
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.online = "";
+        PacketGossipRequest.prototype.online = "";
 
-		/**
+        /**
          * PacketGossipRequest offline.
          * @member {string} offline
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.offline = "";
+        PacketGossipRequest.prototype.offline = "";
 
-		/**
+        /**
          * Creates a new PacketGossipRequest instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipRequest
@@ -3188,11 +3221,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipRequest=} [properties] Properties to set
          * @returns {packets.PacketGossipRequest} PacketGossipRequest instance
          */
-		PacketGossipRequest.create = function create(properties) {
-			return new PacketGossipRequest(properties);
-		};
+        PacketGossipRequest.create = function create(properties) {
+            return new PacketGossipRequest(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipRequest message. Does not implicitly {@link packets.PacketGossipRequest.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipRequest
@@ -3201,19 +3234,19 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipRequest.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			if (message.online != null && message.hasOwnProperty("online"))
-				writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
-			return writer;
-		};
+        PacketGossipRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.online != null && message.hasOwnProperty("online"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipRequest message, length delimited. Does not implicitly {@link packets.PacketGossipRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipRequest
@@ -3222,11 +3255,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipRequest.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketGossipRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipRequest message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipRequest
@@ -3237,38 +3270,38 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipRequest.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipRequest();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.online = reader.string();
-						break;
-					case 4:
-						message.offline = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketGossipRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.online = reader.string();
+                    break;
+                case 4:
+                    message.offline = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipRequest
@@ -3278,13 +3311,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipRequest.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketGossipRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketGossipRequest message.
          * @function verify
          * @memberof packets.PacketGossipRequest
@@ -3292,23 +3325,23 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketGossipRequest.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (message.online != null && message.hasOwnProperty("online"))
-				if (!$util.isString(message.online))
-					return "online: string expected";
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				if (!$util.isString(message.offline))
-					return "offline: string expected";
-			return null;
-		};
+        PacketGossipRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (message.online != null && message.hasOwnProperty("online"))
+                if (!$util.isString(message.online))
+                    return "online: string expected";
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                if (!$util.isString(message.offline))
+                    return "offline: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketGossipRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipRequest
@@ -3316,22 +3349,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipRequest} PacketGossipRequest
          */
-		PacketGossipRequest.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketGossipRequest)
-				return object;
-			let message = new $root.packets.PacketGossipRequest();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.online != null)
-				message.online = String(object.online);
-			if (object.offline != null)
-				message.offline = String(object.offline);
-			return message;
-		};
+        PacketGossipRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketGossipRequest)
+                return object;
+            var message = new $root.packets.PacketGossipRequest();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.online != null)
+                message.online = String(object.online);
+            if (object.offline != null)
+                message.offline = String(object.offline);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketGossipRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipRequest
@@ -3340,44 +3373,44 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketGossipRequest.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.online = "";
-				object.offline = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.online != null && message.hasOwnProperty("online"))
-				object.online = message.online;
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				object.offline = message.offline;
-			return object;
-		};
+        PacketGossipRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.online = "";
+                object.offline = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.online != null && message.hasOwnProperty("online"))
+                object.online = message.online;
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                object.offline = message.offline;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketGossipRequest to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketGossipRequest.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketGossipRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketGossipRequest;
-	})();
+        return PacketGossipRequest;
+    })();
 
-	packets.PacketGossipResponse = (function() {
+    packets.PacketGossipResponse = (function() {
 
-		/**
+        /**
          * Properties of a PacketGossipResponse.
          * @memberof packets
          * @interface IPacketGossipResponse
@@ -3387,7 +3420,7 @@ $root.packets = (function() {
          * @property {string|null} [offline] PacketGossipResponse offline
          */
 
-		/**
+        /**
          * Constructs a new PacketGossipResponse.
          * @memberof packets
          * @classdesc Represents a PacketGossipResponse.
@@ -3395,46 +3428,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipResponse=} [properties] Properties to set
          */
-		function PacketGossipResponse(properties) {
-			if (properties)
-				for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketGossipResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketGossipResponse ver.
          * @member {string} ver
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.ver = "";
+        PacketGossipResponse.prototype.ver = "";
 
-		/**
+        /**
          * PacketGossipResponse sender.
          * @member {string} sender
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.sender = "";
+        PacketGossipResponse.prototype.sender = "";
 
-		/**
+        /**
          * PacketGossipResponse online.
          * @member {string} online
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.online = "";
+        PacketGossipResponse.prototype.online = "";
 
-		/**
+        /**
          * PacketGossipResponse offline.
          * @member {string} offline
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.offline = "";
+        PacketGossipResponse.prototype.offline = "";
 
-		/**
+        /**
          * Creates a new PacketGossipResponse instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipResponse
@@ -3442,11 +3475,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipResponse=} [properties] Properties to set
          * @returns {packets.PacketGossipResponse} PacketGossipResponse instance
          */
-		PacketGossipResponse.create = function create(properties) {
-			return new PacketGossipResponse(properties);
-		};
+        PacketGossipResponse.create = function create(properties) {
+            return new PacketGossipResponse(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipResponse message. Does not implicitly {@link packets.PacketGossipResponse.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipResponse
@@ -3455,19 +3488,19 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipResponse.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			if (message.online != null && message.hasOwnProperty("online"))
-				writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
-			return writer;
-		};
+        PacketGossipResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.online != null && message.hasOwnProperty("online"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipResponse message, length delimited. Does not implicitly {@link packets.PacketGossipResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipResponse
@@ -3476,11 +3509,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipResponse.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketGossipResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipResponse message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipResponse
@@ -3491,38 +3524,38 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipResponse.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			let end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipResponse();
-			while (reader.pos < end) {
-				let tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.online = reader.string();
-						break;
-					case 4:
-						message.offline = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketGossipResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.online = reader.string();
+                    break;
+                case 4:
+                    message.offline = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("ver"))
+                throw $util.ProtocolError("missing required 'ver'", { instance: message });
+            if (!message.hasOwnProperty("sender"))
+                throw $util.ProtocolError("missing required 'sender'", { instance: message });
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipResponse
@@ -3532,13 +3565,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipResponse.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketGossipResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketGossipResponse message.
          * @function verify
          * @memberof packets.PacketGossipResponse
@@ -3546,23 +3579,23 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketGossipResponse.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (message.online != null && message.hasOwnProperty("online"))
-				if (!$util.isString(message.online))
-					return "online: string expected";
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				if (!$util.isString(message.offline))
-					return "offline: string expected";
-			return null;
-		};
+        PacketGossipResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.ver))
+                return "ver: string expected";
+            if (!$util.isString(message.sender))
+                return "sender: string expected";
+            if (message.online != null && message.hasOwnProperty("online"))
+                if (!$util.isString(message.online))
+                    return "online: string expected";
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                if (!$util.isString(message.offline))
+                    return "offline: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketGossipResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipResponse
@@ -3570,22 +3603,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipResponse} PacketGossipResponse
          */
-		PacketGossipResponse.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketGossipResponse)
-				return object;
-			let message = new $root.packets.PacketGossipResponse();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.online != null)
-				message.online = String(object.online);
-			if (object.offline != null)
-				message.offline = String(object.offline);
-			return message;
-		};
+        PacketGossipResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketGossipResponse)
+                return object;
+            var message = new $root.packets.PacketGossipResponse();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.online != null)
+                message.online = String(object.online);
+            if (object.offline != null)
+                message.offline = String(object.offline);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketGossipResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipResponse
@@ -3594,42 +3627,42 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketGossipResponse.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			let object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.online = "";
-				object.offline = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.online != null && message.hasOwnProperty("online"))
-				object.online = message.online;
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				object.offline = message.offline;
-			return object;
-		};
+        PacketGossipResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.online = "";
+                object.offline = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.online != null && message.hasOwnProperty("online"))
+                object.online = message.online;
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                object.offline = message.offline;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketGossipResponse to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketGossipResponse.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketGossipResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketGossipResponse;
-	})();
+        return PacketGossipResponse;
+    })();
 
-	return packets;
+    return packets;
 })();
 
 module.exports = $root;

--- a/src/serializers/thrift/gen-nodejs/packets_types.js
+++ b/src/serializers/thrift/gen-nodejs/packets_types.js
@@ -7,9 +7,11 @@
 
 let thrift = require("thrift");
 let Thrift = thrift.Thrift;
+let Q = thrift.Q;
 
 
 let ttypes = module.exports = {};
+/* istanbul ignore next */
 let PacketEvent = module.exports.PacketEvent = function(args) {
 	this.ver = null;
 	this.sender = null;
@@ -41,51 +43,53 @@ let PacketEvent = module.exports.PacketEvent = function(args) {
 PacketEvent.prototype = {};
 PacketEvent.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.event = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.data = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 5:
-				if (ftype === Thrift.Type.LIST) {
+				if (ftype == Thrift.Type.LIST) {
 					let _size0 = 0;
-					let _rtmp34;
+					var _rtmp34;
 					this.groups = [];
+					let _etype3 = 0;
 					_rtmp34 = input.readListBegin();
+					_etype3 = _rtmp34.etype;
 					_size0 = _rtmp34.size;
 					for (let _i5 = 0; _i5 < _size0; ++_i5)
 					{
@@ -99,7 +103,7 @@ PacketEvent.prototype.read = function(input) {
 				}
 				break;
 			case 6:
-				if (ftype === Thrift.Type.BOOL) {
+				if (ftype == Thrift.Type.BOOL) {
 					this.broadcast = input.readBool();
 				} else {
 					input.skip(ftype);
@@ -111,6 +115,7 @@ PacketEvent.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketEvent.prototype.write = function(output) {
@@ -156,6 +161,7 @@ PacketEvent.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketRequest = module.exports.PacketRequest = function(args) {
@@ -213,96 +219,96 @@ let PacketRequest = module.exports.PacketRequest = function(args) {
 PacketRequest.prototype = {};
 PacketRequest.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.id = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.action = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 5:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.params = input.readBinary();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 6:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.meta = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 7:
-				if (ftype === Thrift.Type.DOUBLE) {
+				if (ftype == Thrift.Type.DOUBLE) {
 					this.timeout = input.readDouble();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 8:
-				if (ftype === Thrift.Type.I32) {
+				if (ftype == Thrift.Type.I32) {
 					this.level = input.readI32();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 9:
-				if (ftype === Thrift.Type.BOOL) {
+				if (ftype == Thrift.Type.BOOL) {
 					this.metrics = input.readBool();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 10:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.parentID = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 11:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.requestID = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 12:
-				if (ftype === Thrift.Type.BOOL) {
+				if (ftype == Thrift.Type.BOOL) {
 					this.stream = input.readBool();
 				} else {
 					input.skip(ftype);
@@ -314,6 +320,7 @@ PacketRequest.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketRequest.prototype.write = function(output) {
@@ -380,6 +387,7 @@ PacketRequest.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketResponse = module.exports.PacketResponse = function(args) {
@@ -421,68 +429,68 @@ let PacketResponse = module.exports.PacketResponse = function(args) {
 PacketResponse.prototype = {};
 PacketResponse.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.id = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.BOOL) {
+				if (ftype == Thrift.Type.BOOL) {
 					this.success = input.readBool();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 5:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.data = input.readBinary();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 6:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.error = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 7:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.meta = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 8:
-				if (ftype === Thrift.Type.BOOL) {
+				if (ftype == Thrift.Type.BOOL) {
 					this.stream = input.readBool();
 				} else {
 					input.skip(ftype);
@@ -494,6 +502,7 @@ PacketResponse.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketResponse.prototype.write = function(output) {
@@ -540,6 +549,7 @@ PacketResponse.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketDiscover = module.exports.PacketDiscover = function(args) {
@@ -557,26 +567,26 @@ let PacketDiscover = module.exports.PacketDiscover = function(args) {
 PacketDiscover.prototype = {};
 PacketDiscover.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
@@ -588,6 +598,7 @@ PacketDiscover.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketDiscover.prototype.write = function(output) {
@@ -604,6 +615,7 @@ PacketDiscover.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let Client = module.exports.Client = function(args) {
@@ -625,33 +637,33 @@ let Client = module.exports.Client = function(args) {
 Client.prototype = {};
 Client.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.type = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.version = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.langVersion = input.readString();
 				} else {
 					input.skip(ftype);
@@ -663,6 +675,7 @@ Client.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 Client.prototype.write = function(output) {
@@ -684,6 +697,7 @@ Client.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketInfo = module.exports.PacketInfo = function(args) {
@@ -694,6 +708,7 @@ let PacketInfo = module.exports.PacketInfo = function(args) {
 	this.ipList = null;
 	this.hostname = null;
 	this.client = null;
+	this.seq = null;
 	if (args) {
 		if (args.ver !== undefined && args.ver !== null) {
 			this.ver = args.ver;
@@ -716,56 +731,61 @@ let PacketInfo = module.exports.PacketInfo = function(args) {
 		if (args.client !== undefined && args.client !== null) {
 			this.client = new ttypes.Client(args.client);
 		}
+		if (args.seq !== undefined && args.seq !== null) {
+			this.seq = args.seq;
+		}
 	}
 };
 PacketInfo.prototype = {};
 PacketInfo.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.services = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.config = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 5:
-				if (ftype === Thrift.Type.LIST) {
+				if (ftype == Thrift.Type.LIST) {
 					let _size8 = 0;
-					let _rtmp312;
+					var _rtmp312;
 					this.ipList = [];
+					let _etype11 = 0;
 					_rtmp312 = input.readListBegin();
+					_etype11 = _rtmp312.etype;
 					_size8 = _rtmp312.size;
 					for (let _i13 = 0; _i13 < _size8; ++_i13)
 					{
@@ -779,16 +799,23 @@ PacketInfo.prototype.read = function(input) {
 				}
 				break;
 			case 6:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.hostname = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 7:
-				if (ftype === Thrift.Type.STRUCT) {
+				if (ftype == Thrift.Type.STRUCT) {
 					this.client = new ttypes.Client();
 					this.client.read(input);
+				} else {
+					input.skip(ftype);
+				}
+				break;
+			case 8:
+				if (ftype == Thrift.Type.I32) {
+					this.seq = input.readI32();
 				} else {
 					input.skip(ftype);
 				}
@@ -799,6 +826,7 @@ PacketInfo.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketInfo.prototype.write = function(output) {
@@ -847,8 +875,14 @@ PacketInfo.prototype.write = function(output) {
 		this.client.write(output);
 		output.writeFieldEnd();
 	}
+	if (this.seq !== null && this.seq !== undefined) {
+		output.writeFieldBegin("seq", Thrift.Type.I32, 8);
+		output.writeI32(this.seq);
+		output.writeFieldEnd();
+	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketDisconnect = module.exports.PacketDisconnect = function(args) {
@@ -866,26 +900,26 @@ let PacketDisconnect = module.exports.PacketDisconnect = function(args) {
 PacketDisconnect.prototype = {};
 PacketDisconnect.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
@@ -897,6 +931,7 @@ PacketDisconnect.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketDisconnect.prototype.write = function(output) {
@@ -913,6 +948,7 @@ PacketDisconnect.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketHeartbeat = module.exports.PacketHeartbeat = function(args) {
@@ -934,33 +970,33 @@ let PacketHeartbeat = module.exports.PacketHeartbeat = function(args) {
 PacketHeartbeat.prototype = {};
 PacketHeartbeat.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.DOUBLE) {
+				if (ftype == Thrift.Type.DOUBLE) {
 					this.cpu = input.readDouble();
 				} else {
 					input.skip(ftype);
@@ -972,6 +1008,7 @@ PacketHeartbeat.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketHeartbeat.prototype.write = function(output) {
@@ -993,6 +1030,7 @@ PacketHeartbeat.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketPing = module.exports.PacketPing = function(args) {
@@ -1014,33 +1052,33 @@ let PacketPing = module.exports.PacketPing = function(args) {
 PacketPing.prototype = {};
 PacketPing.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.I64) {
+				if (ftype == Thrift.Type.I64) {
 					this.time = input.readI64();
 				} else {
 					input.skip(ftype);
@@ -1052,6 +1090,7 @@ PacketPing.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketPing.prototype.write = function(output) {
@@ -1073,6 +1112,7 @@ PacketPing.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketPong = module.exports.PacketPong = function(args) {
@@ -1098,40 +1138,40 @@ let PacketPong = module.exports.PacketPong = function(args) {
 PacketPong.prototype = {};
 PacketPong.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.I64) {
+				if (ftype == Thrift.Type.I64) {
 					this.time = input.readI64();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.I64) {
+				if (ftype == Thrift.Type.I64) {
 					this.arrived = input.readI64();
 				} else {
 					input.skip(ftype);
@@ -1143,6 +1183,7 @@ PacketPong.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketPong.prototype.write = function(output) {
@@ -1169,6 +1210,7 @@ PacketPong.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketGossipHello = module.exports.PacketGossipHello = function(args) {
@@ -1194,40 +1236,40 @@ let PacketGossipHello = module.exports.PacketGossipHello = function(args) {
 PacketGossipHello.prototype = {};
 PacketGossipHello.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.host = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.I32) {
+				if (ftype == Thrift.Type.I32) {
 					this.port = input.readI32();
 				} else {
 					input.skip(ftype);
@@ -1239,6 +1281,7 @@ PacketGossipHello.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketGossipHello.prototype.write = function(output) {
@@ -1265,6 +1308,7 @@ PacketGossipHello.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketGossipRequest = module.exports.PacketGossipRequest = function(args) {
@@ -1290,40 +1334,40 @@ let PacketGossipRequest = module.exports.PacketGossipRequest = function(args) {
 PacketGossipRequest.prototype = {};
 PacketGossipRequest.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.online = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.offline = input.readString();
 				} else {
 					input.skip(ftype);
@@ -1335,6 +1379,7 @@ PacketGossipRequest.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketGossipRequest.prototype.write = function(output) {
@@ -1361,6 +1406,7 @@ PacketGossipRequest.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 
 let PacketGossipResponse = module.exports.PacketGossipResponse = function(args) {
@@ -1386,40 +1432,40 @@ let PacketGossipResponse = module.exports.PacketGossipResponse = function(args) 
 PacketGossipResponse.prototype = {};
 PacketGossipResponse.prototype.read = function(input) {
 	input.readStructBegin();
-	let continueLoop = true;
-	while (continueLoop)
+	while (true)
 	{
 		let ret = input.readFieldBegin();
+		let fname = ret.fname;
 		let ftype = ret.ftype;
 		let fid = ret.fid;
-		if (ftype === Thrift.Type.STOP) {
-			continueLoop = false;
+		if (ftype == Thrift.Type.STOP) {
+			break;
 		}
 		switch (fid)
 		{
 			case 1:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.ver = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 2:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.sender = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 3:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.online = input.readString();
 				} else {
 					input.skip(ftype);
 				}
 				break;
 			case 4:
-				if (ftype === Thrift.Type.STRING) {
+				if (ftype == Thrift.Type.STRING) {
 					this.offline = input.readString();
 				} else {
 					input.skip(ftype);
@@ -1431,6 +1477,7 @@ PacketGossipResponse.prototype.read = function(input) {
 		input.readFieldEnd();
 	}
 	input.readStructEnd();
+	return;
 };
 
 PacketGossipResponse.prototype.write = function(output) {
@@ -1457,5 +1504,6 @@ PacketGossipResponse.prototype.write = function(output) {
 	}
 	output.writeFieldStop();
 	output.writeStructEnd();
+	return;
 };
 

--- a/src/serializers/thrift/packets.thrift
+++ b/src/serializers/thrift/packets.thrift
@@ -56,6 +56,7 @@ struct PacketInfo {
 	5: list<string> ipList,
 	6: string hostname,
 	7: Client client,
+	8: i32 seq,
 }
 
 struct PacketDisconnect {

--- a/test/unit/serializers/protobuf.spec.js
+++ b/test/unit/serializers/protobuf.spec.js
@@ -62,15 +62,18 @@ describe("Test ProtoBuf serializer", () => {
 		const obj = {
 			ver: "3",
 			sender: "test-1",
+			seq: 1,
 			services: [
-				{ name: "users", version: "2", settings: {}, metadata: {}, actions: {
-					"users.create": {}
-				}, events: {
-					"user.created": {}
-				} }
+				{
+					name: "users", version: "2", settings: {}, metadata: {}, actions: {
+						"users.create": {}
+					}, events: {
+						"user.created": {}
+					}
+				}
 			],
 			config: {},
-			ipList: [ "127.0.0.1" ],
+			ipList: ["127.0.0.1"],
 			hostname: "test-server",
 			client: {
 				type: "nodejs",
@@ -79,7 +82,7 @@ describe("Test ProtoBuf serializer", () => {
 			},
 		};
 		const s = serializer.serialize(cloneDeep(obj), P.PACKET_INFO);
-		expect(s.length).toBe(185);
+		expect(s.length).toBe(187);
 
 		const res = serializer.deserialize(s, P.PACKET_INFO);
 		expect(res).not.toBe(obj);
@@ -151,7 +154,7 @@ describe("Test ProtoBuf serializer", () => {
 			meta: {
 				user: {
 					id: 1,
-					roles: [ "admin" ]
+					roles: ["admin"]
 				}
 			},
 			timeout: 1500,
@@ -179,7 +182,7 @@ describe("Test ProtoBuf serializer", () => {
 			meta: {
 				user: {
 					id: 1,
-					roles: [ "admin" ]
+					roles: ["admin"]
 				}
 			},
 			timeout: 1500,
@@ -211,7 +214,7 @@ describe("Test ProtoBuf serializer", () => {
 			meta: {
 				user: {
 					id: 1,
-					roles: [ "admin" ]
+					roles: ["admin"]
 				}
 			},
 			stream: false
@@ -234,7 +237,7 @@ describe("Test ProtoBuf serializer", () => {
 			meta: {
 				user: {
 					id: 1,
-					roles: [ "admin" ]
+					roles: ["admin"]
 				}
 			},
 			stream: true
@@ -268,7 +271,7 @@ describe("Test ProtoBuf serializer", () => {
 			meta: {
 				user: {
 					id: 1,
-					roles: [ "admin" ]
+					roles: ["admin"]
 				}
 			},
 			stream: false

--- a/test/unit/serializers/thrift.spec.js
+++ b/test/unit/serializers/thrift.spec.js
@@ -77,9 +77,10 @@ describe("Test ProtoBuf serializer", () => {
 				version: "1.2.3",
 				langVersion: "6.10.2",
 			},
+			seq: 3
 		};
 		const s = serializer.serialize(cloneDeep(obj), P.PACKET_INFO);
-		expect(s.length).toBe(238);
+		expect(s.length).toBe(245);
 
 		const res = serializer.deserialize(s, P.PACKET_INFO);
 		expect(res).not.toBe(obj);


### PR DESCRIPTION
## :memo: Description

I was trying to add new services dynamically after the broker has been started with `broker.createService` and the other nodes connected in the same transporter (NATS) doesn't update the services list. This bug happens only with the ProtoBuf serializer.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

Just added the `seq` property to PacketInfo message, in order to turn possible the nodes updates their registered services.

This bug occurs since the gossip was updated from when to seq: https://github.com/moleculerjs/moleculer/commit/fbb99106150d4b41798b6d9550c547f83e9f2aa6

This is not a breaking change.

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
