### PR TITLE
Service actions is always defined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -204,7 +204,7 @@ declare namespace Moleculer {
 		schema: ServiceSchema;
 		broker: ServiceBroker;
 		logger: LoggerInstance;
-		actions?: ServiceActions;
+		actions: ServiceActions;
 		Promise: PromiseConstructorLike;
 
 		waitForServices(serviceNames: string | Array<string> | Array<GenericObject>, timeout?: number, interval?: number): PromiseLike<void>;

--- a/test/typescript/tsd/ServiceActions.test-d.ts
+++ b/test/typescript/tsd/ServiceActions.test-d.ts
@@ -20,8 +20,8 @@ class TestService extends Service {
 }
 
 const testService = new TestService(broker);
-if (testService.actions) {
-	expectType<ServiceActions>(testService.actions);
-	expectType<ServiceAction>(testService.actions.foo);
-	expectType<ServiceAction>(testService.actions.bar);
-}
+
+expectType<ServiceActions>(testService.actions);
+expectType<ServiceAction>(testService.actions.foo);
+expectType<ServiceAction>(testService.actions.bar);
+


### PR DESCRIPTION
## :memo: Description

The service class' instance member `actions` is improperly designated as optional in the Typescript declaration file.  After review, `parseServiceSchema` in `service.js` always assigns it to an empty object:
```js
this.actions = {}; // external access to actions
```
This PR makes the service's `actions` property not optional.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

Tested in my own local repository and updated tsd tests.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
