### PR TITLE
TS - expose prefix property in Redis Cacher class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1034,8 +1034,6 @@ declare namespace Moleculer {
 			constructor(opts?: CacherOptions);
 			opts: CacherOptions;
 
-			prefix?: string;
-
 			init(broker: ServiceBroker): void;
 			close(): PromiseLike<any>;
 			get(key: string): PromiseLike<null | GenericObject>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1034,6 +1034,8 @@ declare namespace Moleculer {
 			constructor(opts?: CacherOptions);
 			opts: CacherOptions;
 
+			prefix?: string;
+
 			init(broker: ServiceBroker): void;
 			close(): PromiseLike<any>;
 			get(key: string): PromiseLike<null | GenericObject>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1061,6 +1061,7 @@ declare namespace Moleculer {
 			opts: RedisCacherOptions;
 
 			client: C;
+			prefix: string | null;
 		}
 	}
 

--- a/test/typescript/tsd/Cachers.test-d.ts
+++ b/test/typescript/tsd/Cachers.test-d.ts
@@ -27,6 +27,8 @@ expectType<Cacher>(new Cachers.Redis());
 expectType<Cacher<Cachers.Redis>>(new Cachers.Redis());
 expectType<Cachers.Redis>(new Cachers.Redis());
 expectType<Cachers.Base>(new Cachers.Redis());
+expectType<string|null>(new Cachers.Redis().prefix);
+expectType<string|null>(new Cachers.Redis({ prefix: "foo" }).prefix);
 const redisBroker = new ServiceBroker({ cacher: new Cachers.Redis() });
 expectType<Cachers.Redis>(redisBroker.cacher as Cachers.Redis);
 


### PR DESCRIPTION
## :memo: Description

This PR adds the `prefix` property to the Redis Cacher class type. This change allows TypeScript users to reference the generated cache prefix for use in their own cache keys. By prefixing their cache keys with the Redis Cacher prefix, those entries in the cache may be cleaned up using the Redis Cacher class's `clean` method and the REPL's `clear` command.

### :dart: Relevant issues

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code

## :vertical_traffic_light: How Has This Been Tested?
Manually tested in our moleculer services and via the tsd tests.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
