### PR TITLE
Fix protobuf definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,7 +2052,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -3652,7 +3653,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3673,12 +3675,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3693,17 +3697,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3820,7 +3827,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3832,6 +3840,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3846,6 +3855,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3853,12 +3863,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3877,6 +3889,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3964,7 +3977,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3976,6 +3990,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4061,7 +4076,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4097,6 +4113,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4116,6 +4133,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4159,12 +4177,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,8 +2052,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -3653,8 +3652,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3675,14 +3673,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3697,20 +3693,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3827,8 +3820,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3840,7 +3832,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3855,7 +3846,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3863,14 +3853,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3889,7 +3877,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3977,8 +3964,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3990,7 +3976,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4076,8 +4061,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4113,7 +4097,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4133,7 +4116,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4177,14 +4159,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/serializers/proto/packets.proto
+++ b/src/serializers/proto/packets.proto
@@ -3,104 +3,104 @@ syntax = "proto3";
 package packets;
 
 message PacketEvent {
-	required string ver 	= 1;
-	required string sender 	= 2;
-	required string event 	= 3;
-	optional string data 	= 4;
+	 string ver 	= 1;
+	 string sender 	= 2;
+	 string event 	= 3;
+	 string data 	= 4;
 	repeated string groups 	= 5;
-	required bool broadcast	= 6;
+	 bool broadcast	= 6;
 }
 
 message PacketRequest {
-	required string ver 		= 1;
-	required string sender 		= 2;
-	required string id 			= 3;
-	required string action 		= 4;
-	optional bytes params 		= 5;
-	required string meta 		= 6;
-	required double timeout		= 7;
-	required int32 level 		= 8;
-	optional bool metrics 		= 9;
-	optional string parentID 	= 10;
-	optional string requestID 	= 11;
-	optional bool stream 		= 12;
+	 string ver 		= 1;
+	 string sender 		= 2;
+	 string id 			= 3;
+	 string action 		= 4;
+	 bytes params 		= 5;
+	 string meta 		= 6;
+	 double timeout		= 7;
+	 int32 level 		= 8;
+	 bool metrics 		= 9;
+	 string parentID 	= 10;
+	 string requestID 	= 11;
+	 bool stream 		= 12;
 }
 
 message PacketResponse {
-	required string ver 		= 1;
-	required string sender 		= 2;
-	required string id 			= 3;
-	required bool success 		= 4;
-	optional bytes data 		= 5;
-	optional string error 		= 6;
-	required string meta 		= 7;
-	optional bool stream 		= 8;
+	 string ver 		= 1;
+	 string sender 		= 2;
+	 string id 			= 3;
+	 bool success 		= 4;
+	 bytes data 		= 5;
+	 string error 		= 6;
+	 string meta 		= 7;
+	 bool stream 		= 8;
 }
 
 message PacketDiscover {
-	required string ver 		= 1;
-	required string sender 		= 2;
+	 string ver 		= 1;
+	 string sender 		= 2;
 }
 
 message PacketInfo {
-	required string ver 			= 1;
-	required string sender 			= 2;
-	required string services		= 3;
-	required string config			= 4;
+	 string ver 			= 1;
+	 string sender 			= 2;
+	 string services		= 3;
+	 string config			= 4;
 
 	repeated string ipList			= 5;
-	required string hostname		= 6;
-	required Client client 			= 7;
-	optional int32  seq 			= 8;
+	 string hostname		= 6;
+	 Client client 			= 7;
+	 int32  seq 			= 8;
 
 	message Client {
-		required string type 			= 1;
-		required string version 		= 2;
-		required string langVersion 	= 3;
+		 string type 			= 1;
+		 string version 		= 2;
+		 string langVersion 	= 3;
 	}
 }
 
 message PacketDisconnect {
-	required string ver 	= 1;
-	required string sender 	= 2;
+	 string ver 	= 1;
+	 string sender 	= 2;
 }
 
 message PacketHeartbeat {
-	required string ver 		= 1;
-	required string sender 		= 2;
-	required double cpu 		= 3;
+	 string ver 		= 1;
+	 string sender 		= 2;
+	 double cpu 		= 3;
 }
 
 message PacketPing {
-	required string ver 		= 1;
-	required string sender 		= 2;
-	required int64 time 		= 3;
+	 string ver 		= 1;
+	 string sender 		= 2;
+	 int64 time 		= 3;
 }
 
 message PacketPong {
-	required string ver 		= 1;
-	required string sender 		= 2;
-	required int64 time 		= 3;
-	required int64 arrived 		= 4;
+	 string ver 		= 1;
+	 string sender 		= 2;
+	 int64 time 		= 3;
+	 int64 arrived 		= 4;
 }
 
 message PacketGossipHello {
-	required string ver 		= 1;
-	required string sender 		= 2;
-	required string host 		= 3;
-	required int32 port 		= 4;
+	 string ver 		= 1;
+	 string sender 		= 2;
+	 string host 		= 3;
+	 int32 port 		= 4;
 }
 
 message PacketGossipRequest {
-	required string ver 			= 1;
-	required string sender 			= 2;
-	optional string online			= 3;
-	optional string offline			= 4;
+	 string ver 			= 1;
+	 string sender 			= 2;
+	 string online			= 3;
+	 string offline			= 4;
 }
 
 message PacketGossipResponse {
-	required string ver 			= 1;
-	required string sender 			= 2;
-	optional string online			= 3;
-	optional string offline			= 4;
+	 string ver 			= 1;
+	 string sender 			= 2;
+	 string online			= 3;
+	 string offline			= 4;
 }

--- a/src/serializers/proto/packets.proto
+++ b/src/serializers/proto/packets.proto
@@ -1,6 +1,6 @@
 // packets.proto
-package packets;
 syntax = "proto3";
+package packets;
 
 message PacketEvent {
 	required string ver 	= 1;

--- a/src/serializers/proto/packets.proto.js
+++ b/src/serializers/proto/packets.proto.js
@@ -9,31 +9,30 @@ var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.ut
 // Exported root namespace
 var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
 
-/* istanbul ignore next */
 $root.packets = (function() {
 
-	/**
+    /**
      * Namespace packets.
      * @exports packets
      * @namespace
      */
-	var packets = {};
+    var packets = {};
 
-	packets.PacketEvent = (function() {
+    packets.PacketEvent = (function() {
 
-		/**
+        /**
          * Properties of a PacketEvent.
          * @memberof packets
          * @interface IPacketEvent
-         * @property {string} ver PacketEvent ver
-         * @property {string} sender PacketEvent sender
-         * @property {string} event PacketEvent event
+         * @property {string|null} [ver] PacketEvent ver
+         * @property {string|null} [sender] PacketEvent sender
+         * @property {string|null} [event] PacketEvent event
          * @property {string|null} [data] PacketEvent data
          * @property {Array.<string>|null} [groups] PacketEvent groups
-         * @property {boolean} broadcast PacketEvent broadcast
+         * @property {boolean|null} [broadcast] PacketEvent broadcast
          */
 
-		/**
+        /**
          * Constructs a new PacketEvent.
          * @memberof packets
          * @classdesc Represents a PacketEvent.
@@ -41,63 +40,63 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketEvent=} [properties] Properties to set
          */
-		function PacketEvent(properties) {
-			this.groups = [];
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketEvent(properties) {
+            this.groups = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketEvent ver.
          * @member {string} ver
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.ver = "";
+        PacketEvent.prototype.ver = "";
 
-		/**
+        /**
          * PacketEvent sender.
          * @member {string} sender
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.sender = "";
+        PacketEvent.prototype.sender = "";
 
-		/**
+        /**
          * PacketEvent event.
          * @member {string} event
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.event = "";
+        PacketEvent.prototype.event = "";
 
-		/**
+        /**
          * PacketEvent data.
          * @member {string} data
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.data = "";
+        PacketEvent.prototype.data = "";
 
-		/**
+        /**
          * PacketEvent groups.
          * @member {Array.<string>} groups
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.groups = $util.emptyArray;
+        PacketEvent.prototype.groups = $util.emptyArray;
 
-		/**
+        /**
          * PacketEvent broadcast.
          * @member {boolean} broadcast
          * @memberof packets.PacketEvent
          * @instance
          */
-		PacketEvent.prototype.broadcast = false;
+        PacketEvent.prototype.broadcast = false;
 
-		/**
+        /**
          * Creates a new PacketEvent instance using the specified properties.
          * @function create
          * @memberof packets.PacketEvent
@@ -105,11 +104,11 @@ $root.packets = (function() {
          * @param {packets.IPacketEvent=} [properties] Properties to set
          * @returns {packets.PacketEvent} PacketEvent instance
          */
-		PacketEvent.create = function create(properties) {
-			return new PacketEvent(properties);
-		};
+        PacketEvent.create = function create(properties) {
+            return new PacketEvent(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketEvent message. Does not implicitly {@link packets.PacketEvent.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketEvent
@@ -118,22 +117,26 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketEvent.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.event);
-			if (message.data != null && message.hasOwnProperty("data"))
-				writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
-			if (message.groups != null && message.groups.length)
-				for (var i = 0; i < message.groups.length; ++i)
-					writer.uint32(/* id 5, wireType 2 =*/42).string(message.groups[i]);
-			writer.uint32(/* id 6, wireType 0 =*/48).bool(message.broadcast);
-			return writer;
-		};
+        PacketEvent.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.event != null && message.hasOwnProperty("event"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.event);
+            if (message.data != null && message.hasOwnProperty("data"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
+            if (message.groups != null && message.groups.length)
+                for (var i = 0; i < message.groups.length; ++i)
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.groups[i]);
+            if (message.broadcast != null && message.hasOwnProperty("broadcast"))
+                writer.uint32(/* id 6, wireType 0 =*/48).bool(message.broadcast);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketEvent message, length delimited. Does not implicitly {@link packets.PacketEvent.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketEvent
@@ -142,11 +145,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketEvent.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketEvent.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketEvent message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketEvent
@@ -157,50 +160,42 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketEvent.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketEvent();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.event = reader.string();
-						break;
-					case 4:
-						message.data = reader.string();
-						break;
-					case 5:
-						if (!(message.groups && message.groups.length))
-							message.groups = [];
-						message.groups.push(reader.string());
-						break;
-					case 6:
-						message.broadcast = reader.bool();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("event"))
-				throw $util.ProtocolError("missing required 'event'", { instance: message });
-			if (!message.hasOwnProperty("broadcast"))
-				throw $util.ProtocolError("missing required 'broadcast'", { instance: message });
-			return message;
-		};
+        PacketEvent.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketEvent();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.event = reader.string();
+                    break;
+                case 4:
+                    message.data = reader.string();
+                    break;
+                case 5:
+                    if (!(message.groups && message.groups.length))
+                        message.groups = [];
+                    message.groups.push(reader.string());
+                    break;
+                case 6:
+                    message.broadcast = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketEvent message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketEvent
@@ -210,13 +205,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketEvent.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketEvent.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketEvent message.
          * @function verify
          * @memberof packets.PacketEvent
@@ -224,31 +219,35 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketEvent.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.event))
-				return "event: string expected";
-			if (message.data != null && message.hasOwnProperty("data"))
-				if (!$util.isString(message.data))
-					return "data: string expected";
-			if (message.groups != null && message.hasOwnProperty("groups")) {
-				if (!Array.isArray(message.groups))
-					return "groups: array expected";
-				for (var i = 0; i < message.groups.length; ++i)
-					if (!$util.isString(message.groups[i]))
-						return "groups: string[] expected";
-			}
-			if (typeof message.broadcast !== "boolean")
-				return "broadcast: boolean expected";
-			return null;
-		};
+        PacketEvent.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.event != null && message.hasOwnProperty("event"))
+                if (!$util.isString(message.event))
+                    return "event: string expected";
+            if (message.data != null && message.hasOwnProperty("data"))
+                if (!$util.isString(message.data))
+                    return "data: string expected";
+            if (message.groups != null && message.hasOwnProperty("groups")) {
+                if (!Array.isArray(message.groups))
+                    return "groups: array expected";
+                for (var i = 0; i < message.groups.length; ++i)
+                    if (!$util.isString(message.groups[i]))
+                        return "groups: string[] expected";
+            }
+            if (message.broadcast != null && message.hasOwnProperty("broadcast"))
+                if (typeof message.broadcast !== "boolean")
+                    return "broadcast: boolean expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketEvent message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketEvent
@@ -256,31 +255,31 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketEvent} PacketEvent
          */
-		PacketEvent.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketEvent)
-				return object;
-			var message = new $root.packets.PacketEvent();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.event != null)
-				message.event = String(object.event);
-			if (object.data != null)
-				message.data = String(object.data);
-			if (object.groups) {
-				if (!Array.isArray(object.groups))
-					throw TypeError(".packets.PacketEvent.groups: array expected");
-				message.groups = [];
-				for (var i = 0; i < object.groups.length; ++i)
-					message.groups[i] = String(object.groups[i]);
-			}
-			if (object.broadcast != null)
-				message.broadcast = Boolean(object.broadcast);
-			return message;
-		};
+        PacketEvent.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketEvent)
+                return object;
+            var message = new $root.packets.PacketEvent();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.event != null)
+                message.event = String(object.event);
+            if (object.data != null)
+                message.data = String(object.data);
+            if (object.groups) {
+                if (!Array.isArray(object.groups))
+                    throw TypeError(".packets.PacketEvent.groups: array expected");
+                message.groups = [];
+                for (var i = 0; i < object.groups.length; ++i)
+                    message.groups[i] = String(object.groups[i]);
+            }
+            if (object.broadcast != null)
+                message.broadcast = Boolean(object.broadcast);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketEvent message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketEvent
@@ -289,72 +288,72 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketEvent.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.arrays || options.defaults)
-				object.groups = [];
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.event = "";
-				object.data = "";
-				object.broadcast = false;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.event != null && message.hasOwnProperty("event"))
-				object.event = message.event;
-			if (message.data != null && message.hasOwnProperty("data"))
-				object.data = message.data;
-			if (message.groups && message.groups.length) {
-				object.groups = [];
-				for (var j = 0; j < message.groups.length; ++j)
-					object.groups[j] = message.groups[j];
-			}
-			if (message.broadcast != null && message.hasOwnProperty("broadcast"))
-				object.broadcast = message.broadcast;
-			return object;
-		};
+        PacketEvent.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.groups = [];
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.event = "";
+                object.data = "";
+                object.broadcast = false;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.event != null && message.hasOwnProperty("event"))
+                object.event = message.event;
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = message.data;
+            if (message.groups && message.groups.length) {
+                object.groups = [];
+                for (var j = 0; j < message.groups.length; ++j)
+                    object.groups[j] = message.groups[j];
+            }
+            if (message.broadcast != null && message.hasOwnProperty("broadcast"))
+                object.broadcast = message.broadcast;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketEvent to JSON.
          * @function toJSON
          * @memberof packets.PacketEvent
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketEvent.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketEvent.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketEvent;
-	})();
+        return PacketEvent;
+    })();
 
-	packets.PacketRequest = (function() {
+    packets.PacketRequest = (function() {
 
-		/**
+        /**
          * Properties of a PacketRequest.
          * @memberof packets
          * @interface IPacketRequest
-         * @property {string} ver PacketRequest ver
-         * @property {string} sender PacketRequest sender
-         * @property {string} id PacketRequest id
-         * @property {string} action PacketRequest action
+         * @property {string|null} [ver] PacketRequest ver
+         * @property {string|null} [sender] PacketRequest sender
+         * @property {string|null} [id] PacketRequest id
+         * @property {string|null} [action] PacketRequest action
          * @property {Uint8Array|null} [params] PacketRequest params
-         * @property {string} meta PacketRequest meta
-         * @property {number} timeout PacketRequest timeout
-         * @property {number} level PacketRequest level
+         * @property {string|null} [meta] PacketRequest meta
+         * @property {number|null} [timeout] PacketRequest timeout
+         * @property {number|null} [level] PacketRequest level
          * @property {boolean|null} [metrics] PacketRequest metrics
          * @property {string|null} [parentID] PacketRequest parentID
          * @property {string|null} [requestID] PacketRequest requestID
          * @property {boolean|null} [stream] PacketRequest stream
          */
 
-		/**
+        /**
          * Constructs a new PacketRequest.
          * @memberof packets
          * @classdesc Represents a PacketRequest.
@@ -362,110 +361,110 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketRequest=} [properties] Properties to set
          */
-		function PacketRequest(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketRequest ver.
          * @member {string} ver
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.ver = "";
+        PacketRequest.prototype.ver = "";
 
-		/**
+        /**
          * PacketRequest sender.
          * @member {string} sender
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.sender = "";
+        PacketRequest.prototype.sender = "";
 
-		/**
+        /**
          * PacketRequest id.
          * @member {string} id
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.id = "";
+        PacketRequest.prototype.id = "";
 
-		/**
+        /**
          * PacketRequest action.
          * @member {string} action
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.action = "";
+        PacketRequest.prototype.action = "";
 
-		/**
+        /**
          * PacketRequest params.
          * @member {Uint8Array} params
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.params = $util.newBuffer([]);
+        PacketRequest.prototype.params = $util.newBuffer([]);
 
-		/**
+        /**
          * PacketRequest meta.
          * @member {string} meta
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.meta = "";
+        PacketRequest.prototype.meta = "";
 
-		/**
+        /**
          * PacketRequest timeout.
          * @member {number} timeout
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.timeout = 0;
+        PacketRequest.prototype.timeout = 0;
 
-		/**
+        /**
          * PacketRequest level.
          * @member {number} level
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.level = 0;
+        PacketRequest.prototype.level = 0;
 
-		/**
+        /**
          * PacketRequest metrics.
          * @member {boolean} metrics
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.metrics = false;
+        PacketRequest.prototype.metrics = false;
 
-		/**
+        /**
          * PacketRequest parentID.
          * @member {string} parentID
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.parentID = "";
+        PacketRequest.prototype.parentID = "";
 
-		/**
+        /**
          * PacketRequest requestID.
          * @member {string} requestID
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.requestID = "";
+        PacketRequest.prototype.requestID = "";
 
-		/**
+        /**
          * PacketRequest stream.
          * @member {boolean} stream
          * @memberof packets.PacketRequest
          * @instance
          */
-		PacketRequest.prototype.stream = false;
+        PacketRequest.prototype.stream = false;
 
-		/**
+        /**
          * Creates a new PacketRequest instance using the specified properties.
          * @function create
          * @memberof packets.PacketRequest
@@ -473,11 +472,11 @@ $root.packets = (function() {
          * @param {packets.IPacketRequest=} [properties] Properties to set
          * @returns {packets.PacketRequest} PacketRequest instance
          */
-		PacketRequest.create = function create(properties) {
-			return new PacketRequest(properties);
-		};
+        PacketRequest.create = function create(properties) {
+            return new PacketRequest(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketRequest message. Does not implicitly {@link packets.PacketRequest.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketRequest
@@ -486,30 +485,37 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketRequest.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
-			writer.uint32(/* id 4, wireType 2 =*/34).string(message.action);
-			if (message.params != null && message.hasOwnProperty("params"))
-				writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.params);
-			writer.uint32(/* id 6, wireType 2 =*/50).string(message.meta);
-			writer.uint32(/* id 7, wireType 1 =*/57).double(message.timeout);
-			writer.uint32(/* id 8, wireType 0 =*/64).int32(message.level);
-			if (message.metrics != null && message.hasOwnProperty("metrics"))
-				writer.uint32(/* id 9, wireType 0 =*/72).bool(message.metrics);
-			if (message.parentID != null && message.hasOwnProperty("parentID"))
-				writer.uint32(/* id 10, wireType 2 =*/82).string(message.parentID);
-			if (message.requestID != null && message.hasOwnProperty("requestID"))
-				writer.uint32(/* id 11, wireType 2 =*/90).string(message.requestID);
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				writer.uint32(/* id 12, wireType 0 =*/96).bool(message.stream);
-			return writer;
-		};
+        PacketRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.id != null && message.hasOwnProperty("id"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
+            if (message.action != null && message.hasOwnProperty("action"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.action);
+            if (message.params != null && message.hasOwnProperty("params"))
+                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.params);
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.meta);
+            if (message.timeout != null && message.hasOwnProperty("timeout"))
+                writer.uint32(/* id 7, wireType 1 =*/57).double(message.timeout);
+            if (message.level != null && message.hasOwnProperty("level"))
+                writer.uint32(/* id 8, wireType 0 =*/64).int32(message.level);
+            if (message.metrics != null && message.hasOwnProperty("metrics"))
+                writer.uint32(/* id 9, wireType 0 =*/72).bool(message.metrics);
+            if (message.parentID != null && message.hasOwnProperty("parentID"))
+                writer.uint32(/* id 10, wireType 2 =*/82).string(message.parentID);
+            if (message.requestID != null && message.hasOwnProperty("requestID"))
+                writer.uint32(/* id 11, wireType 2 =*/90).string(message.requestID);
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                writer.uint32(/* id 12, wireType 0 =*/96).bool(message.stream);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketRequest message, length delimited. Does not implicitly {@link packets.PacketRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketRequest
@@ -518,11 +524,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketRequest.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketRequest message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketRequest
@@ -533,72 +539,58 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketRequest.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketRequest();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.id = reader.string();
-						break;
-					case 4:
-						message.action = reader.string();
-						break;
-					case 5:
-						message.params = reader.bytes();
-						break;
-					case 6:
-						message.meta = reader.string();
-						break;
-					case 7:
-						message.timeout = reader.double();
-						break;
-					case 8:
-						message.level = reader.int32();
-						break;
-					case 9:
-						message.metrics = reader.bool();
-						break;
-					case 10:
-						message.parentID = reader.string();
-						break;
-					case 11:
-						message.requestID = reader.string();
-						break;
-					case 12:
-						message.stream = reader.bool();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("id"))
-				throw $util.ProtocolError("missing required 'id'", { instance: message });
-			if (!message.hasOwnProperty("action"))
-				throw $util.ProtocolError("missing required 'action'", { instance: message });
-			if (!message.hasOwnProperty("meta"))
-				throw $util.ProtocolError("missing required 'meta'", { instance: message });
-			if (!message.hasOwnProperty("timeout"))
-				throw $util.ProtocolError("missing required 'timeout'", { instance: message });
-			if (!message.hasOwnProperty("level"))
-				throw $util.ProtocolError("missing required 'level'", { instance: message });
-			return message;
-		};
+        PacketRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.id = reader.string();
+                    break;
+                case 4:
+                    message.action = reader.string();
+                    break;
+                case 5:
+                    message.params = reader.bytes();
+                    break;
+                case 6:
+                    message.meta = reader.string();
+                    break;
+                case 7:
+                    message.timeout = reader.double();
+                    break;
+                case 8:
+                    message.level = reader.int32();
+                    break;
+                case 9:
+                    message.metrics = reader.bool();
+                    break;
+                case 10:
+                    message.parentID = reader.string();
+                    break;
+                case 11:
+                    message.requestID = reader.string();
+                    break;
+                case 12:
+                    message.stream = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketRequest
@@ -608,13 +600,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketRequest.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketRequest message.
          * @function verify
          * @memberof packets.PacketRequest
@@ -622,42 +614,49 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketRequest.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.id))
-				return "id: string expected";
-			if (!$util.isString(message.action))
-				return "action: string expected";
-			if (message.params != null && message.hasOwnProperty("params"))
-				if (!(message.params && typeof message.params.length === "number" || $util.isString(message.params)))
-					return "params: buffer expected";
-			if (!$util.isString(message.meta))
-				return "meta: string expected";
-			if (typeof message.timeout !== "number")
-				return "timeout: number expected";
-			if (!$util.isInteger(message.level))
-				return "level: integer expected";
-			if (message.metrics != null && message.hasOwnProperty("metrics"))
-				if (typeof message.metrics !== "boolean")
-					return "metrics: boolean expected";
-			if (message.parentID != null && message.hasOwnProperty("parentID"))
-				if (!$util.isString(message.parentID))
-					return "parentID: string expected";
-			if (message.requestID != null && message.hasOwnProperty("requestID"))
-				if (!$util.isString(message.requestID))
-					return "requestID: string expected";
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				if (typeof message.stream !== "boolean")
-					return "stream: boolean expected";
-			return null;
-		};
+        PacketRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.action != null && message.hasOwnProperty("action"))
+                if (!$util.isString(message.action))
+                    return "action: string expected";
+            if (message.params != null && message.hasOwnProperty("params"))
+                if (!(message.params && typeof message.params.length === "number" || $util.isString(message.params)))
+                    return "params: buffer expected";
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                if (!$util.isString(message.meta))
+                    return "meta: string expected";
+            if (message.timeout != null && message.hasOwnProperty("timeout"))
+                if (typeof message.timeout !== "number")
+                    return "timeout: number expected";
+            if (message.level != null && message.hasOwnProperty("level"))
+                if (!$util.isInteger(message.level))
+                    return "level: integer expected";
+            if (message.metrics != null && message.hasOwnProperty("metrics"))
+                if (typeof message.metrics !== "boolean")
+                    return "metrics: boolean expected";
+            if (message.parentID != null && message.hasOwnProperty("parentID"))
+                if (!$util.isString(message.parentID))
+                    return "parentID: string expected";
+            if (message.requestID != null && message.hasOwnProperty("requestID"))
+                if (!$util.isString(message.requestID))
+                    return "requestID: string expected";
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                if (typeof message.stream !== "boolean")
+                    return "stream: boolean expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketRequest
@@ -665,41 +664,41 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketRequest} PacketRequest
          */
-		PacketRequest.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketRequest)
-				return object;
-			var message = new $root.packets.PacketRequest();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.id != null)
-				message.id = String(object.id);
-			if (object.action != null)
-				message.action = String(object.action);
-			if (object.params != null)
-				if (typeof object.params === "string")
-					$util.base64.decode(object.params, message.params = $util.newBuffer($util.base64.length(object.params)), 0);
-				else if (object.params.length)
-					message.params = object.params;
-			if (object.meta != null)
-				message.meta = String(object.meta);
-			if (object.timeout != null)
-				message.timeout = Number(object.timeout);
-			if (object.level != null)
-				message.level = object.level | 0;
-			if (object.metrics != null)
-				message.metrics = Boolean(object.metrics);
-			if (object.parentID != null)
-				message.parentID = String(object.parentID);
-			if (object.requestID != null)
-				message.requestID = String(object.requestID);
-			if (object.stream != null)
-				message.stream = Boolean(object.stream);
-			return message;
-		};
+        PacketRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketRequest)
+                return object;
+            var message = new $root.packets.PacketRequest();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.action != null)
+                message.action = String(object.action);
+            if (object.params != null)
+                if (typeof object.params === "string")
+                    $util.base64.decode(object.params, message.params = $util.newBuffer($util.base64.length(object.params)), 0);
+                else if (object.params.length)
+                    message.params = object.params;
+            if (object.meta != null)
+                message.meta = String(object.meta);
+            if (object.timeout != null)
+                message.timeout = Number(object.timeout);
+            if (object.level != null)
+                message.level = object.level | 0;
+            if (object.metrics != null)
+                message.metrics = Boolean(object.metrics);
+            if (object.parentID != null)
+                message.parentID = String(object.parentID);
+            if (object.requestID != null)
+                message.requestID = String(object.requestID);
+            if (object.stream != null)
+                message.stream = Boolean(object.stream);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketRequest
@@ -708,88 +707,88 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketRequest.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.id = "";
-				object.action = "";
-				if (options.bytes === String)
-					object.params = "";
-				else {
-					object.params = [];
-					if (options.bytes !== Array)
-						object.params = $util.newBuffer(object.params);
-				}
-				object.meta = "";
-				object.timeout = 0;
-				object.level = 0;
-				object.metrics = false;
-				object.parentID = "";
-				object.requestID = "";
-				object.stream = false;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.id != null && message.hasOwnProperty("id"))
-				object.id = message.id;
-			if (message.action != null && message.hasOwnProperty("action"))
-				object.action = message.action;
-			if (message.params != null && message.hasOwnProperty("params"))
-				object.params = options.bytes === String ? $util.base64.encode(message.params, 0, message.params.length) : options.bytes === Array ? Array.prototype.slice.call(message.params) : message.params;
-			if (message.meta != null && message.hasOwnProperty("meta"))
-				object.meta = message.meta;
-			if (message.timeout != null && message.hasOwnProperty("timeout"))
-				object.timeout = options.json && !isFinite(message.timeout) ? String(message.timeout) : message.timeout;
-			if (message.level != null && message.hasOwnProperty("level"))
-				object.level = message.level;
-			if (message.metrics != null && message.hasOwnProperty("metrics"))
-				object.metrics = message.metrics;
-			if (message.parentID != null && message.hasOwnProperty("parentID"))
-				object.parentID = message.parentID;
-			if (message.requestID != null && message.hasOwnProperty("requestID"))
-				object.requestID = message.requestID;
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				object.stream = message.stream;
-			return object;
-		};
+        PacketRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.id = "";
+                object.action = "";
+                if (options.bytes === String)
+                    object.params = "";
+                else {
+                    object.params = [];
+                    if (options.bytes !== Array)
+                        object.params = $util.newBuffer(object.params);
+                }
+                object.meta = "";
+                object.timeout = 0;
+                object.level = 0;
+                object.metrics = false;
+                object.parentID = "";
+                object.requestID = "";
+                object.stream = false;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.action != null && message.hasOwnProperty("action"))
+                object.action = message.action;
+            if (message.params != null && message.hasOwnProperty("params"))
+                object.params = options.bytes === String ? $util.base64.encode(message.params, 0, message.params.length) : options.bytes === Array ? Array.prototype.slice.call(message.params) : message.params;
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                object.meta = message.meta;
+            if (message.timeout != null && message.hasOwnProperty("timeout"))
+                object.timeout = options.json && !isFinite(message.timeout) ? String(message.timeout) : message.timeout;
+            if (message.level != null && message.hasOwnProperty("level"))
+                object.level = message.level;
+            if (message.metrics != null && message.hasOwnProperty("metrics"))
+                object.metrics = message.metrics;
+            if (message.parentID != null && message.hasOwnProperty("parentID"))
+                object.parentID = message.parentID;
+            if (message.requestID != null && message.hasOwnProperty("requestID"))
+                object.requestID = message.requestID;
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                object.stream = message.stream;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketRequest to JSON.
          * @function toJSON
          * @memberof packets.PacketRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketRequest.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketRequest;
-	})();
+        return PacketRequest;
+    })();
 
-	packets.PacketResponse = (function() {
+    packets.PacketResponse = (function() {
 
-		/**
+        /**
          * Properties of a PacketResponse.
          * @memberof packets
          * @interface IPacketResponse
-         * @property {string} ver PacketResponse ver
-         * @property {string} sender PacketResponse sender
-         * @property {string} id PacketResponse id
-         * @property {boolean} success PacketResponse success
+         * @property {string|null} [ver] PacketResponse ver
+         * @property {string|null} [sender] PacketResponse sender
+         * @property {string|null} [id] PacketResponse id
+         * @property {boolean|null} [success] PacketResponse success
          * @property {Uint8Array|null} [data] PacketResponse data
          * @property {string|null} [error] PacketResponse error
-         * @property {string} meta PacketResponse meta
+         * @property {string|null} [meta] PacketResponse meta
          * @property {boolean|null} [stream] PacketResponse stream
          */
 
-		/**
+        /**
          * Constructs a new PacketResponse.
          * @memberof packets
          * @classdesc Represents a PacketResponse.
@@ -797,78 +796,78 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketResponse=} [properties] Properties to set
          */
-		function PacketResponse(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketResponse ver.
          * @member {string} ver
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.ver = "";
+        PacketResponse.prototype.ver = "";
 
-		/**
+        /**
          * PacketResponse sender.
          * @member {string} sender
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.sender = "";
+        PacketResponse.prototype.sender = "";
 
-		/**
+        /**
          * PacketResponse id.
          * @member {string} id
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.id = "";
+        PacketResponse.prototype.id = "";
 
-		/**
+        /**
          * PacketResponse success.
          * @member {boolean} success
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.success = false;
+        PacketResponse.prototype.success = false;
 
-		/**
+        /**
          * PacketResponse data.
          * @member {Uint8Array} data
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.data = $util.newBuffer([]);
+        PacketResponse.prototype.data = $util.newBuffer([]);
 
-		/**
+        /**
          * PacketResponse error.
          * @member {string} error
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.error = "";
+        PacketResponse.prototype.error = "";
 
-		/**
+        /**
          * PacketResponse meta.
          * @member {string} meta
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.meta = "";
+        PacketResponse.prototype.meta = "";
 
-		/**
+        /**
          * PacketResponse stream.
          * @member {boolean} stream
          * @memberof packets.PacketResponse
          * @instance
          */
-		PacketResponse.prototype.stream = false;
+        PacketResponse.prototype.stream = false;
 
-		/**
+        /**
          * Creates a new PacketResponse instance using the specified properties.
          * @function create
          * @memberof packets.PacketResponse
@@ -876,11 +875,11 @@ $root.packets = (function() {
          * @param {packets.IPacketResponse=} [properties] Properties to set
          * @returns {packets.PacketResponse} PacketResponse instance
          */
-		PacketResponse.create = function create(properties) {
-			return new PacketResponse(properties);
-		};
+        PacketResponse.create = function create(properties) {
+            return new PacketResponse(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketResponse message. Does not implicitly {@link packets.PacketResponse.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketResponse
@@ -889,24 +888,29 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketResponse.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
-			writer.uint32(/* id 4, wireType 0 =*/32).bool(message.success);
-			if (message.data != null && message.hasOwnProperty("data"))
-				writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.data);
-			if (message.error != null && message.hasOwnProperty("error"))
-				writer.uint32(/* id 6, wireType 2 =*/50).string(message.error);
-			writer.uint32(/* id 7, wireType 2 =*/58).string(message.meta);
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				writer.uint32(/* id 8, wireType 0 =*/64).bool(message.stream);
-			return writer;
-		};
+        PacketResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.id != null && message.hasOwnProperty("id"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.id);
+            if (message.success != null && message.hasOwnProperty("success"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.success);
+            if (message.data != null && message.hasOwnProperty("data"))
+                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.data);
+            if (message.error != null && message.hasOwnProperty("error"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.error);
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                writer.uint32(/* id 7, wireType 2 =*/58).string(message.meta);
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.stream);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketResponse message, length delimited. Does not implicitly {@link packets.PacketResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketResponse
@@ -915,11 +919,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketResponse.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketResponse message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketResponse
@@ -930,56 +934,46 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketResponse.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketResponse();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.id = reader.string();
-						break;
-					case 4:
-						message.success = reader.bool();
-						break;
-					case 5:
-						message.data = reader.bytes();
-						break;
-					case 6:
-						message.error = reader.string();
-						break;
-					case 7:
-						message.meta = reader.string();
-						break;
-					case 8:
-						message.stream = reader.bool();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("id"))
-				throw $util.ProtocolError("missing required 'id'", { instance: message });
-			if (!message.hasOwnProperty("success"))
-				throw $util.ProtocolError("missing required 'success'", { instance: message });
-			if (!message.hasOwnProperty("meta"))
-				throw $util.ProtocolError("missing required 'meta'", { instance: message });
-			return message;
-		};
+        PacketResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.id = reader.string();
+                    break;
+                case 4:
+                    message.success = reader.bool();
+                    break;
+                case 5:
+                    message.data = reader.bytes();
+                    break;
+                case 6:
+                    message.error = reader.string();
+                    break;
+                case 7:
+                    message.meta = reader.string();
+                    break;
+                case 8:
+                    message.stream = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketResponse
@@ -989,13 +983,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketResponse.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketResponse message.
          * @function verify
          * @memberof packets.PacketResponse
@@ -1003,32 +997,37 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketResponse.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.id))
-				return "id: string expected";
-			if (typeof message.success !== "boolean")
-				return "success: boolean expected";
-			if (message.data != null && message.hasOwnProperty("data"))
-				if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
-					return "data: buffer expected";
-			if (message.error != null && message.hasOwnProperty("error"))
-				if (!$util.isString(message.error))
-					return "error: string expected";
-			if (!$util.isString(message.meta))
-				return "meta: string expected";
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				if (typeof message.stream !== "boolean")
-					return "stream: boolean expected";
-			return null;
-		};
+        PacketResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.success != null && message.hasOwnProperty("success"))
+                if (typeof message.success !== "boolean")
+                    return "success: boolean expected";
+            if (message.data != null && message.hasOwnProperty("data"))
+                if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
+                    return "data: buffer expected";
+            if (message.error != null && message.hasOwnProperty("error"))
+                if (!$util.isString(message.error))
+                    return "error: string expected";
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                if (!$util.isString(message.meta))
+                    return "meta: string expected";
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                if (typeof message.stream !== "boolean")
+                    return "stream: boolean expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketResponse
@@ -1036,33 +1035,33 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketResponse} PacketResponse
          */
-		PacketResponse.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketResponse)
-				return object;
-			var message = new $root.packets.PacketResponse();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.id != null)
-				message.id = String(object.id);
-			if (object.success != null)
-				message.success = Boolean(object.success);
-			if (object.data != null)
-				if (typeof object.data === "string")
-					$util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
-				else if (object.data.length)
-					message.data = object.data;
-			if (object.error != null)
-				message.error = String(object.error);
-			if (object.meta != null)
-				message.meta = String(object.meta);
-			if (object.stream != null)
-				message.stream = Boolean(object.stream);
-			return message;
-		};
+        PacketResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketResponse)
+                return object;
+            var message = new $root.packets.PacketResponse();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.success != null)
+                message.success = Boolean(object.success);
+            if (object.data != null)
+                if (typeof object.data === "string")
+                    $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
+                else if (object.data.length)
+                    message.data = object.data;
+            if (object.error != null)
+                message.error = String(object.error);
+            if (object.meta != null)
+                message.meta = String(object.meta);
+            if (object.stream != null)
+                message.stream = Boolean(object.stream);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketResponse
@@ -1071,70 +1070,70 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketResponse.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.id = "";
-				object.success = false;
-				if (options.bytes === String)
-					object.data = "";
-				else {
-					object.data = [];
-					if (options.bytes !== Array)
-						object.data = $util.newBuffer(object.data);
-				}
-				object.error = "";
-				object.meta = "";
-				object.stream = false;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.id != null && message.hasOwnProperty("id"))
-				object.id = message.id;
-			if (message.success != null && message.hasOwnProperty("success"))
-				object.success = message.success;
-			if (message.data != null && message.hasOwnProperty("data"))
-				object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
-			if (message.error != null && message.hasOwnProperty("error"))
-				object.error = message.error;
-			if (message.meta != null && message.hasOwnProperty("meta"))
-				object.meta = message.meta;
-			if (message.stream != null && message.hasOwnProperty("stream"))
-				object.stream = message.stream;
-			return object;
-		};
+        PacketResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.id = "";
+                object.success = false;
+                if (options.bytes === String)
+                    object.data = "";
+                else {
+                    object.data = [];
+                    if (options.bytes !== Array)
+                        object.data = $util.newBuffer(object.data);
+                }
+                object.error = "";
+                object.meta = "";
+                object.stream = false;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.success != null && message.hasOwnProperty("success"))
+                object.success = message.success;
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
+            if (message.error != null && message.hasOwnProperty("error"))
+                object.error = message.error;
+            if (message.meta != null && message.hasOwnProperty("meta"))
+                object.meta = message.meta;
+            if (message.stream != null && message.hasOwnProperty("stream"))
+                object.stream = message.stream;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketResponse to JSON.
          * @function toJSON
          * @memberof packets.PacketResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketResponse.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketResponse;
-	})();
+        return PacketResponse;
+    })();
 
-	packets.PacketDiscover = (function() {
+    packets.PacketDiscover = (function() {
 
-		/**
+        /**
          * Properties of a PacketDiscover.
          * @memberof packets
          * @interface IPacketDiscover
-         * @property {string} ver PacketDiscover ver
-         * @property {string} sender PacketDiscover sender
+         * @property {string|null} [ver] PacketDiscover ver
+         * @property {string|null} [sender] PacketDiscover sender
          */
 
-		/**
+        /**
          * Constructs a new PacketDiscover.
          * @memberof packets
          * @classdesc Represents a PacketDiscover.
@@ -1142,30 +1141,30 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketDiscover=} [properties] Properties to set
          */
-		function PacketDiscover(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketDiscover(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketDiscover ver.
          * @member {string} ver
          * @memberof packets.PacketDiscover
          * @instance
          */
-		PacketDiscover.prototype.ver = "";
+        PacketDiscover.prototype.ver = "";
 
-		/**
+        /**
          * PacketDiscover sender.
          * @member {string} sender
          * @memberof packets.PacketDiscover
          * @instance
          */
-		PacketDiscover.prototype.sender = "";
+        PacketDiscover.prototype.sender = "";
 
-		/**
+        /**
          * Creates a new PacketDiscover instance using the specified properties.
          * @function create
          * @memberof packets.PacketDiscover
@@ -1173,11 +1172,11 @@ $root.packets = (function() {
          * @param {packets.IPacketDiscover=} [properties] Properties to set
          * @returns {packets.PacketDiscover} PacketDiscover instance
          */
-		PacketDiscover.create = function create(properties) {
-			return new PacketDiscover(properties);
-		};
+        PacketDiscover.create = function create(properties) {
+            return new PacketDiscover(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDiscover message. Does not implicitly {@link packets.PacketDiscover.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketDiscover
@@ -1186,15 +1185,17 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDiscover.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			return writer;
-		};
+        PacketDiscover.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDiscover message, length delimited. Does not implicitly {@link packets.PacketDiscover.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketDiscover
@@ -1203,11 +1204,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDiscover.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketDiscover.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketDiscover message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketDiscover
@@ -1218,32 +1219,28 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDiscover.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDiscover();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketDiscover.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDiscover();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketDiscover message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketDiscover
@@ -1253,13 +1250,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDiscover.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketDiscover.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketDiscover message.
          * @function verify
          * @memberof packets.PacketDiscover
@@ -1267,17 +1264,19 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketDiscover.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			return null;
-		};
+        PacketDiscover.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketDiscover message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketDiscover
@@ -1285,18 +1284,18 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketDiscover} PacketDiscover
          */
-		PacketDiscover.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketDiscover)
-				return object;
-			var message = new $root.packets.PacketDiscover();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			return message;
-		};
+        PacketDiscover.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketDiscover)
+                return object;
+            var message = new $root.packets.PacketDiscover();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketDiscover message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketDiscover
@@ -1305,52 +1304,52 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketDiscover.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			return object;
-		};
+        PacketDiscover.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketDiscover to JSON.
          * @function toJSON
          * @memberof packets.PacketDiscover
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketDiscover.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketDiscover.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketDiscover;
-	})();
+        return PacketDiscover;
+    })();
 
-	packets.PacketInfo = (function() {
+    packets.PacketInfo = (function() {
 
-		/**
+        /**
          * Properties of a PacketInfo.
          * @memberof packets
          * @interface IPacketInfo
-         * @property {string} ver PacketInfo ver
-         * @property {string} sender PacketInfo sender
-         * @property {string} services PacketInfo services
-         * @property {string} config PacketInfo config
+         * @property {string|null} [ver] PacketInfo ver
+         * @property {string|null} [sender] PacketInfo sender
+         * @property {string|null} [services] PacketInfo services
+         * @property {string|null} [config] PacketInfo config
          * @property {Array.<string>|null} [ipList] PacketInfo ipList
-         * @property {string} hostname PacketInfo hostname
-         * @property {packets.PacketInfo.IClient} client PacketInfo client
+         * @property {string|null} [hostname] PacketInfo hostname
+         * @property {packets.PacketInfo.IClient|null} [client] PacketInfo client
          * @property {number|null} [seq] PacketInfo seq
          */
 
-		/**
+        /**
          * Constructs a new PacketInfo.
          * @memberof packets
          * @classdesc Represents a PacketInfo.
@@ -1358,79 +1357,79 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketInfo=} [properties] Properties to set
          */
-		function PacketInfo(properties) {
-			this.ipList = [];
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketInfo(properties) {
+            this.ipList = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketInfo ver.
          * @member {string} ver
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.ver = "";
+        PacketInfo.prototype.ver = "";
 
-		/**
+        /**
          * PacketInfo sender.
          * @member {string} sender
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.sender = "";
+        PacketInfo.prototype.sender = "";
 
-		/**
+        /**
          * PacketInfo services.
          * @member {string} services
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.services = "";
+        PacketInfo.prototype.services = "";
 
-		/**
+        /**
          * PacketInfo config.
          * @member {string} config
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.config = "";
+        PacketInfo.prototype.config = "";
 
-		/**
+        /**
          * PacketInfo ipList.
          * @member {Array.<string>} ipList
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.ipList = $util.emptyArray;
+        PacketInfo.prototype.ipList = $util.emptyArray;
 
-		/**
+        /**
          * PacketInfo hostname.
          * @member {string} hostname
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.hostname = "";
+        PacketInfo.prototype.hostname = "";
 
-		/**
+        /**
          * PacketInfo client.
-         * @member {packets.PacketInfo.IClient} client
+         * @member {packets.PacketInfo.IClient|null|undefined} client
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.client = null;
+        PacketInfo.prototype.client = null;
 
-		/**
+        /**
          * PacketInfo seq.
          * @member {number} seq
          * @memberof packets.PacketInfo
          * @instance
          */
-		PacketInfo.prototype.seq = 0;
+        PacketInfo.prototype.seq = 0;
 
-		/**
+        /**
          * Creates a new PacketInfo instance using the specified properties.
          * @function create
          * @memberof packets.PacketInfo
@@ -1438,11 +1437,11 @@ $root.packets = (function() {
          * @param {packets.IPacketInfo=} [properties] Properties to set
          * @returns {packets.PacketInfo} PacketInfo instance
          */
-		PacketInfo.create = function create(properties) {
-			return new PacketInfo(properties);
-		};
+        PacketInfo.create = function create(properties) {
+            return new PacketInfo(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketInfo message. Does not implicitly {@link packets.PacketInfo.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketInfo
@@ -1451,24 +1450,30 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketInfo.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.services);
-			writer.uint32(/* id 4, wireType 2 =*/34).string(message.config);
-			if (message.ipList != null && message.ipList.length)
-				for (var i = 0; i < message.ipList.length; ++i)
-					writer.uint32(/* id 5, wireType 2 =*/42).string(message.ipList[i]);
-			writer.uint32(/* id 6, wireType 2 =*/50).string(message.hostname);
-			$root.packets.PacketInfo.Client.encode(message.client, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
-			if (message.seq != null && message.hasOwnProperty("seq"))
-				writer.uint32(/* id 8, wireType 0 =*/64).int32(message.seq);
-			return writer;
-		};
+        PacketInfo.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.services != null && message.hasOwnProperty("services"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.services);
+            if (message.config != null && message.hasOwnProperty("config"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.config);
+            if (message.ipList != null && message.ipList.length)
+                for (var i = 0; i < message.ipList.length; ++i)
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.ipList[i]);
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.hostname);
+            if (message.client != null && message.hasOwnProperty("client"))
+                $root.packets.PacketInfo.Client.encode(message.client, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+            if (message.seq != null && message.hasOwnProperty("seq"))
+                writer.uint32(/* id 8, wireType 0 =*/64).int32(message.seq);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketInfo message, length delimited. Does not implicitly {@link packets.PacketInfo.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketInfo
@@ -1477,11 +1482,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketInfo.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketInfo.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketInfo message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketInfo
@@ -1492,60 +1497,48 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketInfo.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.services = reader.string();
-						break;
-					case 4:
-						message.config = reader.string();
-						break;
-					case 5:
-						if (!(message.ipList && message.ipList.length))
-							message.ipList = [];
-						message.ipList.push(reader.string());
-						break;
-					case 6:
-						message.hostname = reader.string();
-						break;
-					case 7:
-						message.client = $root.packets.PacketInfo.Client.decode(reader, reader.uint32());
-						break;
-					case 8:
-						message.seq = reader.int32();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("services"))
-				throw $util.ProtocolError("missing required 'services'", { instance: message });
-			if (!message.hasOwnProperty("config"))
-				throw $util.ProtocolError("missing required 'config'", { instance: message });
-			if (!message.hasOwnProperty("hostname"))
-				throw $util.ProtocolError("missing required 'hostname'", { instance: message });
-			if (!message.hasOwnProperty("client"))
-				throw $util.ProtocolError("missing required 'client'", { instance: message });
-			return message;
-		};
+        PacketInfo.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.services = reader.string();
+                    break;
+                case 4:
+                    message.config = reader.string();
+                    break;
+                case 5:
+                    if (!(message.ipList && message.ipList.length))
+                        message.ipList = [];
+                    message.ipList.push(reader.string());
+                    break;
+                case 6:
+                    message.hostname = reader.string();
+                    break;
+                case 7:
+                    message.client = $root.packets.PacketInfo.Client.decode(reader, reader.uint32());
+                    break;
+                case 8:
+                    message.seq = reader.int32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketInfo message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketInfo
@@ -1555,13 +1548,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketInfo.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketInfo.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketInfo message.
          * @function verify
          * @memberof packets.PacketInfo
@@ -1569,38 +1562,43 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketInfo.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.services))
-				return "services: string expected";
-			if (!$util.isString(message.config))
-				return "config: string expected";
-			if (message.ipList != null && message.hasOwnProperty("ipList")) {
-				if (!Array.isArray(message.ipList))
-					return "ipList: array expected";
-				for (var i = 0; i < message.ipList.length; ++i)
-					if (!$util.isString(message.ipList[i]))
-						return "ipList: string[] expected";
-			}
-			if (!$util.isString(message.hostname))
-				return "hostname: string expected";
-			{
-				var error = $root.packets.PacketInfo.Client.verify(message.client);
-				if (error)
-					return "client." + error;
-			}
-			if (message.seq != null && message.hasOwnProperty("seq"))
-				if (!$util.isInteger(message.seq))
-					return "seq: integer expected";
-			return null;
-		};
+        PacketInfo.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.services != null && message.hasOwnProperty("services"))
+                if (!$util.isString(message.services))
+                    return "services: string expected";
+            if (message.config != null && message.hasOwnProperty("config"))
+                if (!$util.isString(message.config))
+                    return "config: string expected";
+            if (message.ipList != null && message.hasOwnProperty("ipList")) {
+                if (!Array.isArray(message.ipList))
+                    return "ipList: array expected";
+                for (var i = 0; i < message.ipList.length; ++i)
+                    if (!$util.isString(message.ipList[i]))
+                        return "ipList: string[] expected";
+            }
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                if (!$util.isString(message.hostname))
+                    return "hostname: string expected";
+            if (message.client != null && message.hasOwnProperty("client")) {
+                var error = $root.packets.PacketInfo.Client.verify(message.client);
+                if (error)
+                    return "client." + error;
+            }
+            if (message.seq != null && message.hasOwnProperty("seq"))
+                if (!$util.isInteger(message.seq))
+                    return "seq: integer expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketInfo message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketInfo
@@ -1608,38 +1606,38 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketInfo} PacketInfo
          */
-		PacketInfo.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketInfo)
-				return object;
-			var message = new $root.packets.PacketInfo();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.services != null)
-				message.services = String(object.services);
-			if (object.config != null)
-				message.config = String(object.config);
-			if (object.ipList) {
-				if (!Array.isArray(object.ipList))
-					throw TypeError(".packets.PacketInfo.ipList: array expected");
-				message.ipList = [];
-				for (var i = 0; i < object.ipList.length; ++i)
-					message.ipList[i] = String(object.ipList[i]);
-			}
-			if (object.hostname != null)
-				message.hostname = String(object.hostname);
-			if (object.client != null) {
-				if (typeof object.client !== "object")
-					throw TypeError(".packets.PacketInfo.client: object expected");
-				message.client = $root.packets.PacketInfo.Client.fromObject(object.client);
-			}
-			if (object.seq != null)
-				message.seq = object.seq | 0;
-			return message;
-		};
+        PacketInfo.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketInfo)
+                return object;
+            var message = new $root.packets.PacketInfo();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.services != null)
+                message.services = String(object.services);
+            if (object.config != null)
+                message.config = String(object.config);
+            if (object.ipList) {
+                if (!Array.isArray(object.ipList))
+                    throw TypeError(".packets.PacketInfo.ipList: array expected");
+                message.ipList = [];
+                for (var i = 0; i < object.ipList.length; ++i)
+                    message.ipList[i] = String(object.ipList[i]);
+            }
+            if (object.hostname != null)
+                message.hostname = String(object.hostname);
+            if (object.client != null) {
+                if (typeof object.client !== "object")
+                    throw TypeError(".packets.PacketInfo.client: object expected");
+                message.client = $root.packets.PacketInfo.Client.fromObject(object.client);
+            }
+            if (object.seq != null)
+                message.seq = object.seq | 0;
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketInfo message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketInfo
@@ -1648,66 +1646,66 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketInfo.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.arrays || options.defaults)
-				object.ipList = [];
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.services = "";
-				object.config = "";
-				object.hostname = "";
-				object.client = null;
-				object.seq = 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.services != null && message.hasOwnProperty("services"))
-				object.services = message.services;
-			if (message.config != null && message.hasOwnProperty("config"))
-				object.config = message.config;
-			if (message.ipList && message.ipList.length) {
-				object.ipList = [];
-				for (var j = 0; j < message.ipList.length; ++j)
-					object.ipList[j] = message.ipList[j];
-			}
-			if (message.hostname != null && message.hasOwnProperty("hostname"))
-				object.hostname = message.hostname;
-			if (message.client != null && message.hasOwnProperty("client"))
-				object.client = $root.packets.PacketInfo.Client.toObject(message.client, options);
-			if (message.seq != null && message.hasOwnProperty("seq"))
-				object.seq = message.seq;
-			return object;
-		};
+        PacketInfo.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.ipList = [];
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.services = "";
+                object.config = "";
+                object.hostname = "";
+                object.client = null;
+                object.seq = 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.services != null && message.hasOwnProperty("services"))
+                object.services = message.services;
+            if (message.config != null && message.hasOwnProperty("config"))
+                object.config = message.config;
+            if (message.ipList && message.ipList.length) {
+                object.ipList = [];
+                for (var j = 0; j < message.ipList.length; ++j)
+                    object.ipList[j] = message.ipList[j];
+            }
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                object.hostname = message.hostname;
+            if (message.client != null && message.hasOwnProperty("client"))
+                object.client = $root.packets.PacketInfo.Client.toObject(message.client, options);
+            if (message.seq != null && message.hasOwnProperty("seq"))
+                object.seq = message.seq;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketInfo to JSON.
          * @function toJSON
          * @memberof packets.PacketInfo
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketInfo.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketInfo.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		PacketInfo.Client = (function() {
+        PacketInfo.Client = (function() {
 
-			/**
+            /**
              * Properties of a Client.
              * @memberof packets.PacketInfo
              * @interface IClient
-             * @property {string} type Client type
-             * @property {string} version Client version
-             * @property {string} langVersion Client langVersion
+             * @property {string|null} [type] Client type
+             * @property {string|null} [version] Client version
+             * @property {string|null} [langVersion] Client langVersion
              */
 
-			/**
+            /**
              * Constructs a new Client.
              * @memberof packets.PacketInfo
              * @classdesc Represents a Client.
@@ -1715,38 +1713,38 @@ $root.packets = (function() {
              * @constructor
              * @param {packets.PacketInfo.IClient=} [properties] Properties to set
              */
-			function Client(properties) {
-				if (properties)
-					for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-						if (properties[keys[i]] != null)
-							this[keys[i]] = properties[keys[i]];
-			}
+            function Client(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
 
-			/**
+            /**
              * Client type.
              * @member {string} type
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-			Client.prototype.type = "";
+            Client.prototype.type = "";
 
-			/**
+            /**
              * Client version.
              * @member {string} version
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-			Client.prototype.version = "";
+            Client.prototype.version = "";
 
-			/**
+            /**
              * Client langVersion.
              * @member {string} langVersion
              * @memberof packets.PacketInfo.Client
              * @instance
              */
-			Client.prototype.langVersion = "";
+            Client.prototype.langVersion = "";
 
-			/**
+            /**
              * Creates a new Client instance using the specified properties.
              * @function create
              * @memberof packets.PacketInfo.Client
@@ -1754,11 +1752,11 @@ $root.packets = (function() {
              * @param {packets.PacketInfo.IClient=} [properties] Properties to set
              * @returns {packets.PacketInfo.Client} Client instance
              */
-			Client.create = function create(properties) {
-				return new Client(properties);
-			};
+            Client.create = function create(properties) {
+                return new Client(properties);
+            };
 
-			/**
+            /**
              * Encodes the specified Client message. Does not implicitly {@link packets.PacketInfo.Client.verify|verify} messages.
              * @function encode
              * @memberof packets.PacketInfo.Client
@@ -1767,16 +1765,19 @@ $root.packets = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-			Client.encode = function encode(message, writer) {
-				if (!writer)
-					writer = $Writer.create();
-				writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-				writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
-				writer.uint32(/* id 3, wireType 2 =*/26).string(message.langVersion);
-				return writer;
-			};
+            Client.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.type != null && message.hasOwnProperty("type"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
+                if (message.version != null && message.hasOwnProperty("version"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
+                if (message.langVersion != null && message.hasOwnProperty("langVersion"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.langVersion);
+                return writer;
+            };
 
-			/**
+            /**
              * Encodes the specified Client message, length delimited. Does not implicitly {@link packets.PacketInfo.Client.verify|verify} messages.
              * @function encodeDelimited
              * @memberof packets.PacketInfo.Client
@@ -1785,11 +1786,11 @@ $root.packets = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-			Client.encodeDelimited = function encodeDelimited(message, writer) {
-				return this.encode(message, writer).ldelim();
-			};
+            Client.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
 
-			/**
+            /**
              * Decodes a Client message from the specified reader or buffer.
              * @function decode
              * @memberof packets.PacketInfo.Client
@@ -1800,37 +1801,31 @@ $root.packets = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-			Client.decode = function decode(reader, length) {
-				if (!(reader instanceof $Reader))
-					reader = $Reader.create(reader);
-				var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo.Client();
-				while (reader.pos < end) {
-					var tag = reader.uint32();
-					switch (tag >>> 3) {
-						case 1:
-							message.type = reader.string();
-							break;
-						case 2:
-							message.version = reader.string();
-							break;
-						case 3:
-							message.langVersion = reader.string();
-							break;
-						default:
-							reader.skipType(tag & 7);
-							break;
-					}
-				}
-				if (!message.hasOwnProperty("type"))
-					throw $util.ProtocolError("missing required 'type'", { instance: message });
-				if (!message.hasOwnProperty("version"))
-					throw $util.ProtocolError("missing required 'version'", { instance: message });
-				if (!message.hasOwnProperty("langVersion"))
-					throw $util.ProtocolError("missing required 'langVersion'", { instance: message });
-				return message;
-			};
+            Client.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketInfo.Client();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.type = reader.string();
+                        break;
+                    case 2:
+                        message.version = reader.string();
+                        break;
+                    case 3:
+                        message.langVersion = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
 
-			/**
+            /**
              * Decodes a Client message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
              * @memberof packets.PacketInfo.Client
@@ -1840,13 +1835,13 @@ $root.packets = (function() {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-			Client.decodeDelimited = function decodeDelimited(reader) {
-				if (!(reader instanceof $Reader))
-					reader = new $Reader(reader);
-				return this.decode(reader, reader.uint32());
-			};
+            Client.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
 
-			/**
+            /**
              * Verifies a Client message.
              * @function verify
              * @memberof packets.PacketInfo.Client
@@ -1854,19 +1849,22 @@ $root.packets = (function() {
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-			Client.verify = function verify(message) {
-				if (typeof message !== "object" || message === null)
-					return "object expected";
-				if (!$util.isString(message.type))
-					return "type: string expected";
-				if (!$util.isString(message.version))
-					return "version: string expected";
-				if (!$util.isString(message.langVersion))
-					return "langVersion: string expected";
-				return null;
-			};
+            Client.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.type != null && message.hasOwnProperty("type"))
+                    if (!$util.isString(message.type))
+                        return "type: string expected";
+                if (message.version != null && message.hasOwnProperty("version"))
+                    if (!$util.isString(message.version))
+                        return "version: string expected";
+                if (message.langVersion != null && message.hasOwnProperty("langVersion"))
+                    if (!$util.isString(message.langVersion))
+                        return "langVersion: string expected";
+                return null;
+            };
 
-			/**
+            /**
              * Creates a Client message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
              * @memberof packets.PacketInfo.Client
@@ -1874,20 +1872,20 @@ $root.packets = (function() {
              * @param {Object.<string,*>} object Plain object
              * @returns {packets.PacketInfo.Client} Client
              */
-			Client.fromObject = function fromObject(object) {
-				if (object instanceof $root.packets.PacketInfo.Client)
-					return object;
-				var message = new $root.packets.PacketInfo.Client();
-				if (object.type != null)
-					message.type = String(object.type);
-				if (object.version != null)
-					message.version = String(object.version);
-				if (object.langVersion != null)
-					message.langVersion = String(object.langVersion);
-				return message;
-			};
+            Client.fromObject = function fromObject(object) {
+                if (object instanceof $root.packets.PacketInfo.Client)
+                    return object;
+                var message = new $root.packets.PacketInfo.Client();
+                if (object.type != null)
+                    message.type = String(object.type);
+                if (object.version != null)
+                    message.version = String(object.version);
+                if (object.langVersion != null)
+                    message.langVersion = String(object.langVersion);
+                return message;
+            };
 
-			/**
+            /**
              * Creates a plain object from a Client message. Also converts values to other types if specified.
              * @function toObject
              * @memberof packets.PacketInfo.Client
@@ -1896,52 +1894,52 @@ $root.packets = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-			Client.toObject = function toObject(message, options) {
-				if (!options)
-					options = {};
-				var object = {};
-				if (options.defaults) {
-					object.type = "";
-					object.version = "";
-					object.langVersion = "";
-				}
-				if (message.type != null && message.hasOwnProperty("type"))
-					object.type = message.type;
-				if (message.version != null && message.hasOwnProperty("version"))
-					object.version = message.version;
-				if (message.langVersion != null && message.hasOwnProperty("langVersion"))
-					object.langVersion = message.langVersion;
-				return object;
-			};
+            Client.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.type = "";
+                    object.version = "";
+                    object.langVersion = "";
+                }
+                if (message.type != null && message.hasOwnProperty("type"))
+                    object.type = message.type;
+                if (message.version != null && message.hasOwnProperty("version"))
+                    object.version = message.version;
+                if (message.langVersion != null && message.hasOwnProperty("langVersion"))
+                    object.langVersion = message.langVersion;
+                return object;
+            };
 
-			/**
+            /**
              * Converts this Client to JSON.
              * @function toJSON
              * @memberof packets.PacketInfo.Client
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-			Client.prototype.toJSON = function toJSON() {
-				return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-			};
+            Client.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
 
-			return Client;
-		})();
+            return Client;
+        })();
 
-		return PacketInfo;
-	})();
+        return PacketInfo;
+    })();
 
-	packets.PacketDisconnect = (function() {
+    packets.PacketDisconnect = (function() {
 
-		/**
+        /**
          * Properties of a PacketDisconnect.
          * @memberof packets
          * @interface IPacketDisconnect
-         * @property {string} ver PacketDisconnect ver
-         * @property {string} sender PacketDisconnect sender
+         * @property {string|null} [ver] PacketDisconnect ver
+         * @property {string|null} [sender] PacketDisconnect sender
          */
 
-		/**
+        /**
          * Constructs a new PacketDisconnect.
          * @memberof packets
          * @classdesc Represents a PacketDisconnect.
@@ -1949,30 +1947,30 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketDisconnect=} [properties] Properties to set
          */
-		function PacketDisconnect(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketDisconnect(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketDisconnect ver.
          * @member {string} ver
          * @memberof packets.PacketDisconnect
          * @instance
          */
-		PacketDisconnect.prototype.ver = "";
+        PacketDisconnect.prototype.ver = "";
 
-		/**
+        /**
          * PacketDisconnect sender.
          * @member {string} sender
          * @memberof packets.PacketDisconnect
          * @instance
          */
-		PacketDisconnect.prototype.sender = "";
+        PacketDisconnect.prototype.sender = "";
 
-		/**
+        /**
          * Creates a new PacketDisconnect instance using the specified properties.
          * @function create
          * @memberof packets.PacketDisconnect
@@ -1980,11 +1978,11 @@ $root.packets = (function() {
          * @param {packets.IPacketDisconnect=} [properties] Properties to set
          * @returns {packets.PacketDisconnect} PacketDisconnect instance
          */
-		PacketDisconnect.create = function create(properties) {
-			return new PacketDisconnect(properties);
-		};
+        PacketDisconnect.create = function create(properties) {
+            return new PacketDisconnect(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDisconnect message. Does not implicitly {@link packets.PacketDisconnect.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketDisconnect
@@ -1993,15 +1991,17 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDisconnect.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			return writer;
-		};
+        PacketDisconnect.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketDisconnect message, length delimited. Does not implicitly {@link packets.PacketDisconnect.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketDisconnect
@@ -2010,11 +2010,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketDisconnect.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketDisconnect.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketDisconnect message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketDisconnect
@@ -2025,32 +2025,28 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDisconnect.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDisconnect();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketDisconnect.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketDisconnect();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketDisconnect message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketDisconnect
@@ -2060,13 +2056,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketDisconnect.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketDisconnect.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketDisconnect message.
          * @function verify
          * @memberof packets.PacketDisconnect
@@ -2074,17 +2070,19 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketDisconnect.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			return null;
-		};
+        PacketDisconnect.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketDisconnect message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketDisconnect
@@ -2092,18 +2090,18 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketDisconnect} PacketDisconnect
          */
-		PacketDisconnect.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketDisconnect)
-				return object;
-			var message = new $root.packets.PacketDisconnect();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			return message;
-		};
+        PacketDisconnect.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketDisconnect)
+                return object;
+            var message = new $root.packets.PacketDisconnect();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketDisconnect message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketDisconnect
@@ -2112,47 +2110,47 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketDisconnect.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			return object;
-		};
+        PacketDisconnect.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketDisconnect to JSON.
          * @function toJSON
          * @memberof packets.PacketDisconnect
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketDisconnect.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketDisconnect.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketDisconnect;
-	})();
+        return PacketDisconnect;
+    })();
 
-	packets.PacketHeartbeat = (function() {
+    packets.PacketHeartbeat = (function() {
 
-		/**
+        /**
          * Properties of a PacketHeartbeat.
          * @memberof packets
          * @interface IPacketHeartbeat
-         * @property {string} ver PacketHeartbeat ver
-         * @property {string} sender PacketHeartbeat sender
-         * @property {number} cpu PacketHeartbeat cpu
+         * @property {string|null} [ver] PacketHeartbeat ver
+         * @property {string|null} [sender] PacketHeartbeat sender
+         * @property {number|null} [cpu] PacketHeartbeat cpu
          */
 
-		/**
+        /**
          * Constructs a new PacketHeartbeat.
          * @memberof packets
          * @classdesc Represents a PacketHeartbeat.
@@ -2160,38 +2158,38 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketHeartbeat=} [properties] Properties to set
          */
-		function PacketHeartbeat(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketHeartbeat(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketHeartbeat ver.
          * @member {string} ver
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-		PacketHeartbeat.prototype.ver = "";
+        PacketHeartbeat.prototype.ver = "";
 
-		/**
+        /**
          * PacketHeartbeat sender.
          * @member {string} sender
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-		PacketHeartbeat.prototype.sender = "";
+        PacketHeartbeat.prototype.sender = "";
 
-		/**
+        /**
          * PacketHeartbeat cpu.
          * @member {number} cpu
          * @memberof packets.PacketHeartbeat
          * @instance
          */
-		PacketHeartbeat.prototype.cpu = 0;
+        PacketHeartbeat.prototype.cpu = 0;
 
-		/**
+        /**
          * Creates a new PacketHeartbeat instance using the specified properties.
          * @function create
          * @memberof packets.PacketHeartbeat
@@ -2199,11 +2197,11 @@ $root.packets = (function() {
          * @param {packets.IPacketHeartbeat=} [properties] Properties to set
          * @returns {packets.PacketHeartbeat} PacketHeartbeat instance
          */
-		PacketHeartbeat.create = function create(properties) {
-			return new PacketHeartbeat(properties);
-		};
+        PacketHeartbeat.create = function create(properties) {
+            return new PacketHeartbeat(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketHeartbeat message. Does not implicitly {@link packets.PacketHeartbeat.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketHeartbeat
@@ -2212,16 +2210,19 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketHeartbeat.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 1 =*/25).double(message.cpu);
-			return writer;
-		};
+        PacketHeartbeat.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.cpu != null && message.hasOwnProperty("cpu"))
+                writer.uint32(/* id 3, wireType 1 =*/25).double(message.cpu);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketHeartbeat message, length delimited. Does not implicitly {@link packets.PacketHeartbeat.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketHeartbeat
@@ -2230,11 +2231,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketHeartbeat.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketHeartbeat.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketHeartbeat message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketHeartbeat
@@ -2245,37 +2246,31 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketHeartbeat.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketHeartbeat();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.cpu = reader.double();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("cpu"))
-				throw $util.ProtocolError("missing required 'cpu'", { instance: message });
-			return message;
-		};
+        PacketHeartbeat.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketHeartbeat();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.cpu = reader.double();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketHeartbeat message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketHeartbeat
@@ -2285,13 +2280,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketHeartbeat.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketHeartbeat.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketHeartbeat message.
          * @function verify
          * @memberof packets.PacketHeartbeat
@@ -2299,19 +2294,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketHeartbeat.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (typeof message.cpu !== "number")
-				return "cpu: number expected";
-			return null;
-		};
+        PacketHeartbeat.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.cpu != null && message.hasOwnProperty("cpu"))
+                if (typeof message.cpu !== "number")
+                    return "cpu: number expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketHeartbeat message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketHeartbeat
@@ -2319,20 +2317,20 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketHeartbeat} PacketHeartbeat
          */
-		PacketHeartbeat.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketHeartbeat)
-				return object;
-			var message = new $root.packets.PacketHeartbeat();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.cpu != null)
-				message.cpu = Number(object.cpu);
-			return message;
-		};
+        PacketHeartbeat.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketHeartbeat)
+                return object;
+            var message = new $root.packets.PacketHeartbeat();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.cpu != null)
+                message.cpu = Number(object.cpu);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketHeartbeat message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketHeartbeat
@@ -2341,50 +2339,50 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketHeartbeat.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.cpu = 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.cpu != null && message.hasOwnProperty("cpu"))
-				object.cpu = options.json && !isFinite(message.cpu) ? String(message.cpu) : message.cpu;
-			return object;
-		};
+        PacketHeartbeat.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.cpu = 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.cpu != null && message.hasOwnProperty("cpu"))
+                object.cpu = options.json && !isFinite(message.cpu) ? String(message.cpu) : message.cpu;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketHeartbeat to JSON.
          * @function toJSON
          * @memberof packets.PacketHeartbeat
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketHeartbeat.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketHeartbeat.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketHeartbeat;
-	})();
+        return PacketHeartbeat;
+    })();
 
-	packets.PacketPing = (function() {
+    packets.PacketPing = (function() {
 
-		/**
+        /**
          * Properties of a PacketPing.
          * @memberof packets
          * @interface IPacketPing
-         * @property {string} ver PacketPing ver
-         * @property {string} sender PacketPing sender
-         * @property {number|Long} time PacketPing time
+         * @property {string|null} [ver] PacketPing ver
+         * @property {string|null} [sender] PacketPing sender
+         * @property {number|Long|null} [time] PacketPing time
          */
 
-		/**
+        /**
          * Constructs a new PacketPing.
          * @memberof packets
          * @classdesc Represents a PacketPing.
@@ -2392,38 +2390,38 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketPing=} [properties] Properties to set
          */
-		function PacketPing(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketPing(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketPing ver.
          * @member {string} ver
          * @memberof packets.PacketPing
          * @instance
          */
-		PacketPing.prototype.ver = "";
+        PacketPing.prototype.ver = "";
 
-		/**
+        /**
          * PacketPing sender.
          * @member {string} sender
          * @memberof packets.PacketPing
          * @instance
          */
-		PacketPing.prototype.sender = "";
+        PacketPing.prototype.sender = "";
 
-		/**
+        /**
          * PacketPing time.
          * @member {number|Long} time
          * @memberof packets.PacketPing
          * @instance
          */
-		PacketPing.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        PacketPing.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-		/**
+        /**
          * Creates a new PacketPing instance using the specified properties.
          * @function create
          * @memberof packets.PacketPing
@@ -2431,11 +2429,11 @@ $root.packets = (function() {
          * @param {packets.IPacketPing=} [properties] Properties to set
          * @returns {packets.PacketPing} PacketPing instance
          */
-		PacketPing.create = function create(properties) {
-			return new PacketPing(properties);
-		};
+        PacketPing.create = function create(properties) {
+            return new PacketPing(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPing message. Does not implicitly {@link packets.PacketPing.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketPing
@@ -2444,16 +2442,19 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPing.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
-			return writer;
-		};
+        PacketPing.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.time != null && message.hasOwnProperty("time"))
+                writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPing message, length delimited. Does not implicitly {@link packets.PacketPing.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketPing
@@ -2462,11 +2463,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPing.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketPing.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketPing message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketPing
@@ -2477,37 +2478,31 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPing.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPing();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.time = reader.int64();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("time"))
-				throw $util.ProtocolError("missing required 'time'", { instance: message });
-			return message;
-		};
+        PacketPing.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPing();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.time = reader.int64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketPing message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketPing
@@ -2517,13 +2512,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPing.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketPing.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketPing message.
          * @function verify
          * @memberof packets.PacketPing
@@ -2531,19 +2526,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketPing.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
-				return "time: integer|Long expected";
-			return null;
-		};
+        PacketPing.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.time != null && message.hasOwnProperty("time"))
+                if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
+                    return "time: integer|Long expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketPing message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketPing
@@ -2551,27 +2549,27 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketPing} PacketPing
          */
-		PacketPing.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketPing)
-				return object;
-			var message = new $root.packets.PacketPing();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.time != null)
-				if ($util.Long)
-					(message.time = $util.Long.fromValue(object.time)).unsigned = false;
-				else if (typeof object.time === "string")
-					message.time = parseInt(object.time, 10);
-				else if (typeof object.time === "number")
-					message.time = object.time;
-				else if (typeof object.time === "object")
-					message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
-			return message;
-		};
+        PacketPing.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketPing)
+                return object;
+            var message = new $root.packets.PacketPing();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.time != null)
+                if ($util.Long)
+                    (message.time = $util.Long.fromValue(object.time)).unsigned = false;
+                else if (typeof object.time === "string")
+                    message.time = parseInt(object.time, 10);
+                else if (typeof object.time === "number")
+                    message.time = object.time;
+                else if (typeof object.time === "object")
+                    message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketPing message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketPing
@@ -2580,58 +2578,58 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketPing.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				if ($util.Long) {
-					var long = new $util.Long(0, 0, false);
-					object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-				} else
-					object.time = options.longs === String ? "0" : 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.time != null && message.hasOwnProperty("time"))
-				if (typeof message.time === "number")
-					object.time = options.longs === String ? String(message.time) : message.time;
-				else
-					object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
-			return object;
-		};
+        PacketPing.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.time = options.longs === String ? "0" : 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.time != null && message.hasOwnProperty("time"))
+                if (typeof message.time === "number")
+                    object.time = options.longs === String ? String(message.time) : message.time;
+                else
+                    object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketPing to JSON.
          * @function toJSON
          * @memberof packets.PacketPing
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketPing.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketPing.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketPing;
-	})();
+        return PacketPing;
+    })();
 
-	packets.PacketPong = (function() {
+    packets.PacketPong = (function() {
 
-		/**
+        /**
          * Properties of a PacketPong.
          * @memberof packets
          * @interface IPacketPong
-         * @property {string} ver PacketPong ver
-         * @property {string} sender PacketPong sender
-         * @property {number|Long} time PacketPong time
-         * @property {number|Long} arrived PacketPong arrived
+         * @property {string|null} [ver] PacketPong ver
+         * @property {string|null} [sender] PacketPong sender
+         * @property {number|Long|null} [time] PacketPong time
+         * @property {number|Long|null} [arrived] PacketPong arrived
          */
 
-		/**
+        /**
          * Constructs a new PacketPong.
          * @memberof packets
          * @classdesc Represents a PacketPong.
@@ -2639,46 +2637,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketPong=} [properties] Properties to set
          */
-		function PacketPong(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketPong(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketPong ver.
          * @member {string} ver
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.ver = "";
+        PacketPong.prototype.ver = "";
 
-		/**
+        /**
          * PacketPong sender.
          * @member {string} sender
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.sender = "";
+        PacketPong.prototype.sender = "";
 
-		/**
+        /**
          * PacketPong time.
          * @member {number|Long} time
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        PacketPong.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-		/**
+        /**
          * PacketPong arrived.
          * @member {number|Long} arrived
          * @memberof packets.PacketPong
          * @instance
          */
-		PacketPong.prototype.arrived = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        PacketPong.prototype.arrived = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
-		/**
+        /**
          * Creates a new PacketPong instance using the specified properties.
          * @function create
          * @memberof packets.PacketPong
@@ -2686,11 +2684,11 @@ $root.packets = (function() {
          * @param {packets.IPacketPong=} [properties] Properties to set
          * @returns {packets.PacketPong} PacketPong instance
          */
-		PacketPong.create = function create(properties) {
-			return new PacketPong(properties);
-		};
+        PacketPong.create = function create(properties) {
+            return new PacketPong(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPong message. Does not implicitly {@link packets.PacketPong.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketPong
@@ -2699,17 +2697,21 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPong.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
-			writer.uint32(/* id 4, wireType 0 =*/32).int64(message.arrived);
-			return writer;
-		};
+        PacketPong.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.time != null && message.hasOwnProperty("time"))
+                writer.uint32(/* id 3, wireType 0 =*/24).int64(message.time);
+            if (message.arrived != null && message.hasOwnProperty("arrived"))
+                writer.uint32(/* id 4, wireType 0 =*/32).int64(message.arrived);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketPong message, length delimited. Does not implicitly {@link packets.PacketPong.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketPong
@@ -2718,11 +2720,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketPong.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketPong.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketPong message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketPong
@@ -2733,42 +2735,34 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPong.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPong();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.time = reader.int64();
-						break;
-					case 4:
-						message.arrived = reader.int64();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("time"))
-				throw $util.ProtocolError("missing required 'time'", { instance: message });
-			if (!message.hasOwnProperty("arrived"))
-				throw $util.ProtocolError("missing required 'arrived'", { instance: message });
-			return message;
-		};
+        PacketPong.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketPong();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.time = reader.int64();
+                    break;
+                case 4:
+                    message.arrived = reader.int64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketPong message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketPong
@@ -2778,13 +2772,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketPong.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketPong.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketPong message.
          * @function verify
          * @memberof packets.PacketPong
@@ -2792,21 +2786,25 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketPong.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
-				return "time: integer|Long expected";
-			if (!$util.isInteger(message.arrived) && !(message.arrived && $util.isInteger(message.arrived.low) && $util.isInteger(message.arrived.high)))
-				return "arrived: integer|Long expected";
-			return null;
-		};
+        PacketPong.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.time != null && message.hasOwnProperty("time"))
+                if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
+                    return "time: integer|Long expected";
+            if (message.arrived != null && message.hasOwnProperty("arrived"))
+                if (!$util.isInteger(message.arrived) && !(message.arrived && $util.isInteger(message.arrived.low) && $util.isInteger(message.arrived.high)))
+                    return "arrived: integer|Long expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketPong message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketPong
@@ -2814,36 +2812,36 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketPong} PacketPong
          */
-		PacketPong.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketPong)
-				return object;
-			var message = new $root.packets.PacketPong();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.time != null)
-				if ($util.Long)
-					(message.time = $util.Long.fromValue(object.time)).unsigned = false;
-				else if (typeof object.time === "string")
-					message.time = parseInt(object.time, 10);
-				else if (typeof object.time === "number")
-					message.time = object.time;
-				else if (typeof object.time === "object")
-					message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
-			if (object.arrived != null)
-				if ($util.Long)
-					(message.arrived = $util.Long.fromValue(object.arrived)).unsigned = false;
-				else if (typeof object.arrived === "string")
-					message.arrived = parseInt(object.arrived, 10);
-				else if (typeof object.arrived === "number")
-					message.arrived = object.arrived;
-				else if (typeof object.arrived === "object")
-					message.arrived = new $util.LongBits(object.arrived.low >>> 0, object.arrived.high >>> 0).toNumber();
-			return message;
-		};
+        PacketPong.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketPong)
+                return object;
+            var message = new $root.packets.PacketPong();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.time != null)
+                if ($util.Long)
+                    (message.time = $util.Long.fromValue(object.time)).unsigned = false;
+                else if (typeof object.time === "string")
+                    message.time = parseInt(object.time, 10);
+                else if (typeof object.time === "number")
+                    message.time = object.time;
+                else if (typeof object.time === "object")
+                    message.time = new $util.LongBits(object.time.low >>> 0, object.time.high >>> 0).toNumber();
+            if (object.arrived != null)
+                if ($util.Long)
+                    (message.arrived = $util.Long.fromValue(object.arrived)).unsigned = false;
+                else if (typeof object.arrived === "string")
+                    message.arrived = parseInt(object.arrived, 10);
+                else if (typeof object.arrived === "number")
+                    message.arrived = object.arrived;
+                else if (typeof object.arrived === "object")
+                    message.arrived = new $util.LongBits(object.arrived.low >>> 0, object.arrived.high >>> 0).toNumber();
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketPong message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketPong
@@ -2852,68 +2850,68 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketPong.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				if ($util.Long) {
-					var long = new $util.Long(0, 0, false);
-					object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-				} else
-					object.time = options.longs === String ? "0" : 0;
-				if ($util.Long) {
-					var long = new $util.Long(0, 0, false);
-					object.arrived = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-				} else
-					object.arrived = options.longs === String ? "0" : 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.time != null && message.hasOwnProperty("time"))
-				if (typeof message.time === "number")
-					object.time = options.longs === String ? String(message.time) : message.time;
-				else
-					object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
-			if (message.arrived != null && message.hasOwnProperty("arrived"))
-				if (typeof message.arrived === "number")
-					object.arrived = options.longs === String ? String(message.arrived) : message.arrived;
-				else
-					object.arrived = options.longs === String ? $util.Long.prototype.toString.call(message.arrived) : options.longs === Number ? new $util.LongBits(message.arrived.low >>> 0, message.arrived.high >>> 0).toNumber() : message.arrived;
-			return object;
-		};
+        PacketPong.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.time = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.time = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.arrived = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.arrived = options.longs === String ? "0" : 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.time != null && message.hasOwnProperty("time"))
+                if (typeof message.time === "number")
+                    object.time = options.longs === String ? String(message.time) : message.time;
+                else
+                    object.time = options.longs === String ? $util.Long.prototype.toString.call(message.time) : options.longs === Number ? new $util.LongBits(message.time.low >>> 0, message.time.high >>> 0).toNumber() : message.time;
+            if (message.arrived != null && message.hasOwnProperty("arrived"))
+                if (typeof message.arrived === "number")
+                    object.arrived = options.longs === String ? String(message.arrived) : message.arrived;
+                else
+                    object.arrived = options.longs === String ? $util.Long.prototype.toString.call(message.arrived) : options.longs === Number ? new $util.LongBits(message.arrived.low >>> 0, message.arrived.high >>> 0).toNumber() : message.arrived;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketPong to JSON.
          * @function toJSON
          * @memberof packets.PacketPong
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketPong.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketPong.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketPong;
-	})();
+        return PacketPong;
+    })();
 
-	packets.PacketGossipHello = (function() {
+    packets.PacketGossipHello = (function() {
 
-		/**
+        /**
          * Properties of a PacketGossipHello.
          * @memberof packets
          * @interface IPacketGossipHello
-         * @property {string} ver PacketGossipHello ver
-         * @property {string} sender PacketGossipHello sender
-         * @property {string} host PacketGossipHello host
-         * @property {number} port PacketGossipHello port
+         * @property {string|null} [ver] PacketGossipHello ver
+         * @property {string|null} [sender] PacketGossipHello sender
+         * @property {string|null} [host] PacketGossipHello host
+         * @property {number|null} [port] PacketGossipHello port
          */
 
-		/**
+        /**
          * Constructs a new PacketGossipHello.
          * @memberof packets
          * @classdesc Represents a PacketGossipHello.
@@ -2921,46 +2919,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipHello=} [properties] Properties to set
          */
-		function PacketGossipHello(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketGossipHello(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketGossipHello ver.
          * @member {string} ver
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.ver = "";
+        PacketGossipHello.prototype.ver = "";
 
-		/**
+        /**
          * PacketGossipHello sender.
          * @member {string} sender
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.sender = "";
+        PacketGossipHello.prototype.sender = "";
 
-		/**
+        /**
          * PacketGossipHello host.
          * @member {string} host
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.host = "";
+        PacketGossipHello.prototype.host = "";
 
-		/**
+        /**
          * PacketGossipHello port.
          * @member {number} port
          * @memberof packets.PacketGossipHello
          * @instance
          */
-		PacketGossipHello.prototype.port = 0;
+        PacketGossipHello.prototype.port = 0;
 
-		/**
+        /**
          * Creates a new PacketGossipHello instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipHello
@@ -2968,11 +2966,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipHello=} [properties] Properties to set
          * @returns {packets.PacketGossipHello} PacketGossipHello instance
          */
-		PacketGossipHello.create = function create(properties) {
-			return new PacketGossipHello(properties);
-		};
+        PacketGossipHello.create = function create(properties) {
+            return new PacketGossipHello(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipHello message. Does not implicitly {@link packets.PacketGossipHello.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipHello
@@ -2981,17 +2979,21 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipHello.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			writer.uint32(/* id 3, wireType 2 =*/26).string(message.host);
-			writer.uint32(/* id 4, wireType 0 =*/32).int32(message.port);
-			return writer;
-		};
+        PacketGossipHello.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.host != null && message.hasOwnProperty("host"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.host);
+            if (message.port != null && message.hasOwnProperty("port"))
+                writer.uint32(/* id 4, wireType 0 =*/32).int32(message.port);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipHello message, length delimited. Does not implicitly {@link packets.PacketGossipHello.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipHello
@@ -3000,11 +3002,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipHello.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketGossipHello.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipHello message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipHello
@@ -3015,42 +3017,34 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipHello.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipHello();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.host = reader.string();
-						break;
-					case 4:
-						message.port = reader.int32();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			if (!message.hasOwnProperty("host"))
-				throw $util.ProtocolError("missing required 'host'", { instance: message });
-			if (!message.hasOwnProperty("port"))
-				throw $util.ProtocolError("missing required 'port'", { instance: message });
-			return message;
-		};
+        PacketGossipHello.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipHello();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.host = reader.string();
+                    break;
+                case 4:
+                    message.port = reader.int32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipHello message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipHello
@@ -3060,13 +3054,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipHello.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketGossipHello.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketGossipHello message.
          * @function verify
          * @memberof packets.PacketGossipHello
@@ -3074,21 +3068,25 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketGossipHello.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (!$util.isString(message.host))
-				return "host: string expected";
-			if (!$util.isInteger(message.port))
-				return "port: integer expected";
-			return null;
-		};
+        PacketGossipHello.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.host != null && message.hasOwnProperty("host"))
+                if (!$util.isString(message.host))
+                    return "host: string expected";
+            if (message.port != null && message.hasOwnProperty("port"))
+                if (!$util.isInteger(message.port))
+                    return "port: integer expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketGossipHello message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipHello
@@ -3096,22 +3094,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipHello} PacketGossipHello
          */
-		PacketGossipHello.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketGossipHello)
-				return object;
-			var message = new $root.packets.PacketGossipHello();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.host != null)
-				message.host = String(object.host);
-			if (object.port != null)
-				message.port = object.port | 0;
-			return message;
-		};
+        PacketGossipHello.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketGossipHello)
+                return object;
+            var message = new $root.packets.PacketGossipHello();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.host != null)
+                message.host = String(object.host);
+            if (object.port != null)
+                message.port = object.port | 0;
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketGossipHello message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipHello
@@ -3120,54 +3118,54 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketGossipHello.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.host = "";
-				object.port = 0;
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.host != null && message.hasOwnProperty("host"))
-				object.host = message.host;
-			if (message.port != null && message.hasOwnProperty("port"))
-				object.port = message.port;
-			return object;
-		};
+        PacketGossipHello.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.host = "";
+                object.port = 0;
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.host != null && message.hasOwnProperty("host"))
+                object.host = message.host;
+            if (message.port != null && message.hasOwnProperty("port"))
+                object.port = message.port;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketGossipHello to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipHello
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketGossipHello.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketGossipHello.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketGossipHello;
-	})();
+        return PacketGossipHello;
+    })();
 
-	packets.PacketGossipRequest = (function() {
+    packets.PacketGossipRequest = (function() {
 
-		/**
+        /**
          * Properties of a PacketGossipRequest.
          * @memberof packets
          * @interface IPacketGossipRequest
-         * @property {string} ver PacketGossipRequest ver
-         * @property {string} sender PacketGossipRequest sender
+         * @property {string|null} [ver] PacketGossipRequest ver
+         * @property {string|null} [sender] PacketGossipRequest sender
          * @property {string|null} [online] PacketGossipRequest online
          * @property {string|null} [offline] PacketGossipRequest offline
          */
 
-		/**
+        /**
          * Constructs a new PacketGossipRequest.
          * @memberof packets
          * @classdesc Represents a PacketGossipRequest.
@@ -3175,46 +3173,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipRequest=} [properties] Properties to set
          */
-		function PacketGossipRequest(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketGossipRequest(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketGossipRequest ver.
          * @member {string} ver
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.ver = "";
+        PacketGossipRequest.prototype.ver = "";
 
-		/**
+        /**
          * PacketGossipRequest sender.
          * @member {string} sender
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.sender = "";
+        PacketGossipRequest.prototype.sender = "";
 
-		/**
+        /**
          * PacketGossipRequest online.
          * @member {string} online
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.online = "";
+        PacketGossipRequest.prototype.online = "";
 
-		/**
+        /**
          * PacketGossipRequest offline.
          * @member {string} offline
          * @memberof packets.PacketGossipRequest
          * @instance
          */
-		PacketGossipRequest.prototype.offline = "";
+        PacketGossipRequest.prototype.offline = "";
 
-		/**
+        /**
          * Creates a new PacketGossipRequest instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipRequest
@@ -3222,11 +3220,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipRequest=} [properties] Properties to set
          * @returns {packets.PacketGossipRequest} PacketGossipRequest instance
          */
-		PacketGossipRequest.create = function create(properties) {
-			return new PacketGossipRequest(properties);
-		};
+        PacketGossipRequest.create = function create(properties) {
+            return new PacketGossipRequest(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipRequest message. Does not implicitly {@link packets.PacketGossipRequest.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipRequest
@@ -3235,19 +3233,21 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipRequest.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			if (message.online != null && message.hasOwnProperty("online"))
-				writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
-			return writer;
-		};
+        PacketGossipRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.online != null && message.hasOwnProperty("online"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipRequest message, length delimited. Does not implicitly {@link packets.PacketGossipRequest.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipRequest
@@ -3256,11 +3256,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipRequest.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketGossipRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipRequest message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipRequest
@@ -3271,38 +3271,34 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipRequest.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipRequest();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.online = reader.string();
-						break;
-					case 4:
-						message.offline = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketGossipRequest.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipRequest();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.online = reader.string();
+                    break;
+                case 4:
+                    message.offline = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipRequest message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipRequest
@@ -3312,13 +3308,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipRequest.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketGossipRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketGossipRequest message.
          * @function verify
          * @memberof packets.PacketGossipRequest
@@ -3326,23 +3322,25 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketGossipRequest.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (message.online != null && message.hasOwnProperty("online"))
-				if (!$util.isString(message.online))
-					return "online: string expected";
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				if (!$util.isString(message.offline))
-					return "offline: string expected";
-			return null;
-		};
+        PacketGossipRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.online != null && message.hasOwnProperty("online"))
+                if (!$util.isString(message.online))
+                    return "online: string expected";
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                if (!$util.isString(message.offline))
+                    return "offline: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketGossipRequest message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipRequest
@@ -3350,22 +3348,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipRequest} PacketGossipRequest
          */
-		PacketGossipRequest.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketGossipRequest)
-				return object;
-			var message = new $root.packets.PacketGossipRequest();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.online != null)
-				message.online = String(object.online);
-			if (object.offline != null)
-				message.offline = String(object.offline);
-			return message;
-		};
+        PacketGossipRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketGossipRequest)
+                return object;
+            var message = new $root.packets.PacketGossipRequest();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.online != null)
+                message.online = String(object.online);
+            if (object.offline != null)
+                message.offline = String(object.offline);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketGossipRequest message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipRequest
@@ -3374,54 +3372,54 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketGossipRequest.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.online = "";
-				object.offline = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.online != null && message.hasOwnProperty("online"))
-				object.online = message.online;
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				object.offline = message.offline;
-			return object;
-		};
+        PacketGossipRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.online = "";
+                object.offline = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.online != null && message.hasOwnProperty("online"))
+                object.online = message.online;
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                object.offline = message.offline;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketGossipRequest to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipRequest
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketGossipRequest.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketGossipRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketGossipRequest;
-	})();
+        return PacketGossipRequest;
+    })();
 
-	packets.PacketGossipResponse = (function() {
+    packets.PacketGossipResponse = (function() {
 
-		/**
+        /**
          * Properties of a PacketGossipResponse.
          * @memberof packets
          * @interface IPacketGossipResponse
-         * @property {string} ver PacketGossipResponse ver
-         * @property {string} sender PacketGossipResponse sender
+         * @property {string|null} [ver] PacketGossipResponse ver
+         * @property {string|null} [sender] PacketGossipResponse sender
          * @property {string|null} [online] PacketGossipResponse online
          * @property {string|null} [offline] PacketGossipResponse offline
          */
 
-		/**
+        /**
          * Constructs a new PacketGossipResponse.
          * @memberof packets
          * @classdesc Represents a PacketGossipResponse.
@@ -3429,46 +3427,46 @@ $root.packets = (function() {
          * @constructor
          * @param {packets.IPacketGossipResponse=} [properties] Properties to set
          */
-		function PacketGossipResponse(properties) {
-			if (properties)
-				for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-					if (properties[keys[i]] != null)
-						this[keys[i]] = properties[keys[i]];
-		}
+        function PacketGossipResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
 
-		/**
+        /**
          * PacketGossipResponse ver.
          * @member {string} ver
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.ver = "";
+        PacketGossipResponse.prototype.ver = "";
 
-		/**
+        /**
          * PacketGossipResponse sender.
          * @member {string} sender
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.sender = "";
+        PacketGossipResponse.prototype.sender = "";
 
-		/**
+        /**
          * PacketGossipResponse online.
          * @member {string} online
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.online = "";
+        PacketGossipResponse.prototype.online = "";
 
-		/**
+        /**
          * PacketGossipResponse offline.
          * @member {string} offline
          * @memberof packets.PacketGossipResponse
          * @instance
          */
-		PacketGossipResponse.prototype.offline = "";
+        PacketGossipResponse.prototype.offline = "";
 
-		/**
+        /**
          * Creates a new PacketGossipResponse instance using the specified properties.
          * @function create
          * @memberof packets.PacketGossipResponse
@@ -3476,11 +3474,11 @@ $root.packets = (function() {
          * @param {packets.IPacketGossipResponse=} [properties] Properties to set
          * @returns {packets.PacketGossipResponse} PacketGossipResponse instance
          */
-		PacketGossipResponse.create = function create(properties) {
-			return new PacketGossipResponse(properties);
-		};
+        PacketGossipResponse.create = function create(properties) {
+            return new PacketGossipResponse(properties);
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipResponse message. Does not implicitly {@link packets.PacketGossipResponse.verify|verify} messages.
          * @function encode
          * @memberof packets.PacketGossipResponse
@@ -3489,19 +3487,21 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipResponse.encode = function encode(message, writer) {
-			if (!writer)
-				writer = $Writer.create();
-			writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
-			writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
-			if (message.online != null && message.hasOwnProperty("online"))
-				writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
-			return writer;
-		};
+        PacketGossipResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.ver);
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.sender);
+            if (message.online != null && message.hasOwnProperty("online"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.online);
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.offline);
+            return writer;
+        };
 
-		/**
+        /**
          * Encodes the specified PacketGossipResponse message, length delimited. Does not implicitly {@link packets.PacketGossipResponse.verify|verify} messages.
          * @function encodeDelimited
          * @memberof packets.PacketGossipResponse
@@ -3510,11 +3510,11 @@ $root.packets = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-		PacketGossipResponse.encodeDelimited = function encodeDelimited(message, writer) {
-			return this.encode(message, writer).ldelim();
-		};
+        PacketGossipResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipResponse message from the specified reader or buffer.
          * @function decode
          * @memberof packets.PacketGossipResponse
@@ -3525,38 +3525,34 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipResponse.decode = function decode(reader, length) {
-			if (!(reader instanceof $Reader))
-				reader = $Reader.create(reader);
-			var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipResponse();
-			while (reader.pos < end) {
-				var tag = reader.uint32();
-				switch (tag >>> 3) {
-					case 1:
-						message.ver = reader.string();
-						break;
-					case 2:
-						message.sender = reader.string();
-						break;
-					case 3:
-						message.online = reader.string();
-						break;
-					case 4:
-						message.offline = reader.string();
-						break;
-					default:
-						reader.skipType(tag & 7);
-						break;
-				}
-			}
-			if (!message.hasOwnProperty("ver"))
-				throw $util.ProtocolError("missing required 'ver'", { instance: message });
-			if (!message.hasOwnProperty("sender"))
-				throw $util.ProtocolError("missing required 'sender'", { instance: message });
-			return message;
-		};
+        PacketGossipResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.packets.PacketGossipResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.ver = reader.string();
+                    break;
+                case 2:
+                    message.sender = reader.string();
+                    break;
+                case 3:
+                    message.online = reader.string();
+                    break;
+                case 4:
+                    message.offline = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
 
-		/**
+        /**
          * Decodes a PacketGossipResponse message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
          * @memberof packets.PacketGossipResponse
@@ -3566,13 +3562,13 @@ $root.packets = (function() {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-		PacketGossipResponse.decodeDelimited = function decodeDelimited(reader) {
-			if (!(reader instanceof $Reader))
-				reader = new $Reader(reader);
-			return this.decode(reader, reader.uint32());
-		};
+        PacketGossipResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
 
-		/**
+        /**
          * Verifies a PacketGossipResponse message.
          * @function verify
          * @memberof packets.PacketGossipResponse
@@ -3580,23 +3576,25 @@ $root.packets = (function() {
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-		PacketGossipResponse.verify = function verify(message) {
-			if (typeof message !== "object" || message === null)
-				return "object expected";
-			if (!$util.isString(message.ver))
-				return "ver: string expected";
-			if (!$util.isString(message.sender))
-				return "sender: string expected";
-			if (message.online != null && message.hasOwnProperty("online"))
-				if (!$util.isString(message.online))
-					return "online: string expected";
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				if (!$util.isString(message.offline))
-					return "offline: string expected";
-			return null;
-		};
+        PacketGossipResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                if (!$util.isString(message.ver))
+                    return "ver: string expected";
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                if (!$util.isString(message.sender))
+                    return "sender: string expected";
+            if (message.online != null && message.hasOwnProperty("online"))
+                if (!$util.isString(message.online))
+                    return "online: string expected";
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                if (!$util.isString(message.offline))
+                    return "offline: string expected";
+            return null;
+        };
 
-		/**
+        /**
          * Creates a PacketGossipResponse message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
          * @memberof packets.PacketGossipResponse
@@ -3604,22 +3602,22 @@ $root.packets = (function() {
          * @param {Object.<string,*>} object Plain object
          * @returns {packets.PacketGossipResponse} PacketGossipResponse
          */
-		PacketGossipResponse.fromObject = function fromObject(object) {
-			if (object instanceof $root.packets.PacketGossipResponse)
-				return object;
-			var message = new $root.packets.PacketGossipResponse();
-			if (object.ver != null)
-				message.ver = String(object.ver);
-			if (object.sender != null)
-				message.sender = String(object.sender);
-			if (object.online != null)
-				message.online = String(object.online);
-			if (object.offline != null)
-				message.offline = String(object.offline);
-			return message;
-		};
+        PacketGossipResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.packets.PacketGossipResponse)
+                return object;
+            var message = new $root.packets.PacketGossipResponse();
+            if (object.ver != null)
+                message.ver = String(object.ver);
+            if (object.sender != null)
+                message.sender = String(object.sender);
+            if (object.online != null)
+                message.online = String(object.online);
+            if (object.offline != null)
+                message.offline = String(object.offline);
+            return message;
+        };
 
-		/**
+        /**
          * Creates a plain object from a PacketGossipResponse message. Also converts values to other types if specified.
          * @function toObject
          * @memberof packets.PacketGossipResponse
@@ -3628,42 +3626,42 @@ $root.packets = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-		PacketGossipResponse.toObject = function toObject(message, options) {
-			if (!options)
-				options = {};
-			var object = {};
-			if (options.defaults) {
-				object.ver = "";
-				object.sender = "";
-				object.online = "";
-				object.offline = "";
-			}
-			if (message.ver != null && message.hasOwnProperty("ver"))
-				object.ver = message.ver;
-			if (message.sender != null && message.hasOwnProperty("sender"))
-				object.sender = message.sender;
-			if (message.online != null && message.hasOwnProperty("online"))
-				object.online = message.online;
-			if (message.offline != null && message.hasOwnProperty("offline"))
-				object.offline = message.offline;
-			return object;
-		};
+        PacketGossipResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.ver = "";
+                object.sender = "";
+                object.online = "";
+                object.offline = "";
+            }
+            if (message.ver != null && message.hasOwnProperty("ver"))
+                object.ver = message.ver;
+            if (message.sender != null && message.hasOwnProperty("sender"))
+                object.sender = message.sender;
+            if (message.online != null && message.hasOwnProperty("online"))
+                object.online = message.online;
+            if (message.offline != null && message.hasOwnProperty("offline"))
+                object.offline = message.offline;
+            return object;
+        };
 
-		/**
+        /**
          * Converts this PacketGossipResponse to JSON.
          * @function toJSON
          * @memberof packets.PacketGossipResponse
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-		PacketGossipResponse.prototype.toJSON = function toJSON() {
-			return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-		};
+        PacketGossipResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
 
-		return PacketGossipResponse;
-	})();
+        return PacketGossipResponse;
+    })();
 
-	return packets;
+    return packets;
 })();
 
 module.exports = $root;


### PR DESCRIPTION
## :memo: Fixes incorrect proto 3 definition

The Protobuf file is listed as using proto3, but the syntax is incorrect. It seems that protobufjs doesn't care, but protoc does. We are working on implementing the protobuf serializer for moleculer-ruby which requires protoc, and we want full parity between the packets. To do this we are actually curling the proto package from moleculerjs and using that, but the definition file is syntactically incorrect for proto3.

My real suggestion would be to create a new protocol repo, that includes the protocol document itself and the packet definition files for serializers like protobuf.

This should not be a breaking change, as it simply removes the required and optional flags (not supported in proto3).

- [X] Bug fix (non-breaking change which fixes an issue)