### PR TITLE
Update migration guide for TS and align ServiceBroker TS types with Context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,7 @@ declare namespace Moleculer {
 
 		errorFields?: Array<string>;
 		stackTrace?: boolean;
+		events?: boolean;
 
 		defaultTags?: GenericObject | Function | null;
 	};
@@ -498,7 +499,7 @@ declare namespace Moleculer {
 		setEndpoint(endpoint: Endpoint): void;
 		setParams(newParams: P, cloning?: boolean): void;
 		call<T>(actionName: string): PromiseLike<T>;
-		call<T, P>(actionName: string, params?: P, opts?: GenericObject): PromiseLike<T>;
+		call<T, P>(actionName: string, params: P, opts?: GenericObject): PromiseLike<T>;
 
 		emit<D>(eventName: string, data: D, opts: GenericObject): PromiseLike<void>;
 		emit<D>(eventName: string, data: D, groups: Array<string>): PromiseLike<void>;
@@ -940,12 +941,28 @@ declare namespace Moleculer {
 
 		findNextActionEndpoint(actionName: string, opts?: GenericObject, ctx?: Context): ActionEndpoint | Errors.MoleculerRetryableError;
 
-		call<T = any, P extends GenericObject = GenericObject>(actionName: string, params?: P, opts?: CallingOptions): PromiseLike<T>;
-		mcall<T = any>(def: Array<CallDefinition> | { [name: string]: CallDefinition }): PromiseLike<Array<T> | T>;
+		call<T>(actionName: string): PromiseLike<T>;
+		call<T, P>(actionName: string, params: P, opts?: GenericObject): PromiseLike<T>;
 
-		emit<P = any>(eventName: string, payload?: P, groups?: string | Array<string> | GenericObject): PromiseLike<void>;
-		broadcast<P = any>(eventName: string, payload?: P, groups?: string | Array<string> | GenericObject): PromiseLike<void>;
-		broadcastLocal<P = any>(eventName: string, payload?: P, groups?: string | Array<string> | GenericObject): PromiseLike<void>;
+		mcall<T>(def: Array<CallDefinition> | { [name: string]: CallDefinition }): PromiseLike<Array<T> | T>;
+
+		emit<D>(eventName: string, data: D, opts: GenericObject): PromiseLike<void>;
+		emit<D>(eventName: string, data: D, groups: Array<string>): PromiseLike<void>;
+		emit<D>(eventName: string, data: D, groups: string): PromiseLike<void>;
+		emit<D>(eventName: string, data: D): PromiseLike<void>;
+		emit(eventName: string): PromiseLike<void>;
+
+		broadcast<D>(eventName: string, data: D, opts: GenericObject): PromiseLike<void>;
+		broadcast<D>(eventName: string, data: D, groups: Array<string>): PromiseLike<void>;
+		broadcast<D>(eventName: string, data: D, groups: string): PromiseLike<void>;
+		broadcast<D>(eventName: string, data: D): PromiseLike<void>;
+		broadcast(eventName: string): PromiseLike<void>;
+
+		broadcastLocal<D>(eventName: string, data: D, opts: GenericObject): PromiseLike<void>;
+		broadcastLocal<D>(eventName: string, data: D, groups: Array<string>): PromiseLike<void>;
+		broadcastLocal<D>(eventName: string, data: D, groups: string): PromiseLike<void>;
+		broadcastLocal<D>(eventName: string, data: D): PromiseLike<void>;
+		broadcastLocal(eventName: string): PromiseLike<void>;
 
 		ping(): PromiseLike<PongResponses>;
 		ping(nodeID: string | Array<string>, timeout?: number): PromiseLike<PongResponse>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -499,7 +499,7 @@ declare namespace Moleculer {
 		setEndpoint(endpoint: Endpoint): void;
 		setParams(newParams: P, cloning?: boolean): void;
 		call<T>(actionName: string): PromiseLike<T>;
-		call<T, P>(actionName: string, params: P, opts?: GenericObject): PromiseLike<T>;
+		call<T, P>(actionName: string, params: P, opts?: CallingOptions): PromiseLike<T>;
 
 		emit<D>(eventName: string, data: D, opts: GenericObject): PromiseLike<void>;
 		emit<D>(eventName: string, data: D, groups: Array<string>): PromiseLike<void>;
@@ -942,7 +942,7 @@ declare namespace Moleculer {
 		findNextActionEndpoint(actionName: string, opts?: GenericObject, ctx?: Context): ActionEndpoint | Errors.MoleculerRetryableError;
 
 		call<T>(actionName: string): PromiseLike<T>;
-		call<T, P>(actionName: string, params: P, opts?: GenericObject): PromiseLike<T>;
+		call<T, P>(actionName: string, params: P, opts?: CallingOptions): PromiseLike<T>;
 
 		mcall<T>(def: Array<CallDefinition> | { [name: string]: CallDefinition }): PromiseLike<Array<T> | T>;
 


### PR DESCRIPTION
## :memo: Description

This PR updates the migration guide for 0.14 to include notes about breaking changes for TS and recommendations for how to remedy them.

While reviewing the 0.14 TS changes, I found that there were several types which were incorrect and made the following changes:
* Several types for `ServiceBroker` were out of sync with their corresponding types for `Context`.  I have updated these to be in sync.
* Added the missing `events` property to the `TracerOptions`.
* Correct the `call` method from the `Context` class to have the options typed as `CallingOptions`.
* Made `params` not optional in `call` if a generic for the parameters was provided.  I cannot think of a use case where someone would explicitly say what type the params should be and then not provide them.  If `params` is not necessary for a call, then simply not providing the generic will allow for that syntax since `call` is defined as an overloaded method.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## :vertical_traffic_light: How Has This Been Tested?

Loaded type definitions in repo with 200+ services and ran typechecking.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
