### PR TITLE
Limit chunk size of streams

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -85,6 +85,7 @@ const defaultOptions = {
 
 	transit: {
 		maxQueueSize: 50 * 1000, // 50k ~ 400MB,
+		maxChunkSize: 256*1024, // 256KB
 		disableReconnect: false,
 		disableVersionCheck: false
 	},

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -205,6 +205,7 @@ describe("Test ServiceBroker constructor", () => {
 			transit: {
 				disableReconnect: false,
 				maxQueueSize: 50 * 1000,
+				maxChunkSize: 262144,
 				disableVersionCheck: false
 			},
 


### PR DESCRIPTION
## :memo: Description

Using streams is a appropriate way to transfer larger quantities of data between services.
Unfortunately one has no influence on the chunk size.
It can happen that the chunk size exceeds the max. packet size of the used transporter.
I.e. NATS has a default payload limit of 1MB.

Also from my experience multiple small transit packets perform better than fewer large packets. (Tested with redis transporter).

To solve this I'd suggest to add a new configuration value "maxChunkSize" for transits and split all stream chunks according to this setting.


### :gem: Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] **I have added tests that prove my fix is effective or that my feature works**
- [*] **New and existing unit tests pass locally with my changes**
- [*] I have commented my code, particularly in hard-to-understand areas
