### PR TITLE
Prefix the groupId with MOL- so that it's possible to configure the Kafka user ACL

### DIFF
--- a/src/transporters/kafka.js
+++ b/src/transporters/kafka.js
@@ -165,7 +165,7 @@ class KafkaTransporter extends Transporter {
 				const consumerOptions = Object.assign({
 					id: "default-kafka-consumer",
 					kafkaHost: this.opts.host,
-					groupId: this.broker.instanceID, //this.nodeID,
+					groupId: 'MOL-'+this.broker.instanceID, //this.nodeID,
 					fromOffset: "latest",
 					encoding: "buffer",
 				}, this.opts.consumer);


### PR DESCRIPTION
Prefix the groupId with `MOL-` so that it's possible to configure the Kafka user ACL to limit access to the `MOL-` prefix. Otherwise you have to give the Kafka user read access to all group names
