### PR TITLE
Update cacher types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -642,8 +642,11 @@ declare namespace Moleculer {
 		}
 
 		class Memory extends Base {}
-		class Redis extends Base {
-			client: any;
+
+		class MemoryLRU extends Base {}
+
+		class Redis<C = any> extends Base {
+			client: C;
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -581,6 +581,15 @@
         "@types/node": "*"
       }
     },
+    "@types/ioredis": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.0.10.tgz",
+      "integrity": "sha512-1ImAFcW5eg4f9UrftlVQPmGCkK1VyCqJ12c2wy3NlEQvzBC0GX64WlN01xj5iETqvsjczJHU+CRMPraBy9pX+g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
@@ -3860,7 +3869,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3871,7 +3881,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3988,7 +3999,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4000,6 +4012,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4126,7 +4139,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4259,6 +4273,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/bunyan": "1.8.6",
+    "@types/ioredis": "4.0.10",
     "@types/node": "11.13.0",
     "@types/pino": "5.8.6",
     "amqplib": "0.5.3",

--- a/test/typescript/tsd/Cachers.test-d.ts
+++ b/test/typescript/tsd/Cachers.test-d.ts
@@ -1,3 +1,4 @@
+import { Redis } from 'ioredis';
 import { expectType } from "tsd";
 import { Cachers, Cacher, ServiceBroker } from "../../../index";
 
@@ -13,6 +14,14 @@ expectType<Cachers.Base>(new Cachers.Memory());
 const memoryBroker = new ServiceBroker({ cacher: new Cachers.Memory() });
 expectType<Cachers.Memory>(memoryBroker.cacher as Cachers.Memory);
 
+// memory lru cacher tests
+expectType<Cacher>(new Cachers.MemoryLRU());
+expectType<Cacher<Cachers.MemoryLRU>>(new Cachers.MemoryLRU());
+expectType<Cachers.MemoryLRU>(new Cachers.MemoryLRU());
+expectType<Cachers.Base>(new Cachers.MemoryLRU());
+const memoryLRUBroker = new ServiceBroker({ cacher: new Cachers.MemoryLRU() });
+expectType<Cachers.MemoryLRU>(memoryLRUBroker.cacher as Cachers.MemoryLRU);
+
 // redis cacher tests
 expectType<Cacher>(new Cachers.Redis());
 expectType<Cacher<Cachers.Redis>>(new Cachers.Redis());
@@ -20,6 +29,11 @@ expectType<Cachers.Redis>(new Cachers.Redis());
 expectType<Cachers.Base>(new Cachers.Redis());
 const redisBroker = new ServiceBroker({ cacher: new Cachers.Redis() });
 expectType<Cachers.Redis>(redisBroker.cacher as Cachers.Redis);
+
+// redis cacher with client tests
+expectType<Cachers.Redis<Redis>>(new Cachers.Redis<Redis>());
+expectType<Redis>(new Cachers.Redis<Redis>().client)
+expectType<any>(new Cachers.Redis().client);
 
 // custom cacher tests
 class CustomCacher extends Cachers.Base {


### PR DESCRIPTION
## :memo: Description

This PR improves the `Cachers` namespace for the typescript declaration file.  First, it adds the missing `MemoryLRU` class to the list of cacher types.  Second, it allows for a generic specification of the `client` type for the `Redis` cacher.  This allows for user-land injection of the `Redis` types without creating a hard dependency on the `ioredis` type definitions as seen in #475 and #476.

I did add `@types/ioredis` as a devDependency in order to verify proper functionality in the `tsd` tests.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

Typescript `tsd` tests included in PR.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
