### PR TITLE
Update types for Typescript - fixed GenericObject

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace Moleculer {
-	type GenericObject = { [name: string]: any };
+	type GenericObject = any;
 
 	type LogLevels = "fatal" | "error" | "warn" | "info" | "debug" | "trace";
 


### PR DESCRIPTION
Current GenericObject makes a lot of trouble when using Moleculer with Typescript.
Extending it allows any property on interface, but we are using Typescript because we want to use strict types.

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)