### PR TITLE
streams in objectMode

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -463,6 +463,7 @@ class Transit {
 
 			// Create a new pass stream
 			pass = new Transform({
+			        objectMode: payload.objectMode,
 				transform: function(chunk, encoding, done) {
 					this.push(chunk);
 					return done();
@@ -609,6 +610,7 @@ class Transit {
 			this.logger.debug(`<= New stream is received from '${packet.sender}'. Seq: ${packet.seq}`);
 
 			pass = new Transform({
+			        objectMode: packet.objectMode,
 				transform: function(chunk, encoding, done) {
 					this.push(chunk);
 					return done();
@@ -737,6 +739,7 @@ class Transit {
 		};
 
 		if (payload.stream) {
+		        payload.objectMode = ctx.params.readableObjectMode === true || (ctx.params._readableState && ctx.params._readableState.objectMode === true);
 			payload.seq = 0;
 		}
 
@@ -777,6 +780,7 @@ class Transit {
 						copy.seq = ++payload.seq;
 						copy.params = null;
 						copy.stream = false;
+						delete copy.objectMode;
 
 						this.logger.debug(`=> Send stream closing to ${nodeName} node. Seq: ${copy.seq}`);
 
@@ -788,6 +792,7 @@ class Transit {
 						const copy = Object.assign({}, payload);
 						copy.seq = ++payload.seq;
 						copy.stream = false;
+						delete copy.objectMode;
 						copy.meta["$streamError"] = this._createPayloadErrorField(err);
 						copy.params = null;
 
@@ -922,6 +927,7 @@ class Transit {
 		if (data && data.readable === true && typeof data.on === "function" && typeof data.pipe === "function") {
 			// Streaming response
 			payload.stream = true;
+			payload.objectMode = data.readableObjectMode === true || (data._readableState && data._readableState.objectMode === true);
 			payload.seq = 0;
 
 			const stream = data;
@@ -944,6 +950,7 @@ class Transit {
 			stream.on("end", () => {
 				const copy = Object.assign({}, payload);
 				copy.stream = false;
+				delete copy.objectMode;
 				copy.seq = ++payload.seq;
 				copy.data = null;
 
@@ -956,6 +963,7 @@ class Transit {
 			stream.on("error", err => {
 				const copy = Object.assign({}, payload);
 				copy.stream = false;
+				delete copy.objectMode;
 				copy.seq = ++payload.seq;
 				if (err) {
 					copy.success = false;

--- a/src/transit.js
+++ b/src/transit.js
@@ -462,7 +462,7 @@ class Transit {
 
 			// Create a new pass stream
 			pass = new Transform({
-			        objectMode: payload.meta && payload.meta["$streamObjectMode"],
+				objectMode: payload.meta && payload.meta["$streamObjectMode"],
 				transform: function(chunk, encoding, done) {
 					this.push(chunk);
 					return done();
@@ -609,7 +609,7 @@ class Transit {
 			this.logger.debug(`<= New stream is received from '${packet.sender}'. Seq: ${packet.seq}`);
 
 			pass = new Transform({
-			        objectMode: packet.meta && packet.meta["$streamObjectMode"],
+				objectMode: packet.meta && packet.meta["$streamObjectMode"],
 				transform: function(chunk, encoding, done) {
 					this.push(chunk);
 					return done();
@@ -738,9 +738,9 @@ class Transit {
 		};
 
 		if (payload.stream) {
-		        if (ctx.params.readableObjectMode === true || (ctx.params._readableState && ctx.params._readableState.objectMode === true)) {
+			if (ctx.params.readableObjectMode === true || (ctx.params._readableState && ctx.params._readableState.objectMode === true)) {
 				payload.meta = payload.meta || {};
-			        payload.meta["$streamObjectMode"] = true;
+				payload.meta["$streamObjectMode"] = true;
 			}
 			payload.seq = 0;
 		}

--- a/test/integration/stream.spec.js
+++ b/test/integration/stream.spec.js
@@ -357,27 +357,27 @@ describe("Test to send stream in objectMode as ctx.param", () => {
 		return b1.Promise.resolve()
 			.then(() => b1.call("data.store", stream))
 			.then(res => expect(res).toBe("OK"))
-			.then(() => stream.push({"id": 123, data: "first record"}))
+			.then(() => stream.push({ "id": 123, data: "first record" }))
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"}
+					{ "id": 123, data: "first record" }
 				]);
-				stream.push({"id": 786, data: "second record"});
+				stream.push({ "id": 786, data: "second record" });
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"},
-					{"id": 786, data: "second record"}
+					{ "id": 123, data: "first record" },
+					{ "id": 786, data: "second record" }
 				]);
 				stream.emit("end");
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"},
-					{"id": 786, data: "second record"},
+					{ "id": 123, data: "first record" },
+					{ "id": 786, data: "second record" },
 					"<END>"
 				]);
 			});
@@ -393,18 +393,18 @@ describe("Test to send stream in objectMode as ctx.param", () => {
 		return b1.Promise.resolve()
 			.then(() => b1.call("data.store", stream))
 			.then(res => expect(res).toBe("OK"))
-			.then(() => stream.push({"id": 123, data: "first record"}))
+			.then(() => stream.push({ "id": 123, data: "first record" }))
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"}
+					{ "id": 123, data: "first record" }
 				]);
 				stream.emit("error", new Error("Something happened"));
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"},
+					{ "id": 123, data: "first record" },
 					"<ERROR:Something happened>",
 					"<END>"
 				]);
@@ -457,27 +457,27 @@ describe("Test to receive a stream in objectMode as response", () => {
 				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
 				res.on("end", () => FLOW.push("<END>"));
 			})
-			.then(() => stream.push({"id": 123, data: "first record"}))
+			.then(() => stream.push({ "id": 123, data: "first record" }))
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"}
+					{ "id": 123, data: "first record" }
 				]);
-				stream.push({"id": 786, data: "second record"});
+				stream.push({ "id": 786, data: "second record" });
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"},
-					{"id": 786, data: "second record"}
+					{ "id": 123, data: "first record" },
+					{ "id": 786, data: "second record" }
 				]);
 				stream.emit("end");
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"},
-					{"id": 786, data: "second record"},
+					{ "id": 123, data: "first record" },
+					{ "id": 786, data: "second record" },
 					"<END>"
 				]);
 			});
@@ -494,18 +494,18 @@ describe("Test to receive a stream in objectMode as response", () => {
 				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
 				res.on("end", () => FLOW.push("<END>"));
 			})
-			.then(() => stream.push({"id": 123, data: "first record"}))
+			.then(() => stream.push({ "id": 123, data: "first record" }))
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"}
+					{ "id": 123, data: "first record" }
 				]);
 				stream.emit("error", new Error("Something happened"));
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{"id": 123, data: "first record"},
+					{ "id": 123, data: "first record" },
 					"<ERROR:Something happened>",
 					"<END>"
 				]);
@@ -534,14 +534,14 @@ describe("Test duplex streaming, result in objectMode", () => {
 		name: "csv",
 		actions: {
 			parse(ctx) {
-		                const pass = new Stream.Readable({
+				const pass = new Stream.Readable({
 					objectMode: true,
-		                        read() {}
+					read() {}
 				});
 
 				// this fake parser only works if each chunk is exactly one line
 				let line=0;
-				ctx.params.on("data", msg => pass.push({line:++line,data:msg.toString().split(";")}));
+				ctx.params.on("data", msg => pass.push({ line: ++line, data: msg }));
 				ctx.params.on("end", () => pass.emit("end"));
 				ctx.params.on("error", err => pass.emit("error", err));
 				return pass;
@@ -555,6 +555,7 @@ describe("Test duplex streaming, result in objectMode", () => {
 	it("should send & receive stream in objectMode", () => {
 		const FLOW = [];
 		const stream = new Stream.Readable({
+			objectMode: true,
 			read() {}
 		});
 
@@ -567,27 +568,27 @@ describe("Test duplex streaming, result in objectMode", () => {
 				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
 				res.on("end", () => FLOW.push("<END>"));
 			})
-			.then(() => stream.push("123;first record"))
+			.then(() => stream.push({ "id": 123, data: "first record" }))
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{line: 1, data: ["123","first record"]}
+					{ line: 1, data: { "id": 123, data: "first record" } }
 				]);
-				stream.push(Buffer.from("786;second record"));
+				stream.push({ "id": 786, data: "second record" });
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{line: 1, data: ["123","first record"]},
-					{line: 2, data: ["786","second record"]}
+					{ line: 1, data: { "id": 123, data: "first record" } },
+					{ line: 2, data: { "id": 786, data: "second record" } }
 				]);
 				stream.emit("end");
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{line: 1, data: ["123","first record"]},
-					{line: 2, data: ["786","second record"]},
+					{ line: 1, data: { "id": 123, data: "first record" } },
+					{ line: 2, data: { "id": 786, data: "second record" } },
 					"<END>"
 				]);
 			});
@@ -596,29 +597,30 @@ describe("Test duplex streaming, result in objectMode", () => {
 	it("should receive stream in objectMode & handle error", () => {
 		const FLOW = [];
 		const stream = new Stream.Readable({
+			objectMode: true,
 			read() {}
 		});
 		return b1.Promise.resolve()
 			.then(() => b1.call("csv.parse", stream))
 			.then(res => {
 				expect(res).toBeInstanceOf(Stream.Readable);
-                                expect(res.readableObjectMode === true || (res._readableState && res._readableState.objectMode === true)).toBe(true);
+				expect(res.readableObjectMode === true || (res._readableState && res._readableState.objectMode === true)).toBe(true);
 				res.on("data", msg => FLOW.push(msg));
 				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
 				res.on("end", () => FLOW.push("<END>"));
 			})
-			.then(() => stream.push("123;first record"))
+			.then(() => stream.push({ "id": 123, data: "first record" }))
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{line: 1, data: ["123","first record"]}
+					{ line: 1, data: { "id": 123, data: "first record" } }
 				]);
 				stream.emit("error", new Error("Something happened"));
 			})
 			.delay(100)
 			.then(() => {
 				expect(FLOW).toEqual([
-					{line: 1, data: ["123","first record"]},
+					{ line: 1, data: { "id": 123, data: "first record" } },
 					"<ERROR:Something happened>",
 					"<END>"
 				]);

--- a/test/integration/stream.spec.js
+++ b/test/integration/stream.spec.js
@@ -308,3 +308,321 @@ describe("Test duplex streaming", () => {
 	});
 
 });
+
+describe("Test to send stream in objectMode as ctx.param", () => {
+
+	let b1 = new ServiceBroker({
+		logger: false,
+		namespace: "test-4",
+		transporter: "Fake",
+		nodeID: "node-1"
+	});
+
+	let b2 = new ServiceBroker({
+		logger: false,
+		namespace: "test-4",
+		transporter: "Fake",
+		nodeID: "node-2"
+	});
+
+	let FLOW = [];
+	let stream = new Stream.Readable({
+		objectMode: true,
+		read() {}
+	});
+
+	b2.createService({
+		name: "data",
+		actions: {
+			store(ctx) {
+				expect(FLOW).toEqual([]);
+				expect(ctx.params).toBeInstanceOf(Stream.Readable);
+				expect(ctx.params.readableObjectMode === true || (ctx.params._readableState && ctx.params._readableState.objectMode === true)).toBe(true);
+				ctx.params.on("data", msg => FLOW.push(msg));
+				ctx.params.on("error", err => {
+					FLOW.push("<ERROR:" + err.message + ">");
+				});
+				ctx.params.on("end", () => FLOW.push("<END>"));
+
+				return "OK";
+			}
+		}
+	});
+
+	beforeAll(() => Promise.all([b1.start(), b2.start()]));
+	afterAll(() => Promise.all([b1.stop(), b2.stop()]));
+
+	it("should receive stream in objectMode on b2", () => {
+		FLOW = [];
+		return b1.Promise.resolve()
+			.then(() => b1.call("data.store", stream))
+			.then(res => expect(res).toBe("OK"))
+			.then(() => stream.push({"id": 123, data: "first record"}))
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"}
+				]);
+				stream.push({"id": 786, data: "second record"});
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"},
+					{"id": 786, data: "second record"}
+				]);
+				stream.emit("end");
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"},
+					{"id": 786, data: "second record"},
+					"<END>"
+				]);
+			});
+	});
+
+	it("should receive stream in objectMode & handle error", () => {
+		FLOW = [];
+		stream = new Stream.Readable({
+			objectMode: true,
+			read() {}
+		});
+
+		return b1.Promise.resolve()
+			.then(() => b1.call("data.store", stream))
+			.then(res => expect(res).toBe("OK"))
+			.then(() => stream.push({"id": 123, data: "first record"}))
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"}
+				]);
+				stream.emit("error", new Error("Something happened"));
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"},
+					"<ERROR:Something happened>",
+					"<END>"
+				]);
+			});
+	});
+
+});
+
+describe("Test to receive a stream in objectMode as response", () => {
+
+	let b1 = new ServiceBroker({
+		logger: false,
+		namespace: "test-5",
+		transporter: "Fake",
+		nodeID: "node-1"
+	});
+
+	let b2 = new ServiceBroker({
+		logger: false,
+		namespace: "test-5",
+		transporter: "Fake",
+		nodeID: "node-2"
+	});
+
+	const stream = new Stream.Readable({
+		objectMode: true,
+		read() {}
+	});
+
+	b2.createService({
+		name: "db",
+		actions: {
+			query() {
+				return stream;
+			}
+		}
+	});
+
+	beforeAll(() => Promise.all([b1.start(), b2.start()]));
+	afterAll(() => Promise.all([b1.stop(), b2.stop()]));
+
+	it("should receive stream in objectMode", () => {
+		const FLOW = [];
+		return b1.Promise.resolve()
+			.then(() => b1.call("db.query"))
+			.then(res => {
+				expect(res).toBeInstanceOf(Stream.Readable);
+				expect(res.readableObjectMode === true || (res._readableState && res._readableState.objectMode === true)).toBe(true);
+				res.on("data", msg => FLOW.push(msg));
+				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
+				res.on("end", () => FLOW.push("<END>"));
+			})
+			.then(() => stream.push({"id": 123, data: "first record"}))
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"}
+				]);
+				stream.push({"id": 786, data: "second record"});
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"},
+					{"id": 786, data: "second record"}
+				]);
+				stream.emit("end");
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"},
+					{"id": 786, data: "second record"},
+					"<END>"
+				]);
+			});
+	});
+
+	it("should receive stream in objectMode & handle error", () => {
+		const FLOW = [];
+		return b1.Promise.resolve()
+			.then(() => b1.call("db.query"))
+			.then(res => {
+				expect(res).toBeInstanceOf(Stream.Readable);
+				expect(res.readableObjectMode === true || (res._readableState && res._readableState.objectMode === true)).toBe(true);
+				res.on("data", msg => FLOW.push(msg));
+				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
+				res.on("end", () => FLOW.push("<END>"));
+			})
+			.then(() => stream.push({"id": 123, data: "first record"}))
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"}
+				]);
+				stream.emit("error", new Error("Something happened"));
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{"id": 123, data: "first record"},
+					"<ERROR:Something happened>",
+					"<END>"
+				]);
+			});
+	});
+
+});
+
+describe("Test duplex streaming, result in objectMode", () => {
+
+	let b1 = new ServiceBroker({
+		logger: false,
+		namespace: "test-6",
+		transporter: "Fake",
+		nodeID: "node-1"
+	});
+
+	let b2 = new ServiceBroker({
+		logger: false,
+		namespace: "test-6",
+		transporter: "Fake",
+		nodeID: "node-2"
+	});
+
+	b2.createService({
+		name: "csv",
+		actions: {
+			parse(ctx) {
+		                const pass = new Stream.Readable({
+					objectMode: true,
+		                        read() {}
+				});
+
+				// this fake parser only works if each chunk is exactly one line
+				let line=0;
+				ctx.params.on("data", msg => pass.push({line:++line,data:msg.toString().split(";")}));
+				ctx.params.on("end", () => pass.emit("end"));
+				ctx.params.on("error", err => pass.emit("error", err));
+				return pass;
+			}
+		}
+	});
+
+	beforeAll(() => Promise.all([b1.start(), b2.start()]));
+	afterAll(() => Promise.all([b1.stop(), b2.stop()]));
+
+	it("should send & receive stream in objectMode", () => {
+		const FLOW = [];
+		const stream = new Stream.Readable({
+			read() {}
+		});
+
+		return b1.Promise.resolve()
+			.then(() => b1.call("csv.parse", stream))
+			.then(res => {
+				expect(res).toBeInstanceOf(Stream.Readable);
+				expect(res.readableObjectMode === true || (res._readableState && res._readableState.objectMode === true)).toBe(true);
+				res.on("data", msg => FLOW.push(msg));
+				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
+				res.on("end", () => FLOW.push("<END>"));
+			})
+			.then(() => stream.push("123;first record"))
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{line: 1, data: ["123","first record"]}
+				]);
+				stream.push(Buffer.from("786;second record"));
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{line: 1, data: ["123","first record"]},
+					{line: 2, data: ["786","second record"]}
+				]);
+				stream.emit("end");
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{line: 1, data: ["123","first record"]},
+					{line: 2, data: ["786","second record"]},
+					"<END>"
+				]);
+			});
+	});
+
+	it("should receive stream in objectMode & handle error", () => {
+		const FLOW = [];
+		const stream = new Stream.Readable({
+			read() {}
+		});
+		return b1.Promise.resolve()
+			.then(() => b1.call("csv.parse", stream))
+			.then(res => {
+				expect(res).toBeInstanceOf(Stream.Readable);
+                                expect(res.readableObjectMode === true || (res._readableState && res._readableState.objectMode === true)).toBe(true);
+				res.on("data", msg => FLOW.push(msg));
+				res.on("error", err => FLOW.push("<ERROR:" + err.message + ">"));
+				res.on("end", () => FLOW.push("<END>"));
+			})
+			.then(() => stream.push("123;first record"))
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{line: 1, data: ["123","first record"]}
+				]);
+				stream.emit("error", new Error("Something happened"));
+			})
+			.delay(100)
+			.then(() => {
+				expect(FLOW).toEqual([
+					{line: 1, data: ["123","first record"]},
+					"<ERROR:Something happened>",
+					"<END>"
+				]);
+			});
+	});
+
+});

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -541,6 +541,7 @@ describe("Test Transit.requestHandler", () => {
 			meta: { a: 5 },
 			action: "posts.find",
 			stream: true,
+			objectMode: false,
 			seq: 4
 		};
 
@@ -738,7 +739,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const payload = { ver: "4", sender: "remote", action: "posts.import", id: "123" };
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", () => STORE.push("-- ERROR --"));
@@ -746,9 +747,9 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 3, params: "CHUNK-3" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, params: "CHUNK-3" }))).toBeNull();
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2",
@@ -776,7 +777,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const errorHandler = jest.fn(() => STORE.push("-- ERROR --"));
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", errorHandler);
@@ -784,8 +785,8 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2"
@@ -813,7 +814,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const payload = { ver: "4", sender: "remote", action: "posts.import", id: "123" };
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", () => STORE.push("-- ERROR --"));
@@ -821,12 +822,12 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 4, params: "CHUNK-4" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 3, params: "CHUNK-3" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 6, params: "CHUNK-6" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 5, params: "CHUNK-5" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, params: "CHUNK-4" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, params: "CHUNK-3" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, params: "CHUNK-6" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, params: "CHUNK-5" }))).toBeNull();
 			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: false, seq: 7 }))).toBeNull();
 
 			return broker.Promise.delay(100).then(() => {
@@ -848,7 +849,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const payload = { ver: "4", sender: "remote", action: "posts.import", id: "124" };
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", () => STORE.push("-- ERROR --"));
@@ -856,13 +857,13 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 4, params: "CHUNK-4" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 3, params: "CHUNK-3" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, params: "CHUNK-4" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, params: "CHUNK-3" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
 			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: false, seq: 7 }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 6, params: "CHUNK-6" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 5, params: "CHUNK-5" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, params: "CHUNK-6" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, params: "CHUNK-5" }))).toBeNull();
 
 			return broker.Promise.delay(100).then(() => {
 				expect(STORE).toEqual([
@@ -1084,7 +1085,7 @@ describe("Test Transit.responseHandler", () => {
 		};
 		transit.pendingRequests.set(id, req);
 
-		let payload = { ver: "4", sender: "remote", id, success: true, stream: true, seq: 5 };
+		let payload = { ver: "4", sender: "remote", id, success: true, stream: true, objectMode: false, seq: 5 };
 		transit.responseHandler(payload);
 
 		expect(transit._handleIncomingResponseStream).toHaveBeenCalledTimes(1);
@@ -1140,7 +1141,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		transit.pendingRequests.set("124", req);
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1150,9 +1151,9 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2",
@@ -1187,7 +1188,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		transit.pendingRequests.set("125", req);
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1197,8 +1198,8 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2"
@@ -1234,7 +1235,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		const errorHandler = jest.fn(() => STORE.push("-- ERROR --"));
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1244,12 +1245,12 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
 			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: false, seq: 7 }), req)).toBe(true);
 
 			return broker.Promise.delay(100).then(() => {
@@ -1279,7 +1280,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		const errorHandler = jest.fn(() => STORE.push("-- ERROR --"));
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1289,13 +1290,13 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
 			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: false, seq: 7 }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
 
 			return broker.Promise.delay(100).then(() => {
 				expect(STORE).toEqual([
@@ -1447,6 +1448,7 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
+						objectMode: false,
 						params: null,
 						parentID: null,
 						requestID: "req-12345",
@@ -1472,6 +1474,7 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
+						objectMode: false,
 						params: Buffer.from("first chunk"),
 						parentID: null,
 						requestID: "req-12345",
@@ -1491,6 +1494,7 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
+						objectMode: false,
 						params: Buffer.from("second chunk"),
 						parentID: null,
 						requestID: "req-12345",
@@ -1545,6 +1549,7 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
+						objectMode: false,
 						params: null,
 						parentID: null,
 						requestID: "req-12345",
@@ -1569,6 +1574,7 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
+						objectMode: false,
 						params: Buffer.from("first chunk"),
 						parentID: null,
 						requestID: "req-12345",
@@ -1854,6 +1860,7 @@ describe("Test Transit.sendResponse", () => {
 						data: null,
 						id: "12345",
 						meta,
+						objectMode: false,
 						seq: 0,
 						stream: true,
 						success: true
@@ -1873,6 +1880,7 @@ describe("Test Transit.sendResponse", () => {
 						data: Buffer.from("first chunk"),
 						id: "12345",
 						meta,
+						objectMode: false,
 						seq: 1,
 						stream: true,
 						success: true
@@ -1886,6 +1894,7 @@ describe("Test Transit.sendResponse", () => {
 					payload: {
 						data: Buffer.from("second chunk"),
 						id: "12345",
+						objectMode: false,
 						meta,
 						seq: 2,
 						stream: true,
@@ -1931,6 +1940,7 @@ describe("Test Transit.sendResponse", () => {
 						data: null,
 						id: "12345",
 						meta,
+						objectMode: false,
 						seq: 0,
 						stream: true,
 						success: true
@@ -1949,6 +1959,7 @@ describe("Test Transit.sendResponse", () => {
 						data: Buffer.from("first chunk"),
 						id: "12345",
 						meta,
+						objectMode: false,
 						seq: 1,
 						stream: true,
 						success: true

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -1619,6 +1619,109 @@ describe("Test Transit._sendRequest", () => {
 			});
 		});
 
+		it("should send stream objects", () => {
+			transit.publish.mockClear();
+
+			let stream = new Stream.Readable({
+				objectMode: true,
+				read() {}
+			});
+			ctx.params = stream;
+
+			return transit._sendRequest(ctx, resolve, reject).catch(protectReject).then(() => {
+				expect(transit.publish).toHaveBeenCalledTimes(1);
+				expect(transit.publish).toHaveBeenCalledWith({
+					type: "REQ",
+					target: "remote",
+					payload: {
+						action: "users.find",
+						id: "12345",
+						level: 1,
+						meta: {},
+						tracing: null,
+						objectMode: true,
+						params: null,
+						parentID: null,
+						requestID: "req-12345",
+						caller: null,
+						seq: 0,
+						stream: true,
+						timeout: null
+					}
+				});
+
+				transit.publish.mockClear();
+				stream.push({id:0});
+				stream.push({id:1});
+			}).delay(100).then(() => {
+
+				expect(transit.publish).toHaveBeenCalledTimes(2);
+				expect(transit.publish).toHaveBeenCalledWith({
+					type: "REQ",
+					target: "remote",
+					payload: {
+						action: "users.find",
+						id: "12345",
+						level: 1,
+						meta: {},
+						tracing: null,
+						objectMode: true,
+						params: {id:0},
+						parentID: null,
+						requestID: "req-12345",
+						caller: null,
+						seq: 1,
+						stream: true,
+						timeout: null
+					}
+				});
+
+				expect(transit.publish).toHaveBeenCalledWith({
+					type: "REQ",
+					target: "remote",
+					payload: {
+						action: "users.find",
+						id: "12345",
+						level: 1,
+						meta: {},
+						tracing: null,
+						objectMode: true,
+						params: {id:1},
+						parentID: null,
+						requestID: "req-12345",
+						caller: null,
+						seq: 2,
+						stream: true,
+						timeout: null
+					}
+				});
+
+				transit.publish.mockClear();
+				stream.emit("end");
+			}).delay(100).then(() => {
+
+				expect(transit.publish).toHaveBeenCalledWith({
+					type: "REQ",
+					target: "remote",
+					payload: {
+						action: "users.find",
+						id: "12345",
+						level: 1,
+						meta: {},
+						tracing: null,
+						params: null,
+						parentID: null,
+						requestID: "req-12345",
+						caller: null,
+						seq: 3,
+						stream: false,
+						timeout: null
+					}
+				});
+			});
+		});
+
+
 	});
 
 });

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -540,7 +540,6 @@ describe("Test Transit.requestHandler", () => {
 			meta: { a: 5 },
 			action: "posts.find",
 			stream: true,
-			objectMode: false,
 			seq: 4
 		};
 
@@ -738,7 +737,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const payload = { ver: "4", sender: "remote", action: "posts.import", id: "123" };
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", () => STORE.push("-- ERROR --"));
@@ -746,9 +745,9 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, params: "CHUNK-3" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 3, params: "CHUNK-3" }))).toBeNull();
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2",
@@ -776,7 +775,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const errorHandler = jest.fn(() => STORE.push("-- ERROR --"));
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", errorHandler);
@@ -784,8 +783,8 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2"
@@ -813,7 +812,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const payload = { ver: "4", sender: "remote", action: "posts.import", id: "123" };
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", () => STORE.push("-- ERROR --"));
@@ -821,12 +820,12 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, params: "CHUNK-4" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, params: "CHUNK-3" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, params: "CHUNK-6" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, params: "CHUNK-5" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 4, params: "CHUNK-4" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 3, params: "CHUNK-3" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 6, params: "CHUNK-6" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 5, params: "CHUNK-5" }))).toBeNull();
 			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: false, seq: 7 }))).toBeNull();
 
 			return broker.Promise.delay(100).then(() => {
@@ -848,7 +847,7 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		const payload = { ver: "4", sender: "remote", action: "posts.import", id: "124" };
 
 		it("should create new stream", () => {
-			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, params: "CHUNK-1" }));
+			const pass = transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 1, params: "CHUNK-1" }));
 			expect(pass).toBeInstanceOf(Transform);
 			pass.on("data", data => STORE.push(data.toString()));
 			pass.on("error", () => STORE.push("-- ERROR --"));
@@ -856,13 +855,13 @@ describe("Test Transit._handleIncomingRequestStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, params: "CHUNK-4" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, params: "CHUNK-3" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, params: "CHUNK-2" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 0 }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 4, params: "CHUNK-4" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 3, params: "CHUNK-3" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 2, params: "CHUNK-2" }))).toBeNull();
 			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: false, seq: 7 }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, params: "CHUNK-6" }))).toBeNull();
-			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, params: "CHUNK-5" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 6, params: "CHUNK-6" }))).toBeNull();
+			expect(transit._handleIncomingRequestStream(Object.assign({}, payload, { stream: true, seq: 5, params: "CHUNK-5" }))).toBeNull();
 
 			return broker.Promise.delay(100).then(() => {
 				expect(STORE).toEqual([
@@ -1084,7 +1083,7 @@ describe("Test Transit.responseHandler", () => {
 		};
 		transit.pendingRequests.set(id, req);
 
-		let payload = { ver: "4", sender: "remote", id, success: true, stream: true, objectMode: false, seq: 5 };
+		let payload = { ver: "4", sender: "remote", id, success: true, stream: true, seq: 5 };
 		transit.responseHandler(payload);
 
 		expect(transit._handleIncomingResponseStream).toHaveBeenCalledTimes(1);
@@ -1140,7 +1139,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		transit.pendingRequests.set("124", req);
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1150,9 +1149,9 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2",
@@ -1187,7 +1186,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		transit.pendingRequests.set("125", req);
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1197,8 +1196,8 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should add chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
 			expect(STORE).toEqual([
 				"CHUNK-1",
 				"CHUNK-2"
@@ -1234,7 +1233,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		const errorHandler = jest.fn(() => STORE.push("-- ERROR --"));
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1244,12 +1243,12 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
 			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: false, seq: 7 }), req)).toBe(true);
 
 			return broker.Promise.delay(100).then(() => {
@@ -1279,7 +1278,7 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		const errorHandler = jest.fn(() => STORE.push("-- ERROR --"));
 
 		it("should create new stream", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 1, data: "CHUNK-1" }), req)).toBe(true);
 			expect(req.resolve).toHaveBeenCalledTimes(1);
 			const pass = req.resolve.mock.calls[0][0];
 			expect(pass).toBeInstanceOf(Transform);
@@ -1289,13 +1288,13 @@ describe("Test Transit._handleIncomingResponseStream", () => {
 		});
 
 		it("should reorder chunks", () => {
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 0 }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 0 }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 4, data: "CHUNK-4" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 3, data: "CHUNK-3" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 2, data: "CHUNK-2" }), req)).toBe(true);
 			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: false, seq: 7 }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
-			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, objectMode: false, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 6, data: "CHUNK-6" }), req)).toBe(true);
+			expect(transit._handleIncomingResponseStream(Object.assign({}, payload, { stream: true, seq: 5, data: "CHUNK-5" }), req)).toBe(true);
 
 			return broker.Promise.delay(100).then(() => {
 				expect(STORE).toEqual([
@@ -1447,7 +1446,6 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
-						objectMode: false,
 						params: null,
 						parentID: null,
 						requestID: "req-12345",
@@ -1473,7 +1471,6 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
-						objectMode: false,
 						params: Buffer.from("first chunk"),
 						parentID: null,
 						requestID: "req-12345",
@@ -1493,7 +1490,6 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
-						objectMode: false,
 						params: Buffer.from("second chunk"),
 						parentID: null,
 						requestID: "req-12345",
@@ -1548,7 +1544,6 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
-						objectMode: false,
 						params: null,
 						parentID: null,
 						requestID: "req-12345",
@@ -1573,7 +1568,6 @@ describe("Test Transit._sendRequest", () => {
 						level: 1,
 						meta: {},
 						tracing: null,
-						objectMode: false,
 						params: Buffer.from("first chunk"),
 						parentID: null,
 						requestID: "req-12345",
@@ -1636,9 +1630,8 @@ describe("Test Transit._sendRequest", () => {
 						action: "users.find",
 						id: "12345",
 						level: 1,
-						meta: {},
+						meta: { $streamObjectMode: true },
 						tracing: null,
-						objectMode: true,
 						params: null,
 						parentID: null,
 						requestID: "req-12345",
@@ -1662,9 +1655,8 @@ describe("Test Transit._sendRequest", () => {
 						action: "users.find",
 						id: "12345",
 						level: 1,
-						meta: {},
+						meta: { $streamObjectMode: true },
 						tracing: null,
-						objectMode: true,
 						params: {id:0},
 						parentID: null,
 						requestID: "req-12345",
@@ -1682,9 +1674,8 @@ describe("Test Transit._sendRequest", () => {
 						action: "users.find",
 						id: "12345",
 						level: 1,
-						meta: {},
+						meta: { $streamObjectMode: true },
 						tracing: null,
-						objectMode: true,
 						params: {id:1},
 						parentID: null,
 						requestID: "req-12345",
@@ -1706,7 +1697,7 @@ describe("Test Transit._sendRequest", () => {
 						action: "users.find",
 						id: "12345",
 						level: 1,
-						meta: {},
+						meta: { $streamObjectMode: true },
 						tracing: null,
 						params: null,
 						parentID: null,
@@ -1719,7 +1710,6 @@ describe("Test Transit._sendRequest", () => {
 				});
 			});
 		});
-
 
 	});
 
@@ -1962,7 +1952,6 @@ describe("Test Transit.sendResponse", () => {
 						data: null,
 						id: "12345",
 						meta,
-						objectMode: false,
 						seq: 0,
 						stream: true,
 						success: true
@@ -1982,7 +1971,6 @@ describe("Test Transit.sendResponse", () => {
 						data: Buffer.from("first chunk"),
 						id: "12345",
 						meta,
-						objectMode: false,
 						seq: 1,
 						stream: true,
 						success: true
@@ -1996,7 +1984,6 @@ describe("Test Transit.sendResponse", () => {
 					payload: {
 						data: Buffer.from("second chunk"),
 						id: "12345",
-						objectMode: false,
 						meta,
 						seq: 2,
 						stream: true,
@@ -2042,7 +2029,6 @@ describe("Test Transit.sendResponse", () => {
 						data: null,
 						id: "12345",
 						meta,
-						objectMode: false,
 						seq: 0,
 						stream: true,
 						success: true
@@ -2061,7 +2047,6 @@ describe("Test Transit.sendResponse", () => {
 						data: Buffer.from("first chunk"),
 						id: "12345",
 						meta,
-						objectMode: false,
 						seq: 1,
 						stream: true,
 						success: true


### PR DESCRIPTION
## :memo: Description

Added support for transit of streams in objectMode.

Using streams in objectMode generated errors before, as the data was no String or Buffer.
With this change the receiver will get a stream working in objectMode.

### :gem: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update


## :vertical_traffic_light: How Has This Been Tested?

Tested with moleculer 0.14-beta6.

- [ ] Unit Tests

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
