### PR TITLE
implement a ctx.mcall method for #247

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -336,7 +336,8 @@ class Context {
 			const distTimeout = this.options.timeout - duration;
 
 			if (distTimeout <= 0) {
-				return Promise.reject(new RequestSkippedError({ action: def.map(d => d.action).join(", "), nodeID: this.broker.nodeID }));
+				const action = (Array.isArray(def) ? def : Object.values(def)).map(d => d.action).join(", ");
+				return Promise.reject(new RequestSkippedError({ action, nodeID: this.broker.nodeID }));
 			}
 
 			if (!opts.timeout || distTimeout < opts.timeout)

--- a/src/context.js
+++ b/src/context.js
@@ -323,6 +323,47 @@ class Context {
 		});
 	}
 
+	mcall(def, _opts) {
+		const opts = Object.assign({
+			parentCtx: this
+		}, _opts);
+
+		if (this.options.timeout > 0 && this.startHrTime) {
+			// Distributed timeout handling. Decrementing the timeout value with the elapsed time.
+			// If the timeout below 0, skip the call.
+			const diff = process.hrtime(this.startHrTime);
+			const duration = (diff[0] * 1e3) + (diff[1] / 1e6);
+			const distTimeout = this.options.timeout - duration;
+
+			if (distTimeout <= 0) {
+				return Promise.reject(new RequestSkippedError({ action: def.map(d => d.action).join(", "), nodeID: this.broker.nodeID }));
+			}
+
+			if (!opts.timeout || distTimeout < opts.timeout)
+				opts.timeout = distTimeout;
+		}
+
+		// Max calling level check to avoid calling loops
+		if (this.broker.options.maxCallLevel > 0 && this.level >= this.broker.options.maxCallLevel) {
+			return Promise.reject(new MaxCallLevelError({ nodeID: this.broker.nodeID, level: this.level }));
+		}
+
+		let p = this.broker.mcall(def, opts);
+
+		// Merge metadata with sub context metadata
+		return p.then(res => {
+			if (Array.isArray(p.ctx) && p.ctx.length)
+				p.ctx.forEach(ctx => mergeMeta(this, ctx.meta));
+
+			return res;
+		}).catch(err => {
+			if (Array.isArray(p.ctx) && p.ctx.length)
+				p.ctx.forEach(ctx => mergeMeta(this, ctx.meta));
+
+			return Promise.reject(err);
+		});
+	}
+
 	/**
 	 * Emit an event (grouped & balanced global event)
 	 *

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -1184,7 +1184,7 @@ class ServiceBroker {
 	 */
 	mcall(def, opts) {
 		if (Array.isArray(def)) {
-			return Promise.all(def.map(item => this.call(item.action, item.params, opts || item.options)));
+			return Promise.all(def.map(item => this.call(item.action, item.params, item.options || opts)));
 
 		} else if (_.isObject(def)) {
 			let results = {};

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -634,6 +634,115 @@ describe("Test call with meta merge", () => {
 	});
 });
 
+describe("Test mcall method", () => {
+	let broker = new ServiceBroker({ logger: false, maxCallLevel: 5 });
+	broker.mcall = jest.fn(() => broker.Promise.resolve());
+
+	it("should call broker.mcall method with itself", () => {
+		let ctx = new Context(broker);
+
+		let p = { id: 5 };
+		let a = [
+			{ action: "posts.find", params: p },
+			{ action: "posts.list", params: p }
+		];
+
+		ctx.mcall(a);
+
+		expect(broker.mcall).toHaveBeenCalledTimes(1);
+		expect(broker.mcall).toHaveBeenCalledWith(a, { parentCtx: ctx });
+		expect(broker.mcall).toHaveBeenCalledWith(a, { parentCtx: ctx });
+	});
+
+	it("should call broker.call method with options", () => {
+		broker.mcall.mockClear();
+
+		let ctx = new Context(broker);
+		ctx.level = 4;
+
+		let p = { id: 5 };
+		let a = [
+			{ action: "posts.find", params: p },
+			{ action: "posts.list", params: p }
+		];
+		let opts = { timeout: 2500 };
+
+		ctx.mcall(a, opts);
+
+		expect(broker.mcall).toHaveBeenCalledTimes(1);
+		expect(broker.mcall).toHaveBeenCalledWith(a, { parentCtx: ctx, timeout: 2500 });
+		expect(broker.mcall.mock.calls[0][2]).not.toBe(opts);
+		expect(opts.parentCtx).toBeUndefined();
+	});
+
+	it("should throw Error if reached the 'maxCallLevel'", () => {
+		broker.mcall.mockClear();
+
+		let ctx = new Context(broker);
+		ctx.level = 5;
+		return ctx.mcall([
+			{ action: "posts.find", params: {} },
+			{ action: "posts.list", params: {} }
+		]).then(protectReject).catch(err => {
+			expect(broker.mcall).toHaveBeenCalledTimes(0);
+			expect(err).toBeInstanceOf(MaxCallLevelError);
+			expect(err.code).toBe(500);
+			expect(err.data).toEqual({ nodeID: broker.nodeID, level: 5 });
+		});
+	});
+});
+
+describe("Test mcall with meta merge", () => {
+	let broker = new ServiceBroker({ logger: false, maxCallLevel: 5 });
+	let err = new Error("Subcall error");
+
+	broker.mcall = jest.fn()
+		.mockImplementationOnce(() => {
+			const p = broker.Promise.resolve();
+			p.ctx = [
+				{ meta: { b: 5 } },
+				{ meta: { c: 3 } }
+			];
+			return p;
+		})
+		.mockImplementationOnce(() => {
+			const p = broker.Promise.reject(err);
+			p.ctx = [
+				{ meta: { b: 5 } },
+				{ meta: { c: 3 } }
+			];
+			return p;
+		});
+
+	it("should merge meta from sub-context if resolved", () => {
+		let ctx = new Context(broker);
+		ctx.meta.a = "Hello";
+		ctx.meta.b = 1;
+		return ctx.mcall([
+			{ action: "posts.find", params: {} },
+			{ action: "posts.list", params: {} }
+		]).catch(protectReject).then(() => {
+			expect(broker.mcall).toHaveBeenCalledTimes(1);
+			expect(ctx.meta).toEqual({ a: "Hello", b: 5, c: 3 });
+		});
+	});
+
+	it("should merge meta from sub-context if rejected", () => {
+		broker.mcall.mockClear();
+		let ctx = new Context(broker);
+		ctx.meta.a = "Hello";
+		ctx.meta.b = 1;
+		return ctx.mcall([
+			{ action: "posts.find", params: {} },
+			{ action: "posts.list", params: {} }
+		]).then(protectReject).catch(e => {
+			expect(e).toBe(err);
+			expect(broker.mcall).toHaveBeenCalledTimes(1);
+			expect(ctx.meta).toEqual({ a: "Hello", b: 5, c: 3 });
+		});
+	});
+});
+
 describe("Test emit method", () => {
 	const broker = new ServiceBroker({ logger: false });
 	broker.emit = jest.fn();

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -31,7 +31,7 @@ const Serializers = require("../../src/serializers");
 const Transporters = require("../../src/transporters");
 const Strategies = require("../../src/strategies");
 const MiddlewareHandler = require("../../src/middleware");
-const { MoleculerError, ServiceNotFoundError, ServiceNotAvailableError } = require("../../src/errors");
+const { MoleculerError, MoleculerServerError, ServiceNotFoundError, ServiceNotAvailableError } = require("../../src/errors");
 
 describe("Test ServiceBroker constructor", () => {
 
@@ -1989,12 +1989,12 @@ describe("Test broker.mcall", () => {
 		return broker.mcall([
 			{ action: "posts.find", params: { limit: 2, offset: 0 }, options: { timeout: 500 } },
 			{ action: "users.find", params: { limit: 2, sort: "username" } }
-		]).catch(protectReject).then(res => {
+		], { timeout: 200 }).catch(protectReject).then(res => {
 			expect(res).toEqual(["posts.find", "users.find"]);
 
 			expect(broker.call).toHaveBeenCalledTimes(2);
 			expect(broker.call).toHaveBeenCalledWith("posts.find", { limit: 2, offset: 0 }, { timeout: 500 });
-			expect(broker.call).toHaveBeenCalledWith("users.find", { limit: 2, sort: "username" }, undefined);
+			expect(broker.call).toHaveBeenCalledWith("users.find", { limit: 2, sort: "username" }, { timeout: 200 });
 		});
 	});
 
@@ -2004,19 +2004,19 @@ describe("Test broker.mcall", () => {
 		return broker.mcall({
 			posts: { action: "posts.find", params: { limit: 2, offset: 0 }, options: { timeout: 500 } },
 			users: { action: "users.find", params: { limit: 2, sort: "username" } }
-		}).catch(protectReject).then(res => {
+		}, { timeout: 200 }).catch(protectReject).then(res => {
 			expect(res).toEqual({ posts: "posts.find", users: "users.find" });
 
 			expect(broker.call).toHaveBeenCalledTimes(2);
 			expect(broker.call).toHaveBeenCalledWith("posts.find", { limit: 2, offset: 0 }, { timeout: 500 });
-			expect(broker.call).toHaveBeenCalledWith("users.find", { limit: 2, sort: "username" }, undefined);
+			expect(broker.call).toHaveBeenCalledWith("users.find", { limit: 2, sort: "username" }, { timeout: 200 });
 		});
 	});
 
 	it("should throw error", () => {
 		expect(() => {
 			return broker.mcall(6);
-		}).toThrowError(MoleculerError);
+		}).toThrowError(MoleculerServerError);
 	});
 });
 


### PR DESCRIPTION
## :memo: Description

Implemented a `ctx.mcall` method, so it can be used to pass meta.

### :dart: Relevant issues
#247 meta is not passed when using mcall

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: Example code
```js
ctx.mcall([
  { action: 'posts.find', params: { author: 1 } },
  { action: 'users.find', params: { name: 'Nazar' } }
], {
  meta: { token: '63f20c2d-8902-4d86-ad87-b58c9e2333c2' }
})
``` 
