### PR TITLE
Add type definition for Transporter's 'onConnected()' function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -998,6 +998,7 @@ declare namespace Moleculer {
 		init(transit: Transit, messageHandler: (cmd: string, msg: string) => void, afterConnect: (wasReconnect: boolean) => void): void;
 		connect(): PromiseLike<any>;
 		disconnect(): PromiseLike<any>;
+		onConnected(wasReconnect: boolean): PromiseLike<any>;
 
 		makeSubscriptions(topics: Array<GenericObject>): PromiseLike<void>;
 		subscribe(cmd: string, nodeID?: string): PromiseLike<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -998,7 +998,7 @@ declare namespace Moleculer {
 		init(transit: Transit, messageHandler: (cmd: string, msg: string) => void, afterConnect: (wasReconnect: boolean) => void): void;
 		connect(): PromiseLike<any>;
 		disconnect(): PromiseLike<any>;
-		onConnected(wasReconnect: boolean): PromiseLike<any>;
+		onConnected(wasReconnect?: boolean): PromiseLike<any>;
 
 		makeSubscriptions(topics: Array<GenericObject>): PromiseLike<void>;
 		subscribe(cmd: string, nodeID?: string): PromiseLike<void>;


### PR DESCRIPTION
## :memo: Description
This PR adds transporter's `onConnected()` type definition, which is currently missing
### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)