### PR TITLE
Fix a bug of redis cache lock

### DIFF
--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -60,14 +60,13 @@ class RedisCacher extends BaseCacher {
 			/* istanbul ignore next */
 			this.logger.error(err);
 		});
-		if (this.opts.lock && this.opts.lock.enabled !== false) {
-			try {
-				Redlock = require('redlock');
-			} catch (err) {
-				/* istanbul ignore next */
-				this.broker.fatal("The 'redlock' package is missing. Please install it with 'npm install redlock --save' command.", err, true);
-			}
-
+		try {
+			Redlock = require('redlock');
+		} catch (err) {
+			/* istanbul ignore next */
+			this.logger.warn("The 'redlock' package is missing. If you want to enable cache lock, please install it with 'npm install redlock --save' command.");
+		}
+		if (Redlock) {
 			let redlockClients = (this.opts.redlock ? this.opts.redlock.clients : null) || [this.client]
 			/**
 			 * redlock client instance

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -446,37 +446,14 @@ describe("Test RedisCacher lock method", () => {
 
 describe("Test RedisCacher with opts.lock", () => {
 
-	it("should create redlock clients when opts.lock==true", () => {
+	it("should create redlock clients", () => {
 		let broker = new ServiceBroker({ logger: false });
 		let cacher = new RedisCacher({
-			ttl: 30,
-			lock: true
+			ttl: 30
 		});
 		cacher.init(broker);
 		expect(cacher.redlock).toBeDefined();
 		expect(cacher.redlockNonBlocking).toBeDefined();
-	});
-
-	it("should not create redlock clients when opts.lock==false", () => {
-		let broker = new ServiceBroker({ logger: false });
-		let cacher = new RedisCacher({
-			ttl: 30,
-			lock: false
-		});
-		cacher.init(broker);
-		expect(cacher.redlock).toBeUndefined();
-		expect(cacher.redlockNonBlocking).toBeUndefined();
-	});
-
-	it("should not create redlock clients when opts.lock.enabled==false", () => {
-		let broker = new ServiceBroker({logger: false});
-		let cacher = new RedisCacher({
-			ttl: 30,
-			lock: { enabled: false }
-		});
-		cacher.init(broker);
-		expect(cacher.redlock).toBeUndefined();
-		expect(cacher.redlockNonBlocking).toBeUndefined();
 	});
 
 });


### PR DESCRIPTION

## :memo: Description
🐛 This is a bug from `RedisCacher`, I had forgot that cache lock could be enabled locally. 😅 So it should always create the `redlock` clients.


### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
