### PR TITLE
[datadog metrics] allow custom base URL

### DIFF
--- a/src/metrics/reporters/datadog.js
+++ b/src/metrics/reporters/datadog.js
@@ -33,6 +33,7 @@ class DatadogReporter extends BaseReporter {
 
 		this.opts = _.defaultsDeep(this.opts, {
 			host: os.hostname(),
+			baseUrl: BASE_URL,
 			apiVersion: "v1",
 			path: "/series",
 			apiKey: process.env.DATADOG_API_KEY,
@@ -77,7 +78,7 @@ class DatadogReporter extends BaseReporter {
 
 		if (series.length == 0) return;
 
-		return fetch(`${BASE_URL}${this.opts.apiVersion}${this.opts.path}?api_key=${this.opts.apiKey}`, {
+		return fetch(`${this.opts.baseUrl}${this.opts.apiVersion}${this.opts.path}?api_key=${this.opts.apiKey}`, {
 			method: "post",
 			body: JSON.stringify({ series }),
 			headers: {

--- a/test/unit/metrics/reporters/datadog.spec.js
+++ b/test/unit/metrics/reporters/datadog.spec.js
@@ -28,7 +28,8 @@ describe("Test Datadog Reporter class", () => {
 
 				metricNameFormatter: null,
 				labelNameFormatter: null,
-
+				
+				baseUrl: "https://api.datadoghq.com/api/",
 				apiKey: "datadog-api-key",
 				path: "/series",
 				apiVersion: "v1",
@@ -46,7 +47,8 @@ describe("Test Datadog Reporter class", () => {
 				excludes: ["moleculer.circuit-breaker.**", "moleculer.custom.**"],
 				metricNameFormatter: () => {},
 				labelNameFormatter: () => {},
-
+				
+				baseUrl: "https://api.custom-url.com/api/",
 				apiKey: "12345",
 				apiVersion: "v2",
 				host: "custom-hostname",
@@ -61,6 +63,7 @@ describe("Test Datadog Reporter class", () => {
 				metricNameFormatter: expect.any(Function),
 				labelNameFormatter: expect.any(Function),
 
+				baseUrl: "https://api.custom-url.com/api/",
 				apiKey: "12345",
 				path: "/series",
 				apiVersion: "v2",


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently Datadog has two sites US (https://api.datadoghq.com/api/) and EU ( https://api.datadoghq.eu/api/). However, at this moment the base URL is hardcoded and uses US site. 

https://github.com/moleculerjs/moleculer/blob/f9c9421271a68af7fe30a8034ede696bcd89c2e1/src/metrics/reporters/datadog.js#L16

This PR allows to customize the URL.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: Example code
```js
           {
                type: "Datadog",
                options: {
                    // Custom base URL
                    baseUrl: "https://api.datadoghq.eu/api/",
                    host: "my-host",
                    apiVersion: "v1",
                    path: "/series",
                    // ... //
                }
            }
``` 

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
