### PR TITLE
Service modifications support for ES6 classes

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -627,7 +627,7 @@ class ServiceBroker {
 
 		schema = this.normalizeSchemaConstructor(schema);
 		if (this.ServiceFactory.isPrototypeOf(schema)) {
-			service = new schema(this);
+			service = new schema(this, schemaMods);
 		} else {
 			let s = schema;
 			if (schemaMods)

--- a/src/service.js
+++ b/src/service.js
@@ -39,11 +39,11 @@ class Service {
 	 * Creates an instance of Service by schema.
 	 *
 	 * @param {ServiceBroker} 	broker	broker of service
-	 * @param {Object=} 		schema	schema of service
+	 * @param {Object} 			schema	schema of service
 	 *
 	 * @memberof Service
 	 */
-	constructor(broker, schema = undefined) {
+	constructor(broker, schema) {
 		if (!_.isObject(broker))
 			throw new ServiceSchemaError("Must set a ServiceBroker instance!");
 

--- a/src/service.js
+++ b/src/service.js
@@ -39,11 +39,11 @@ class Service {
 	 * Creates an instance of Service by schema.
 	 *
 	 * @param {ServiceBroker} 	broker	broker of service
-	 * @param {Object} 			schema	schema of service
+	 * @param {Object=} 		schema	schema of service
 	 *
 	 * @memberof Service
 	 */
-	constructor(broker, schema) {
+	constructor(broker, schema = undefined) {
 		if (!_.isObject(broker))
 			throw new ServiceSchemaError("Must set a ServiceBroker instance!");
 


### PR DESCRIPTION
## :memo: Description

In some cases architectual solutions can split service and service runner logic. In that case, if you need provide to service some settings or update schema parameters, you can use `schemaMods`. 

It working for GenericObject definition, but not working for ES6 classes. I added providing `schemaMods` parameters to ES6 classes.

### :dart: Relevant issues
#483 Service modifications support for ES6 classes

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
class ES6Service extends Service {
	constructor(broker, schemaMods) {
		super(broker);

		this.name = "es6-with-schema-mods";
		this.version = 2;
		this.settings = {};
		this.actions = {
			send: () => Prmise.resolve()
		};

		if (schemaMods && schemaMods.settings && schemaMods.settings.connectionString) {
			this.settings.connectionString = schemaMods.settings.connectionString;
		}

		// this should prevent override this.actions in parseServiceSchema method
		this.parseServiceSchema(Object.assign({}, this));
	}
}

let broker = new ServiceBroker({ logger: false });
broker.createService(ES6Service, { settings: { connectionString: "mongodb://localhost:27017/test" } });
``` 

## :vertical_traffic_light: How Has This Been Tested?

I've added 2 additional unit tests to check schema creating proccess for ES6 classes

- [x] should create service from ES6 instance without schema mods
- [x] should create service from ES6 instance with schema mods

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
