### PR TITLE
Default param to empty object in call if undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -448,7 +448,7 @@ declare namespace Moleculer {
 		disconnected(): void;
 	}
 
-	class Context<P = GenericObject, M = GenericObject> {
+	class Context<P = {}, M extends object = {}> {
 		constructor(broker: ServiceBroker, endpoint: Endpoint);
 		id: string;
 		broker: ServiceBroker;
@@ -475,7 +475,7 @@ declare namespace Moleculer {
 
 		level: number;
 
-		params: P | null;
+		params: P;
 		meta: M;
 
 		requestID: string | null;
@@ -484,18 +484,19 @@ declare namespace Moleculer {
 
 		setEndpoint(endpoint: Endpoint): void;
 		setParams(newParams: P, cloning?: boolean): void;
-		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
+		call<T, P>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
+		call<T, P>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
 
-		emit<D = any>(eventName: string, data: D, opts: GenericObject): void;
-		emit<D = any>(eventName: string, data: D, groups: Array<string>): void;
-		emit<D = any>(eventName: string, data: D, groups: string): void;
-		emit<D = any>(eventName: string, data: D): void;
+		emit<D>(eventName: string, data: D, opts: GenericObject): void;
+		emit<D>(eventName: string, data: D, groups: Array<string>): void;
+		emit<D>(eventName: string, data: D, groups: string): void;
+		emit<D>(eventName: string, data: D): void;
 		emit(eventName: string): void;
 
-		broadcast<D = any>(eventName: string, data: D, opts: GenericObject): void;
-		broadcast<D = any>(eventName: string, data: D, groups: Array<string>): void;
-		broadcast<D = any>(eventName: string, data: D, groups: string): void;
-		broadcast<D = any>(eventName: string, data: D): void;
+		broadcast<D>(eventName: string, data: D, opts: GenericObject): void;
+		broadcast<D>(eventName: string, data: D, groups: Array<string>): void;
+		broadcast<D>(eventName: string, data: D, groups: string): void;
+		broadcast<D>(eventName: string, data: D): void;
 		broadcast(eventName: string): void;
 
 		copy(endpoint: Endpoint): Context;

--- a/index.d.ts
+++ b/index.d.ts
@@ -484,7 +484,7 @@ declare namespace Moleculer {
 
 		setEndpoint(endpoint: Endpoint): void;
 		setParams(newParams: P, cloning?: boolean): void;
-		call<T, P>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
+		call<T>(actionName: string): PromiseLike<T>;
 		call<T, P>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
 
 		emit<D>(eventName: string, data: D, opts: GenericObject): void;

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -1003,7 +1003,7 @@ class ServiceBroker {
 	 * @memberof ServiceBroker
 	 */
 	call(actionName, params, opts = {}) {
-		if (params == null)
+		if (params === undefined)
 			params = {}; // Backward compatibility
 
 		// Create context

--- a/test/integration/__snapshots__/tracing.spec.js.snap
+++ b/test/integration/__snapshots__/tracing.spec.js.snap
@@ -56,7 +56,7 @@ Array [
       "fromCache": false,
       "nodeID": "broker-1",
       "options": Object {},
-      "params": Object {},
+      "params": null,
       "remoteCall": false,
     },
     "traceID": "broker-1-1",

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1670,7 +1670,57 @@ describe("Test broker.call", () => {
 	beforeAll(() => oldContextCreate = broker.ContextFactory.create);
 	afterAll(() => broker.ContextFactory.create = oldContextCreate);
 
+	it("should default params on context to empty object if undefined", () => {
+		let context = {
+			action,
+			endpoint: ep,
+			setEndpoint: jest.fn()
+		};
+		broker.ContextFactory.create = jest.fn(() => context);
+
+		let p = broker.call("posts.find");
+		return p.catch(protectReject).then(() => {
+			expect(broker.ContextFactory.create).toHaveBeenCalledWith(broker, null, {}, {});
+			context.setEndpoint.mockClear();
+		});
+	});
+
+	it("should set params on context to passed in value", () => {
+		let context = {
+			action,
+			endpoint: ep,
+			setEndpoint: jest.fn()
+		};
+		broker.ContextFactory.create = jest.fn(() => context);
+
+		let params = { userId: "userId-value" };
+		let p = broker.call("posts.find", params );
+		return p.catch(protectReject).then(() => {
+			expect(broker.ContextFactory.create).toHaveBeenCalledWith(broker, null, params, {});
+			context.setEndpoint.mockClear();
+		});
+	});
+
+	it("should set params on context to null if passed in value is null", () => {
+		let context = {
+			action,
+			endpoint: ep,
+			setEndpoint: jest.fn()
+		};
+		broker.ContextFactory.create = jest.fn(() => context);
+
+		let p = broker.call("posts.find", null);
+		return p.catch(protectReject).then(() => {
+			expect(broker.ContextFactory.create).toHaveBeenCalledWith(broker, null, null, {});
+			context.setEndpoint.mockClear();
+		});
+	});
+
 	it("should create new Context & call handler", () => {
+		action.handler.mockClear();
+		broker.ContextFactory.create.mockClear();
+		broker.findNextActionEndpoint.mockClear();
+
 		let context = {
 			action,
 			endpoint: ep,


### PR DESCRIPTION
## :memo: Only default params to empty object in broker.call if params are undefined and make Context class types stricter

This PR implements the suggestions made by @shawnmcknight in issue #571 to make the typing on the Context class more restrictive. In that issue it was noted that the updated typings for the `params` member was a breaking change for TypeScript users because `params` was now nullable. TypeScript users would have to perform a null check before accessing `ctx.params`. A proposed solution was to make the types more restrictive, forcing TypeScript users to explicitly set `P` to null if they wanted `params` to be null. In addition to this, a change was made in `broker.call` to only default `params` to an empty object if `params` was undefined. This mostly preserves backwards compatibility and allows the caller to actually set `params` to null if they wish.

The default types on the Context class were left so we did not have to change every single use of Context in the types. A default of empty object instead of GenericObject means that the caller will most likely have to specify a type since empty object is very limited. The thinking here is that in order to get type safety on ctx.call, ctx.emit, and ctx.broadcast the caller must provide types and defaulting to GenericObject is to unrestricted to be safe.

### :dart: Relevant issues
#571 

### :gem: Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I ran our services using this version of moleculer-services

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
