### PR TITLE
Use correct end time for span reporters

### DIFF
--- a/src/tracing/exporters/datadog.js
+++ b/src/tracing/exporters/datadog.js
@@ -176,7 +176,7 @@ class DatadogTraceExporter extends BaseTraceExporter {
 			this.addTags(ddSpan, "error", this.errorToObject(span.error));
 		}
 
-		ddSpan.finish(span.endTime);
+		ddSpan.finish(span.finishTime);
 
 		if (item.oldSpan) {
 			this.ddScope._spans[item.asyncId] = item.oldSpan;

--- a/src/tracing/exporters/jaeger.js
+++ b/src/tracing/exporters/jaeger.js
@@ -189,7 +189,7 @@ class JaegerTraceExporter extends BaseTraceExporter {
 			this.addTags(jaegerSpan, "error", this.errorToObject(span.error));
 		}
 
-		jaegerSpan.finish(span.endTime);
+		jaegerSpan.finish(span.finishTime);
 
 		return jaegerSpan;
 	}


### PR DESCRIPTION
## :memo: Description

Found that span.endTIme is not defined and other implementations use span.finishTime 

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
