### PR TITLE
Update event emit and broadcast to allow type specification for payload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,12 +118,12 @@ declare namespace Moleculer {
 
 		setParams(newParams: P, cloning?: boolean): void;
 		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
-		emit(eventName: string, data: any, groups: Array<string>): void;
-		emit(eventName: string, data: any, groups: string): void;
-		emit(eventName: string, data: any): void;
-		broadcast(eventName: string, data: any, groups: Array<string>): void;
-		broadcast(eventName: string, data: any, groups: string): void;
-		broadcast(eventName: string, data: any): void;
+		emit<D = any>(eventName: string, data: D, groups: Array<string>): void;
+		emit<D = any>(eventName: string, data: D, groups: string): void;
+		emit<D = any>(eventName: string, data: D): void;
+		broadcast<D = any>(eventName: string, data: D, groups: Array<string>): void;
+		broadcast<D = any>(eventName: string, data: D, groups: string): void;
+		broadcast<D = any>(eventName: string, data: D): void;
 
 		static create(broker: ServiceBroker, endpoint: Endpoint, params: GenericObject, opts: GenericObject): Context;
 		static create(broker: ServiceBroker, endpoint: Endpoint, params: GenericObject): Context;
@@ -500,7 +500,7 @@ declare namespace Moleculer {
 		 *
 		 * @memberof ServiceBroker
 		 */
-		emit(eventName: string, payload?: any, groups?: string | Array<string>): void;
+		emit<P = any>(eventName: string, payload?: P, groups?: string | Array<string>): void;
 
 		/**
 		 * Emit an event for all local & remote services
@@ -512,7 +512,7 @@ declare namespace Moleculer {
 		 *
 		 * @memberof ServiceBroker
 		 */
-		broadcast(eventName: string, payload?: any, groups?: string | Array<string>): void
+		broadcast<P = any>(eventName: string, payload?: P, groups?: string | Array<string>): void
 
 		/**
 		 * Emit an event for all local services
@@ -524,7 +524,7 @@ declare namespace Moleculer {
 		 *
 		 * @memberof ServiceBroker
 		 */
-		broadcastLocal(eventName: string, payload?: any, groups?: string | Array<string>): void;
+		broadcastLocal<P = any>(eventName: string, payload?: P, groups?: string | Array<string>): void;
 
 		ping(): PromiseLike<PongResponses>;
 		ping(nodeID: string, timeout?: number): PromiseLike<PongResponse>;


### PR DESCRIPTION
## :memo: Description

This PR adds type generics to the typescript definition for event `emit` and `broadcast`.  The type specified in the generic will be used to type the data sent through the event channel.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

### :scroll: Example code
```ts
ctx.emit<string>('entity.event', 'foo');
``` 

## :vertical_traffic_light: How Has This Been Tested?

Ran in my own project's repo before submission.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
