### PR TITLE
fix generics for actions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -627,7 +627,7 @@ declare namespace Moleculer {
 		[name: string]: any;
 	}
 
-	type ServiceAction<T = Promise<any>, P extends GenericObject = GenericObject> = ((params?: P, opts?: CallingOptions) => T) & ThisType<Service>;
+	type ServiceAction = (<T = Promise<any>, P extends GenericObject = GenericObject>(params?: P, opts?: CallingOptions) => T) & ThisType<Service>;
 
 	interface ServiceActions {
 		[name: string]: ServiceAction;


### PR DESCRIPTION
## :memo: Description

Generics as to be defined when calling action (for type checking works well), works also without generics.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```typescript
//type boolean
const result = await this.actions.findByGEO<Promise<boolean>, PaginatedGeoPayload>({
  // type PaginatedGeoPayload
  ...ctx.params, page: 1, pageSize: 1,
});
```

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
