### PR TITLE
Update to support proper type of service instance actions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace Moleculer {
 
 	type ActionVisibility = "published" | "public" | "protected" | "private"
 
-	interface Action {
+	interface ActionSchema {
 		name?: string;
 		visibility?: ActionVisibility;
 		params?: ActionParams;
@@ -81,6 +81,8 @@ declare namespace Moleculer {
 		[key: string]: any;
 	}
 
+	type ServiceActionsSchema = { [key: string]: ActionSchema | ActionHandler; };
+
 	interface BrokerNode {
 		id: string;
 		available: boolean;
@@ -88,16 +90,12 @@ declare namespace Moleculer {
 		hostname: boolean;
 	}
 
-	type ServiceActions = { [key: string]: Action | ActionHandler; };
-	type Actions = ServiceActions;
-
-
 	class Context<P = GenericObject, M = GenericObject> {
 		constructor(broker: ServiceBroker, endpoint: Endpoint);
 		id: string;
 		broker: ServiceBroker;
 		endpoint: Endpoint;
-		action: Action;
+		action: ActionSchema;
 		service?: Service;
 		nodeID?: string;
 
@@ -151,7 +149,7 @@ declare namespace Moleculer {
 
 	type Middleware = {
 		[name: string]:
-			| ((handler: ActionHandler, action: Action) => any)
+			| ((handler: ActionHandler, action: ActionSchema) => any)
 			| ((handler: ActionHandler, event: ServiceEvent) => any)
 			| ((handler: ActionHandler) => any)
 			| ((service: Service) => any)
@@ -176,7 +174,7 @@ declare namespace Moleculer {
 		settings?: ServiceSettingSchema;
 		dependencies?: string | GenericObject | Array<string> | Array<GenericObject>;
 		metadata?: GenericObject;
-		actions?: ServiceActions;
+		actions?: ServiceActionsSchema;
 		mixins?: Array<ServiceSchema>;
 		methods?: ServiceMethods;
 
@@ -185,6 +183,12 @@ declare namespace Moleculer {
 		started?: (() => PromiseLike<void>) | Array<() => PromiseLike<void>>;
 		stopped?: (() => PromiseLike<void>) | Array<() => PromiseLike<void>>;
 		[name: string]: any;
+	}
+
+	type ServiceAction<T = PromiseLike<any>, P extends GenericObject = GenericObject> = ((params?: P, opts?: CallingOptions) => T) & ThisType<Service>;
+
+	interface ServiceActions {
+		[name: string]: ServiceAction;
 	}
 
 	class Service implements ServiceSchema {
@@ -391,7 +395,7 @@ declare namespace Moleculer {
 
 	interface ActionEndpoint extends Endpoint {
 		service: Service;
-		action: Action;
+		action: ActionSchema;
 	}
 
 	interface PongResponse {

--- a/test/typescript/tsd/ServiceActions.test-d.ts
+++ b/test/typescript/tsd/ServiceActions.test-d.ts
@@ -1,0 +1,27 @@
+import { expectType } from "tsd";
+import { Service, ServiceBroker, ServiceAction, ServiceActions } from "../../../index";
+
+const broker = new ServiceBroker({ logger: false, transporter: "fake" });
+
+class TestService extends Service {
+	constructor(broker: ServiceBroker) {
+		super(broker);
+
+		this.parseServiceSchema({
+			name: "test1",
+			actions: {
+				foo: {
+					async handler() { }
+				},
+				bar() { }
+			}
+		});
+	}
+}
+
+const testService = new TestService(broker);
+if (testService.actions) {
+	expectType<ServiceActions>(testService.actions);
+	expectType<ServiceAction>(testService.actions.foo);
+	expectType<ServiceAction>(testService.actions.bar);
+}


### PR DESCRIPTION
## :memo: Description

Service instances contain an `actions` property which contains key/value pairs of action names and functions.  This comes from `service.js` as:

```js
// Expose to be callable as `this.actions.find({ ...params })`
const ep = this.broker.registry.createPrivateActionEndpoint(innerAction);
this.actions[name] = (params, opts) => {
  return wrappedHandler(this.broker.ContextFactory.create(this.broker, ep, params, opts || {}));
};
```

Currently, the `Service` class in `index.d.ts` is mistyped as `actions` being a type of `ServiceActions` which is not the type of the instance, but rather the type of what gets provided in a service's schema.

This PR updates the type of `ServiceActions` to match the signature of the service instance property and modifies all existing types that are related to the service's schema to contain a `Schema` suffix to more easily clarify the usages.  Because this changes existing type names and behaviors, it would be a breaking change and thus this PR targets the `next` branch.

It's possible to accomplish this change with brand new type names and thus not cause a breaking change, but the renaming adds clarity to the existing types and I think it makes sense to make the change.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## :vertical_traffic_light: How Has This Been Tested?

Typescript `tsd` tests included in PR.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
