### PR TITLE
Fix Cachers TS definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -626,16 +626,24 @@ declare namespace Moleculer {
 		deserialize(type: string, data: Buffer): Packet;
 	}
 
-	class Cacher {
-		constructor(opts?: GenericObject);
-		init(broker: ServiceBroker): void;
-		close(): PromiseLike<any>;
-		get(key: string): PromiseLike<null | GenericObject>;
-		set(key: string, data: any, ttl?: number): PromiseLike<any>;
-		del(key: string|Array<string>): PromiseLike<any>;
-		clean(match?: string|Array<string>): PromiseLike<any>;
-		client?: any;
+	namespace Cachers {
+		class Base {
+			constructor(opts?: GenericObject);
+			init(broker: ServiceBroker): void;
+			close(): PromiseLike<any>;
+			get(key: string): PromiseLike<null | GenericObject>;
+			set(key: string, data: any, ttl?: number): PromiseLike<any>;
+			del(key: string|Array<string>): PromiseLike<any>;
+			clean(match?: string|Array<string>): PromiseLike<any>;
+		}
+
+		class Memory extends Base {}
+		class Redis extends Base {
+			client: any;
+		}
 	}
+
+	type Cacher<T extends Cachers.Base = Cachers.Base> = T;
 
 	class Serializer {
 		constructor();
@@ -722,12 +730,6 @@ declare namespace Moleculer {
 		class TCP extends Base { }
 	}
 
-	const Cachers: {
-		Base: Cacher,
-		Memory: Cacher,
-		MemoryLRU: Cacher,
-		Redis: Cacher
-	};
 	const Serializers: {
 		Base: Serializer,
 		JSON: Serializer,

--- a/test/typescript/tsd/Caches.test-d.ts
+++ b/test/typescript/tsd/Caches.test-d.ts
@@ -1,0 +1,32 @@
+import { expectType } from "tsd";
+import { Cachers, Cacher, ServiceBroker } from "../../../index";
+
+// base cacher tests
+expectType<Cacher>(new Cachers.Base());
+expectType<Cachers.Base>(new Cachers.Base());
+
+// memory cacher tests
+expectType<Cacher>(new Cachers.Memory());
+expectType<Cacher<Cachers.Memory>>(new Cachers.Memory());
+expectType<Cachers.Memory>(new Cachers.Memory());
+expectType<Cachers.Base>(new Cachers.Memory());
+const memoryBroker = new ServiceBroker({ cacher: new Cachers.Memory() });
+expectType<Cachers.Memory>(memoryBroker.cacher as Cachers.Memory);
+
+// redis cacher tests
+expectType<Cacher>(new Cachers.Redis());
+expectType<Cacher<Cachers.Redis>>(new Cachers.Redis());
+expectType<Cachers.Redis>(new Cachers.Redis());
+expectType<Cachers.Base>(new Cachers.Redis());
+const redisBroker = new ServiceBroker({ cacher: new Cachers.Redis() });
+expectType<Cachers.Redis>(redisBroker.cacher as Cachers.Redis);
+
+// custom cacher tests
+class CustomCacher extends Cachers.Base {
+	private foo = 'bar';
+}
+expectType<Cacher>(new CustomCacher());
+expectType<Cacher<CustomCacher>>(new CustomCacher());
+expectType<Cachers.Base>(new CustomCacher());
+const customCacherBroker = new ServiceBroker({ cacher: new CustomCacher() });
+expectType<CustomCacher>(customCacherBroker.cacher as CustomCacher);


### PR DESCRIPTION
## :memo: Description

The typescript definitions for `Cachers` is incorrect.  It has no reference for the `Base` cacher and the references for the `Memory` and `Redis` cachers are indicated as instances of `Cacher` rather than a class constructor.  This prevents creating a custom cacher in TypeScript since you cannot extend what isn't there.

This PR updates the definitions so that `Base`, `Memory`, and `Redis` are all class constructors rather than instances.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## :vertical_traffic_light: How Has This Been Tested?

Typescript tests included in PR.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
