### PR TITLE
Updates to 0.14 typedefs of Context-based events and debounce and thr…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -534,10 +534,10 @@ declare namespace Moleculer {
 		context?: boolean;
 		debounce?: number;
 		throttle?: number;
-		handler?: ServiceEventHandler | ServiceEventOldHandler;
+		handler?: ServiceEventHandler | ServiceEventLegacyHandler;
 	}
 
-	type ServiceEvents = { [key: string]: ServiceEventHandler | ServiceEventOldHandler | ServiceEvent };
+	type ServiceEvents = { [key: string]: ServiceEventHandler | ServiceEventLegacyHandler | ServiceEvent };
 
 	type ServiceMethods = { [key: string]: ((...args: any[]) => any) } & ThisType<Service>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -524,15 +524,20 @@ declare namespace Moleculer {
 		[name: string]: any;
 	}
 
-	type ServiceEventHandler = ((payload: any, sender: string, eventName: string) => void) & ThisType<Service>;
+	type ServiceEventOldHandler = ((payload: any, sender: string, eventName: string, ctx: Context) => void) & ThisType<Service>;
+
+	type ServiceEventHandler = ((ctx: Context) => void) & ThisType<Service>;
 
 	interface ServiceEvent {
 		name?: string;
 		group?: string;
-		handler?: ServiceEventHandler;
+		context?: boolean;
+		debounce?: number;
+		throttle?: number;
+		handler?: ServiceEventHandler | ServiceEventOldHandler;
 	}
 
-	type ServiceEvents = { [key: string]: ServiceEventHandler | ServiceEvent };
+	type ServiceEvents = { [key: string]: ServiceEventHandler | ServiceEventOldHandler | ServiceEvent };
 
 	type ServiceMethods = { [key: string]: ((...args: any[]) => any) } & ThisType<Service>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -524,7 +524,7 @@ declare namespace Moleculer {
 		[name: string]: any;
 	}
 
-	type ServiceEventOldHandler = ((payload: any, sender: string, eventName: string, ctx: Context) => void) & ThisType<Service>;
+	type ServiceEventLegacyHandler = ((payload: any, sender: string, eventName: string, ctx: Context) => void) & ThisType<Service>;
 
 	type ServiceEventHandler = ((ctx: Context) => void) & ThisType<Service>;
 


### PR DESCRIPTION
## :memo: Description
Changed typedef of ServiceEventHandler to match old and new signature.
Added 0.14 options (context, debounce, throttle) of ServiceEvent.

This change is neccessary to be able to use the new options and Conext-based events with TypeScript.

### :gem: Type of change
- [ ] New feature (non-breaking change which adds functionality)

## :checkered_flag: Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

