### PR TITLE
Added Type Definition disableVersionCheck for BrokerTransitOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -244,6 +244,7 @@ declare namespace Moleculer {
 		maxQueueSize?: number;
 		packetLogFilter?: Array<string>;
 		disableReconnect?: boolean;
+		disableVersionCheck?: boolean;
 	}
 
 	interface BrokerTrackingOptions {


### PR DESCRIPTION
## :memo: Description
Transit Options are missing a type definition for `disableVersionCheck` as specified in `v0.13` broker documentation.

### :dart: Relevant issues
No Issues

### :gem: Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```js
disableVersionCheck?: boolean;
``` 

## :vertical_traffic_light: How Has This Been Tested?
- [X] Tested with all existing unit tests

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
