### PR TITLE
Service settings types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -170,10 +170,10 @@ declare namespace Moleculer {
 		wrapMethod(method: string, handler: ActionHandler, bindTo: any): typeof handler;
 	}
 
-	interface ServiceSchema {
+	interface ServiceSchema<S = ServiceSettingSchema> {
 		name: string;
 		version?: string | number;
-		settings?: ServiceSettingSchema;
+		settings?: S;
 		dependencies?: string | GenericObject | Array<string> | Array<GenericObject>;
 		metadata?: GenericObject;
 		actions?: ServiceActions;
@@ -187,17 +187,17 @@ declare namespace Moleculer {
 		[name: string]: any;
 	}
 
-	class Service implements ServiceSchema {
-		constructor(broker: ServiceBroker, schema?: ServiceSchema);
+	class Service<S = ServiceSettingSchema> implements ServiceSchema {
+		constructor(broker: ServiceBroker, schema?: ServiceSchema<S>);
 
-		protected parseServiceSchema(schema: ServiceSchema): void;
+		protected parseServiceSchema(schema: ServiceSchema<S>): void;
 
 		name: string;
 		version?: string | number;
-		settings: ServiceSettingSchema;
+		settings: S;
 		metadata: GenericObject;
 		dependencies: string | GenericObject | Array<string> | Array<GenericObject>;
-		schema: ServiceSchema;
+		schema: ServiceSchema<S>;
 		broker: ServiceBroker;
 		logger: LoggerInstance;
 		actions?: ServiceActions;

--- a/test/typescript/tsd/ServiceSettings.test-d.ts
+++ b/test/typescript/tsd/ServiceSettings.test-d.ts
@@ -1,0 +1,66 @@
+import { expectType } from "tsd";
+import {
+	Service,
+	ServiceBroker,
+	ServiceSchema,
+	ServiceSettingSchema,
+} from "../../../index";
+
+// set up some test globals
+const broker = new ServiceBroker({ logger: false, transporter: "fake" });
+interface ExtendedSettings extends ServiceSettingSchema {
+	foo: string;
+}
+
+// test that ServiceSchema uses default service settings schema
+const testSettingsSchema1: ServiceSchema = {
+	name: 'testSchema1',
+	settings: {
+		foo: 'bar',
+	},
+};
+expectType<ServiceSettingSchema>(testSettingsSchema1.settings!); // assert non-null to avoid undefined check
+
+// test that service gets default service settings schema
+class TestService1 extends Service {
+	constructor(broker: ServiceBroker) {
+		super(broker);
+
+		this.parseServiceSchema({
+			name: 'testService1',
+			settings: {
+				foo: 'bar',
+			},
+		});
+	}
+}
+const testService1 = new TestService1(broker);
+expectType<ServiceSettingSchema>(testService1.settings);
+expectType<ServiceSchema>(testService1.schema);
+expectType<ServiceSchema<ServiceSettingSchema>>(testService1.schema);
+
+// test that ServiceSchema uses extended service settings schema
+const testSettingsSchema2: ServiceSchema<ExtendedSettings> = {
+	name: 'testSchema2',
+	settings: {
+		foo: 'bar',
+	},
+};
+expectType<ExtendedSettings>(testSettingsSchema2.settings!); ; // assert non-null to avoid undefined check
+
+// test that service gets extended service settings schema
+class TestService2 extends Service<ExtendedSettings> {
+	constructor(broker: ServiceBroker) {
+		super(broker);
+
+		this.parseServiceSchema({
+			name: 'testService2',
+			settings: {
+				foo: 'bar',
+			},
+		});
+	}
+}
+const testService2 = new TestService2(broker);
+expectType<ExtendedSettings>(testService2.settings);
+expectType<ServiceSchema<ExtendedSettings>>(testService2.schema);


### PR DESCRIPTION
## :memo: Description
For Typescript consumers, the `settings` property of a service is not currently typed. The default implementation essentially gives all `settings` properties the `any` type which means that upon consumption of them there isn't any type safety at all.

This PR augments the `ServiceSchema` and `Service` types to allow specification of a Generic which defaults to `ServiceSettingSchema`.  The value provided in this generic will become the type of the settings object.  This allows for type safety in `parseServiceSchema` as well as later type safety of the settings in the service's instance.

The other approach to this problem that I can think of would be to alter the behavior of `parseServiceSchema`.  Presently, that routine would override any values one might manually place on service instance members (like the `settings` object).  This prevents direct assignation of `settings` in the class definition.  It might be a better approach to allow es6 classes without making use of `parseServiceSchema` and consumers could specify properties such as settings directly in the class definition.  I think another function would be necessary to apply mixins and initialize the service, but properties such as `settings` could be applied directly then.  I can explore this approach either in tandem with this PR or in lieu of this PR if that sounds like a better path forward, or go another direction entirely if some suggestions are offered.


### :gem: Type of change

- [X] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

I've implemented this in my own project as well as included tsd tests.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
