### PR TITLE
Allow Hooks to be registered as array of method names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -596,13 +596,13 @@ declare namespace Moleculer {
 
 	interface ServiceHooks {
 		before?: {
-			[key: string]: ((ctx: Context<any, any>) => Promise<void> | void) | string
+			[key: string]: ((ctx: Context<any, any>) => Promise<void> | void) | string | string[]
 		},
 		after?: {
-			[key: string]: ((ctx: Context<any, any>, res: any) => Promise<any> | any) | string
+			[key: string]: ((ctx: Context<any, any>, res: any) => Promise<any> | any) | string | string[]
 		},
 		error?: {
-			[key: string]: ((ctx: Context<any, any>, err: Error) => Promise<void> | void) | string
+			[key: string]: ((ctx: Context<any, any>, err: Error) => Promise<void> | void) | string | string[]
 		},
 	}
 


### PR DESCRIPTION
## :memo: Description

Fixes index.d.ts to allow Hooks to be registered as array of method names

### :gem: Type of change


- [*] Bug fix (non-breaking change which fixes an issue)


## :vertical_traffic_light: How Has This Been Tested?

Tested with a service that was running with moleculer v0.13 and is not working again.

## :checkered_flag: Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] **New and existing unit tests pass locally with my changes**
