### PR TITLE
Use published module as HR time source

### DIFF
--- a/src/tracing/now.js
+++ b/src/tracing/now.js
@@ -13,4 +13,4 @@ function now() {
 const loadNs = now();
 const loadMs = Date.now();
 
-module.exports = () => loadMs + now() - loadNs;
+module.exports = () => loadMs + loadNs;


### PR DESCRIPTION
This makes it a lot easier to generate tracing data that is compatible with moleculer. Other trace producers can just use performance-now and their desired tracing client to publish spans without even knowing about moleculer.