### PR TITLE
Update types of Context.action, Context.service, Context.endpoint to be nullable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,7 @@ declare namespace Moleculer {
 		constructor(broker: ServiceBroker, endpoint: Endpoint);
 		id: string;
 		broker: ServiceBroker;
-		endpoint?: Endpoint;
+		endpoint?: Endpoint | null;
 		action?: ActionSchema | null;
 		service?: Service | null;
 		nodeID?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,8 +97,8 @@ declare namespace Moleculer {
 		id: string;
 		broker: ServiceBroker;
 		endpoint?: Endpoint;
-		action?: ActionSchema;
-		service?: Service;
+		action?: ActionSchema | null;
+		service?: Service | null;
 		nodeID?: string;
 
 		options: CallingOptions;


### PR DESCRIPTION
## :memo: Description
Hello!
Currently, Context will default `endpoint`, `service`, and `action` to [null if they are not provided](https://github.com/moleculerjs/moleculer/blob/next/src/context.js#L64-L66). However, the Typescript declaration for Context does not allow these values to be null. This can cause problems when the Typescript option `strictNullChecks` is enabled. This change modifies the Context type to allow these three values to be null.

### :gem: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
