### PR TITLE
Feature/amqp defaults cleanup

### DIFF
--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -74,11 +74,15 @@ class AmqpTransporter extends Transporter {
 		if (typeof opts.consumeOptions !== "object")
 			opts.consumeOptions = {};
 
+		// The default behavior is to delete the queues after they haven't had any
+		// connected consumers for 2 minutes.
+		const autoDeleteQueuesAfterDefault = 2*60*1000;
+
 		opts.autoDeleteQueues =
-			opts.autoDeleteQueues === true ? 2*60*1000 :
+			opts.autoDeleteQueues === true ? autoDeleteQueuesAfterDefault :
 				typeof opts.autoDeleteQueues === "number" ? opts.autoDeleteQueues :
 					opts.autoDeleteQueues === false ? -1 :
-						-1; // Eventually we could change default
+						autoDeleteQueuesAfterDefault;
 
 		// Support for multiple URLs (clusters)
 		opts.url = Array.isArray(opts.url)

--- a/test/unit/transporters/amqp.spec.js
+++ b/test/unit/transporters/amqp.spec.js
@@ -61,7 +61,7 @@ describe("Test AmqpTransporter constructor", () => {
 			messageOptions: {},
 			queueOptions: {},
 			consumeOptions: {},
-			autoDeleteQueues: -1
+			autoDeleteQueues: 120000
 		});
 		expect(transporter.connected).toBe(false);
 		expect(transporter.hasBuiltInBalancer).toBe(true);
@@ -80,7 +80,7 @@ describe("Test AmqpTransporter constructor", () => {
 			messageOptions: { expiration: 120000, persistent: true, mandatory: true },
 			queueOptions: { deadLetterExchange: "dlx", maxLength: 100 },
 			consumeOptions: { priority: 5 },
-			autoDeleteQueues: -1
+			autoDeleteQueues: 31337
 		};
 		let transporter = new AmqpTransporter(opts);
 		expect(transporter.opts).toEqual(opts);
@@ -253,7 +253,7 @@ describe("Test AmqpTransporter subscribe", () => {
 				expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(1);
 				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
 				expect(transporter.channel.assertQueue)
-					.toHaveBeenCalledWith("MOL-TEST.RES.node", {});
+					.toHaveBeenCalledWith("MOL-TEST.RES.node", { expires: 120000 });
 				expect(transporter.channel.consume)
 					.toHaveBeenCalledWith("MOL-TEST.RES.node", jasmine.any(Function), { noAck: true });
 
@@ -292,7 +292,7 @@ describe("Test AmqpTransporter subscribe", () => {
 				expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(1);
 				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
 				expect(transporter.channel.assertQueue)
-					.toHaveBeenCalledWith("MOL-TEST.REQ.node", {});
+					.toHaveBeenCalledWith("MOL-TEST.REQ.node", { expires: 120000 });
 				expect(transporter.channel.consume)
 					.toHaveBeenCalledWith("MOL-TEST.REQ.node", jasmine.any(Function), { noAck: false });
 
@@ -313,7 +313,7 @@ describe("Test AmqpTransporter subscribe", () => {
 				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
 
 				expect(transporter.channel.assertQueue)
-					.toHaveBeenCalledWith("MOL-TEST.EVENT.node", { messageTtl: 3000 }); // use ttl option
+					.toHaveBeenCalledWith("MOL-TEST.EVENT.node", { expires: 120000, messageTtl: 3000 }); // use ttl option
 				expect(transporter.channel.consume)
 					.toHaveBeenCalledWith("MOL-TEST.EVENT.node", jasmine.any(Function), { noAck: true });
 
@@ -410,7 +410,7 @@ describe("Test AmqpTransporter subscribe", () => {
 				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
 				expect(transporter.channel.assertQueue)
 					.toHaveBeenCalledWith("MOL-TEST.EVENTB.posts.cache.clear",
-						{ messageTtl: 3000 });
+						{ expires: 120000, messageTtl: 3000 });
 				expect(transporter.channel.consume)
 					.toHaveBeenCalledWith("MOL-TEST.EVENTB.posts.cache.clear", jasmine.any(Function), {});
 

--- a/test/unit/transporters/index.spec.js
+++ b/test/unit/transporters/index.spec.js
@@ -108,7 +108,7 @@ describe("Test Transporter resolver", () => {
 				messageOptions: {},
 				queueOptions: {},
 				consumeOptions: {},
-				autoDeleteQueues: -1
+				autoDeleteQueues: 120000
 			});
 		});
 	});


### PR DESCRIPTION
## :memo: Description

Leaving the cleanup process disabled will eventually create a lot of unused queues that can be hard to clean up and they are unlikely to every serve any purpose again.

Enabling this feature by default will ensure a good onboarding experience for new implemntors and should result in a smoother experience all over.

### :dart: Relevant issues
- #635

### :gem: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Nothing in particular, other than having it manually configured before.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
