### PR TITLE
Use serializers in redis

### DIFF
--- a/dev/redis-cacher.js
+++ b/dev/redis-cacher.js
@@ -1,0 +1,46 @@
+"use strict";
+
+let chalk = require("chalk");
+let ServiceBroker = require("../src/service-broker");
+
+// Create broker
+let broker = new ServiceBroker({
+	logLevel: "debug",
+	cacher: {
+		type: "Redis",
+		options: {
+			serializer: "Notepack"
+		}
+	}
+});
+
+broker.createService({
+	name: "greeter",
+	actions: {
+		hello: {
+			//cache: false,
+			cache: {
+				enabled: true
+			},
+			handler(ctx) {
+				return {
+					a: 5,
+					b: "John",
+					c: true,
+					d: null,
+					e: {
+						f: Date.now(),
+						g: new Date()
+					},
+					h: Buffer.from("Hello")
+				};
+			}
+		}
+	}
+});
+
+broker.start()
+	.then(() => broker.call("greeter.hello").then(res => broker.logger.info(res, res.e.g instanceof Date)))
+	.then(() => broker.call("greeter.hello").then(res => broker.logger.info(res, res.e.g instanceof Date)))
+	.catch(err => broker.logger.error(err))
+	.then(() => broker.repl());

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -8,8 +8,9 @@
 
 const Promise = require("bluebird");
 const BaseCacher = require("./base");
-const _ = require('lodash')
+const _ = require("lodash");
 const { BrokerOptionsError } = require("../errors");
+const Serializers = require("../serializers");
 
 /**
  * Cacher factory for Redis
@@ -54,7 +55,7 @@ class RedisCacher extends BaseCacher {
 		 */
 		if (this.opts.cluster) {
 			if (!this.opts.cluster.nodes || this.opts.cluster.nodes.length === 0) {
-				throw new BrokerOptionsError('No nodes defined for cluster')
+				throw new BrokerOptionsError("No nodes defined for cluster");
 			}
 
 			this.logger.info("Setting Redis.Cluster Cacher");
@@ -76,20 +77,20 @@ class RedisCacher extends BaseCacher {
 			this.logger.error(err);
 		});
 		try {
-			Redlock = require('redlock');
+			Redlock = require("redlock");
 		} catch (err) {
 			/* istanbul ignore next */
 			this.logger.warn("The 'redlock' package is missing. If you want to enable cache lock, please install it with 'npm install redlock --save' command.");
 		}
 		if (Redlock) {
-			let redlockClients = (this.opts.redlock ? this.opts.redlock.clients : null) || [this.client]
+			let redlockClients = (this.opts.redlock ? this.opts.redlock.clients : null) || [this.client];
 			/**
 			 * redlock client instance
 			 * @memberof RedisCacher
 			 */
 			this.redlock = new Redlock(
 				redlockClients,
-				_.omit(this.opts.redlock, ['clients'])
+				_.omit(this.opts.redlock, ["clients"])
 			);
 			// Non-blocking redlock client, used for tryLock()
 			this.redlockNonBlocking = new Redlock(
@@ -97,7 +98,7 @@ class RedisCacher extends BaseCacher {
 				{
 					retryCount: 0
 				}
-			)
+			);
 		}
 		if (this.opts.monitor) {
 			/* istanbul ignore next */
@@ -108,6 +109,9 @@ class RedisCacher extends BaseCacher {
 				});
 			});
 		}
+
+		// create an instance of serializer (default to JSON)
+		this.serializer = Serializers.resolve(this.opts.serializer);
 
 		this.logger.debug("Redis Cacher created. Prefix: " + this.prefix);
 	}
@@ -131,11 +135,11 @@ class RedisCacher extends BaseCacher {
 	 */
 	get(key) {
 		this.logger.debug(`GET ${key}`);
-		return this.client.get(this.prefix + key).then((data) => {
+		return this.client.getBuffer(this.prefix + key).then((data) => {
 			if (data) {
 				this.logger.debug(`FOUND ${key}`);
 				try {
-					return JSON.parse(data);
+					return this.serializer.deserialize(data);
 				} catch (err) {
 					this.logger.error("Redis result parse error.", err, data);
 				}
@@ -155,7 +159,8 @@ class RedisCacher extends BaseCacher {
 	 * @memberof Cacher
 	 */
 	set(key, data, ttl) {
-		data = JSON.stringify(data);
+		data = this.serializer.serialize(data);
+
 		this.logger.debug(`SET ${key}`);
 
 		if (ttl == null)
@@ -218,25 +223,25 @@ class RedisCacher extends BaseCacher {
 	 */
 
 	getWithTTL(key) {
-		return this.client.pipeline().get(this.prefix + key).ttl(this.prefix + key).exec().then((res) => {
-			let [err0, data] = res[0]
-			let [err1, ttl] = res[1]
+		return this.client.pipeline().getBuffer(this.prefix + key).ttl(this.prefix + key).exec().then((res) => {
+			let [err0, data] = res[0];
+			let [err1, ttl] = res[1];
 			if(err0){
-				return Promise.reject(err0)
+				return Promise.reject(err0);
 			}
 			if(err1){
-				return Promise.reject(err1)
+				return Promise.reject(err1);
 			}
 			if (data) {
 				this.logger.debug(`FOUND ${key}`);
 				try {
-					data = JSON.parse(data);
+					data = this.serializer.deserialize(data);
 				} catch (err) {
 					this.logger.error("Redis result parse error.", err, data);
-					data = null
+					data = null;
 				}
 			}
-			return { data, ttl }
+			return { data, ttl };
 		});
 	}
 
@@ -251,10 +256,10 @@ class RedisCacher extends BaseCacher {
 	 * @memberof RedisCacher
 	 */
 	lock(key, ttl=15000) {
-		key = this.prefix + key + "-lock"
+		key = this.prefix + key + "-lock";
 		return this.redlock.lock(key, ttl).then(lock=>{
-			return ()=>lock.unlock()
-		})
+			return ()=>lock.unlock();
+		});
 	}
 
 	/**
@@ -267,10 +272,10 @@ class RedisCacher extends BaseCacher {
 	 * @memberof RedisCacher
 	 */
 	tryLock(key, ttl=15000) {
-		key = this.prefix + key + "-lock"
+		key = this.prefix + key + "-lock";
 		return this.redlockNonBlocking.lock(key, ttl).then(lock=>{
-			return ()=>lock.unlock()
-		})
+			return ()=>lock.unlock();
+		});
 	}
 
 	_sequentialPromises(elements) {
@@ -280,7 +285,7 @@ class RedisCacher extends BaseCacher {
 	}
 
 	_clusterScanDel(pattern) {
-		const scanDelPromises = []
+		const scanDelPromises = [];
 		const nodes = this.client.nodes();
 
 		nodes.forEach(node => {
@@ -314,24 +319,25 @@ class RedisCacher extends BaseCacher {
 			});
 
 			stream.on("error", (err) => {
-				console.error('Error occured while deleting keys from node')
+				// eslint-disable-next-line no-console
+				console.error("Error occured while deleting keys from node");
 				reject(err);
 			});
 
 			stream.on("end", () => {
-	//			console.log('End deleting keys from node')
+				//			console.log('End deleting keys from node')
 				resolve();
 			});
-		})
+		});
 	}
 
 	_scanDel(pattern) {
 		let Redis = require("ioredis");
 
 		if (this.client instanceof Redis.Cluster) {
-			return this._clusterScanDel(pattern)
+			return this._clusterScanDel(pattern);
 		} else {
-			return this._nodeScanDel(this.client, pattern)
+			return this._nodeScanDel(this.client, pattern);
 		}
 	}
 }


### PR DESCRIPTION
## :memo: Description

The existing `Redis` cacher _always_ serializes using JSON.  However, there are differences between how JSON serialization works and how some of the other transporter serializers work.  For instance, the Notepack and Msgpack serializers are able to serialize and deserialize `Date` objects while JSON serialization converts them to date-strings.

Because the `Redis` cacher serializes using JSON regardless of the transporter's serializer, this can result in different behaviors when an action result pulls from cache instead of being run through the action normally.  For instance, if an action returns an object with a `Date` object for one of its properties, when using Notepack this will be returned as a true `Date` object.  However, if the same action responds using the Redis cache, it will have been converted to a string.

This PR adds handling to the `Redis` cacher to accept an option named `serializer`.  This `serializer` option works in exactly the same manner as the transporter serializer does.  By specifying an option for this value, that serializer will be used when serializing/deserializing to and from the Redis cache.  It would be recommended to keep the transporter and cacher serializer in sync to avoid any strange behaviors.

If a cacher serializer is not chosen, JSON will default (just like the transporter), so this does not cause any breaking change.

While making these changes I found a large number of errors reported by `eslint` which were also addressed.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

### :scroll: Example code
```js
const broker = new ServiceBroker({
  cacher: {
    type: "Redis",
    options: {
      serializer: "Notepack",
    },
  },
});
``` 

## :vertical_traffic_light: How Has This Been Tested?

Redis cacher unit tests have been updated as part of the PR.

I also ran a modified version of the `simple` example service to turn on caching and run the same action call repeatedly.  I ran tests without specifying a serializer (which should use JSON) as well as tests with specifying the Notepack serializer.  I confirmed that the action results from the first call were the same as the repeated calls which would have come from cache.  I also used the Redis CLI to confirm that the data was being stored differently when using the different serializers.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
