### PR TITLE
Allow service broker to be reclaimed by GC

### DIFF
--- a/src/metrics/commons.js
+++ b/src/metrics/commons.js
@@ -20,13 +20,6 @@ try {
 	// silent
 }
 
-// Load `gc-stats` module for GC metrics.
-try {
-	gc = (require("gc-stats"))();
-} catch (e) {
-	// silent
-}
-
 // Load `event-loop-stats` metric for Event-loop metrics.
 try {
 	eventLoop = require("event-loop-stats");
@@ -139,6 +132,13 @@ function registerCommonMetrics() {
  *
  */
 function startGCWatcher() {
+// Load `gc-stats` module for GC metrics.
+	try {
+		gc = (require("gc-stats"))();
+	} catch (e) {
+	// silent
+	}
+
 	/* istanbul ignore next */
 	if (gc) {
 		gc.on("stats", stats => {

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -189,7 +189,6 @@ class ServiceBroker {
 
 			// Async storage for Contexts
 			this.scope = new AsyncStorage(this);
-			this.scope.enable();
 
 			// Metrics Registry
 			this.metrics = new MetricRegistry(this, this.options.metrics);
@@ -415,6 +414,10 @@ class ServiceBroker {
 	start() {
 		return Promise.resolve()
 			.then(() => {
+				this.tracer.restartScope();
+				this.scope.enable();
+			})
+			.then(() => {
 				return this.callMiddlewareHook("starting", [this]);
 			})
 			.then(() => {
@@ -500,6 +503,10 @@ class ServiceBroker {
 			.then(() => {
 				if (_.isFunction(this.options.stopped))
 					return this.options.stopped(this);
+			})
+			.then(() => {
+				this.tracer.stopAndClearScope();
+				this.scope.stop();
 			})
 			.catch(err => {
 				/* istanbul ignore next */

--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -70,6 +70,7 @@ class Tracer {
 
 		this.scope = new AsyncStorage(this.broker);
 		this.scope.enable();
+		this._scopeEnabled = true;
 
 		if (this.opts.enabled)
 			this.logger.info("Tracing: Enabled");
@@ -105,6 +106,30 @@ class Tracer {
 	 */
 	isEnabled() {
 		return this.opts.enabled;
+	}
+
+	/**
+	 * Disable trace hooks and clear the store - noop if scope is already stopped
+	 *
+	 * @memberof Tracer
+	 */
+	stopAndClearScope() {
+		if (this._scopeEnabled) {
+			this.scope.stop();
+			this._scopeEnabled = false;
+		}
+	}
+
+	/**
+	 * Renable the trace hooks - noop if scope is already enabled
+	 *
+	 * @memberof Tracer
+	 */
+	restartScope() {
+		if (!this._scopeEnabled) {
+			this.scope.enable();
+			this._scopeEnabled = true;
+		}
 	}
 
 	/**

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -451,11 +451,16 @@ describe("Test broker.start", () => {
 		broker.broadcastLocal = jest.fn();
 		broker.metrics.set = jest.fn();
 		broker.callMiddlewareHook = jest.fn();
+		broker.scope.enable = jest.fn();
+		broker.tracer.restartScope = jest.fn();
 
 
-		beforeAll(() => broker.start());
+		beforeAll(() =>	broker.start());
 
 		it("should call started of services", () => {
+			expect(broker.scope.enable).toHaveBeenCalledTimes(1);
+			expect(broker.tracer.restartScope).toHaveBeenCalledTimes(1);
+
 			expect(optStarted).toHaveBeenCalledTimes(1);
 			expect(schema.started).toHaveBeenCalledTimes(1);
 			expect(broker.transit.connect).toHaveBeenCalledTimes(1);
@@ -495,10 +500,15 @@ describe("Test broker.start", () => {
 		broker.broadcastLocal = jest.fn();
 		broker.metrics.set = jest.fn();
 		broker.callMiddlewareHook = jest.fn();
+		broker.scope.enable = jest.fn();
+		broker.tracer.restartScope = jest.fn();
 
 		beforeAll(() => broker.start());
 
 		it("should call started of services", () => {
+			expect(broker.scope.enable).toHaveBeenCalledTimes(1);
+			expect(broker.tracer.restartScope).toHaveBeenCalledTimes(1);
+
 			expect(optStarted).toHaveBeenCalledTimes(1);
 			expect(schema.started).toHaveBeenCalledTimes(1);
 			expect(broker.transit.connect).toHaveBeenCalledTimes(1);
@@ -539,12 +549,17 @@ describe("Test broker.start", () => {
 		broker.localBus.emit = jest.fn();
 		broker.metrics.set = jest.fn();
 		broker.callMiddlewareHook = jest.fn();
+		broker.scope.enable = jest.fn();
+		broker.tracer.restartScope = jest.fn();
 
 		it("should reject", () => {
 			return expect(broker.start()).rejects.toBeDefined();
 		});
 
 		it("should not call others", () => {
+			expect(broker.scope.enable).toHaveBeenCalledTimes(1);
+			expect(broker.tracer.restartScope).toHaveBeenCalledTimes(1);
+
 			expect(optStarted).toHaveBeenCalledTimes(0);
 			expect(broker.transit.connect).toHaveBeenCalledTimes(1);
 			expect(schema.started).toHaveBeenCalledTimes(1);
@@ -587,6 +602,8 @@ describe("Test broker.stop", () => {
 		broker.metrics.set = jest.fn();
 		broker.metrics.stop = jest.fn();
 		broker.loggerFactory.stop = jest.fn();
+		broker.scope.stop = jest.fn();
+		broker.tracer.stopAndClearScope = jest.fn();
 
 		broker.cacher = {
 			close: jest.fn(() => Promise.resolve())
@@ -615,6 +632,9 @@ describe("Test broker.stop", () => {
 
 				expect(broker.broadcastLocal).toHaveBeenCalledTimes(1);
 				expect(broker.broadcastLocal).toHaveBeenCalledWith("$broker.stopped");
+
+				expect(broker.scope.stop).toHaveBeenCalledTimes(1);
+				expect(broker.tracer.stopAndClearScope).toHaveBeenCalledTimes(1);
 
 				expect(broker.metrics.set).toHaveBeenCalledTimes(1);
 				expect(broker.metrics.set).toHaveBeenCalledWith("moleculer.broker.started", 0);
@@ -648,6 +668,8 @@ describe("Test broker.stop", () => {
 		broker.metrics.stop = jest.fn();
 		broker.metrics.set = jest.fn();
 		broker.loggerFactory.stop = jest.fn();
+		broker.scope.stop = jest.fn();
+		broker.tracer.stopAndClearScope = jest.fn();
 
 		broker.cacher = {
 			close: jest.fn(() => Promise.resolve())
@@ -676,6 +698,9 @@ describe("Test broker.stop", () => {
 
 				expect(broker.broadcastLocal).toHaveBeenCalledTimes(1);
 				expect(broker.broadcastLocal).toHaveBeenCalledWith("$broker.stopped");
+
+				expect(broker.scope.stop).toHaveBeenCalledTimes(1);
+				expect(broker.tracer.stopAndClearScope).toHaveBeenCalledTimes(1);
 
 				expect(broker.metrics.set).toHaveBeenCalledTimes(1);
 				expect(broker.metrics.set).toHaveBeenCalledWith("moleculer.broker.started", 0);
@@ -708,6 +733,8 @@ describe("Test broker.stop", () => {
 		broker.metrics.set = jest.fn();
 		broker.loggerFactory.stop = jest.fn();
 		broker.callMiddlewareHook = jest.fn();
+		broker.scope.stop = jest.fn();
+		broker.tracer.stopAndClearScope = jest.fn();
 
 		broker.cacher = {
 			close: jest.fn(() => Promise.resolve())
@@ -735,6 +762,9 @@ describe("Test broker.stop", () => {
 
 				expect(broker.broadcastLocal).toHaveBeenCalledTimes(1);
 				expect(broker.broadcastLocal).toHaveBeenCalledWith("$broker.stopped");
+
+				expect(broker.scope.stop).toHaveBeenCalledTimes(1);
+				expect(broker.tracer.stopAndClearScope).toHaveBeenCalledTimes(1);
 
 				expect(broker.metrics.set).toHaveBeenCalledTimes(1);
 				expect(broker.metrics.set).toHaveBeenCalledWith("moleculer.broker.started", 0);


### PR DESCRIPTION
Changes to add tracing and to collect garbage collection metrics were
causing the ServiceBroker instances to not be reclaimed after going out
of scope in our test suite where we create a new ServiceBroker instance and a lot of services in each test file.

The use of AsyncStorage in both the service broker and the Tracer class
were causing AsyncStorage to hold the ServiceBroker. The broker's
start/stop lifecycle hooks were modified to enable the scope and to
disable the scope and clear the store on stop. I added two new methods to the `Tracer` class to facilitate this. `restartScope` and `stopAndClearScope` can be used to enable/disable scope. They are no-ops if called repeatedly.

The automatic import and invocation of the gc-stats module in the metrics module
was causing the ServiceBroker to be held by system/Context in our unit
tests. I am not sure of the exact reason but only importing and invoking
the module when metrics are enabled resolved this issue

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/609

### :gem: Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

To verify that the service broker was being released I ran our Jest test suite with the --logHeapUsage flag.

To verify that the gc metrics and tracing still worked correctly I ran our services with tracing and metrics enabled and verified that tracing worked and gc stats were being emitted.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
