### PR TITLE
TS: service lifecycles can be arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -181,9 +181,9 @@ declare namespace Moleculer {
 		methods?: ServiceMethods;
 
 		events?: ServiceEvents;
-		created?: () => void;
-		started?: () => PromiseLike<void>;
-		stopped?: () => PromiseLike<void>;
+		created?: (() => void) | Array<() => void>;
+		started?: (() => PromiseLike<void>) | Array<() => PromiseLike<void>>;
+		stopped?: (() => PromiseLike<void>) | Array<() => PromiseLike<void>>;
 		[name: string]: any;
 	}
 
@@ -728,7 +728,7 @@ declare namespace Moleculer {
 		Redis: Cacher
 	};
 	const Serializers: {
-		Base: Serializer,		   
+		Base: Serializer,
 		JSON: Serializer,
 		Avro: Serializer,
 		MsgPack: Serializer,

--- a/test/typescript/tsd/ServiceSchema_lifecycles.test-d.ts
+++ b/test/typescript/tsd/ServiceSchema_lifecycles.test-d.ts
@@ -1,0 +1,37 @@
+import { expectType } from "tsd";
+import { Service, ServiceBroker, ServiceSchema } from "../../../index";
+
+const broker = new ServiceBroker({ logger: false, transporter: "fake" });
+
+class TestService1 extends Service {
+	constructor(broker: ServiceBroker) {
+		super(broker);
+
+		this.parseServiceSchema({
+			name: "test1",
+			created() {},
+			async started() {},
+			async stopped() {}
+		});
+	}
+}
+
+class TestService2 extends Service {
+	constructor(broker: ServiceBroker) {
+		super(broker);
+
+		this.parseServiceSchema({
+			name: "test2",
+			created: [() => {}, () => {}],
+			started: [async () => {}, async () => {}],
+			stopped: [async () => {}, async () => {}]
+		});
+	}
+}
+
+const testService1 = new TestService1(broker);
+expectType<ServiceSchema>(testService1.schema);
+
+const testService2 = new TestService2(broker);
+expectType<ServiceSchema>(testService2.schema);
+


### PR DESCRIPTION
## :memo: Description

This PR adjusts the typescript definitions for ServiceSchema to allow the lifecycle events to be typed as arrays.

Note: As there are very few tsd tests in the repo, I am unsure what the expectations are for those types of tests.   I did my best to try to create what made sense to me as a test of this change, but will adjust if necessary.

### :dart: Relevant issues
Resolves #520 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Typescript unit tests created to test both single and array specifications.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
