### PR TITLE
Update BrokerOptions factory types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -302,8 +302,8 @@ declare namespace Moleculer {
 		middlewares?: Array<Middleware>;
 		replCommands?: Array<GenericObject>;
 
-		ServiceFactory?: Service;
-		ContextFactory?: Context;
+		ServiceFactory?: typeof Service;
+		ContextFactory?: typeof Context;
 
 		created?: (broker: ServiceBroker) => void;
 		started?: (broker: ServiceBroker) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3843,12 +3843,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3868,7 +3870,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4016,6 +4019,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }


### PR DESCRIPTION
## :memo: Description
This PR improves the `BrokerOptions` namespace for the typescript declaration file. `ServiceBroker` accepts `ServiceFactory `and `ContextFactory `as optional configuration options, these options expect classes that serve as an alternative to `service.js` and `context.js`, but with the current settings in TypeScript, these options expect instances instead of classes.

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```ts
import { Service, ServiceBroker, Context, GenericObject } from "../../../index";

class MyServiceFactory extends Service {

}

class MyContextFactory<P = GenericObject, M = GenericObject> extends Context<P, M> {
	
}

const broker = new ServiceBroker({ 
	logger: false, 
	transporter: "fake", 
	ServiceFactory: MyServiceFactory, 
	ContextFactory: MyContextFactory 
});

``` 

## :vertical_traffic_light: How Has This Been Tested?
It is not possible to perform a new tsd test in this case, since the factories are not exposed (at least by the TypeScript definition), on the other hand, the sample code starts to work, and before it did not work

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
