### PR TITLE
Close open handles in tests

### DIFF
--- a/src/cachers/memory-lru.js
+++ b/src/cachers/memory-lru.js
@@ -70,6 +70,16 @@ class MemoryLRUCacher extends BaseCacher {
 	}
 
 	/**
+	 * Close cacher
+	 *
+	 * @memberof MemoryLRUCacher
+	 */
+	close() {
+		clearInterval(this.timer);
+		return Promise.resolve();
+	}
+
+	/**
 	 * Get data from cache by key
 	 *
 	 * @param {any} key

--- a/src/cachers/memory.js
+++ b/src/cachers/memory.js
@@ -61,6 +61,16 @@ class MemoryCacher extends BaseCacher {
 	}
 
 	/**
+	 * Close cacher
+	 *
+	 * @memberof MemoryCacher
+	 */
+	close() {
+		clearInterval(this.timer);
+		return Promise.resolve();
+	}
+
+	/**
 	 * Get data from cache by key
 	 *
 	 * @param {any} key

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -126,7 +126,7 @@ class RedisCacher extends BaseCacher {
 	 * @memberof RedisCacher
 	 */
 	close() {
-		return this.client.quit();
+		return this.client != null ? this.client.quit() : Promise.resolve();
 	}
 
 	/**

--- a/src/loggers/base.js
+++ b/src/loggers/base.js
@@ -29,7 +29,7 @@ class BaseLogger {
 			level: "info",
 			createLogger: null
 		});
-
+		this.Promise = Promise; // default promise before logger is initialized
 	}
 
 	/**
@@ -40,13 +40,14 @@ class BaseLogger {
 	init(loggerFactory)  {
 		this.loggerFactory = loggerFactory;
 		this.broker = this.loggerFactory.broker;
+		this.Promise = this.broker.Promise;
 	}
 
 	/**
 	 * Stopping logger
 	 */
 	stop() {
-		return this.broker.Promise.resolve();
+		return this.Promise.resolve();
 	}
 
 	getLogLevel(mod) {

--- a/src/metrics/reporters/datadog.js
+++ b/src/metrics/reporters/datadog.js
@@ -69,6 +69,19 @@ class DatadogReporter extends BaseReporter {
 	}
 
 	/**
+	 * Stop reporter
+	 *
+	 * @memberof DatadogReporter
+	 */
+	stop() {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		return Promise.resolve();
+	}
+
+	/**
 	 * Flush metric data to Datadog server
 	 *
 	 * @memberof DatadogReporter

--- a/src/tracing/exporters/base.js
+++ b/src/tracing/exporters/base.js
@@ -16,6 +16,7 @@ class BaseTraceExporter {
 	 */
 	constructor(opts) {
 		this.opts = opts || {};
+		this.Promise = Promise; // default promise before logger is initialized
 	}
 
 	/**
@@ -27,6 +28,7 @@ class BaseTraceExporter {
 	init(tracer) {
 		this.tracer = tracer;
 		this.broker = tracer.broker;
+		this.Promise = this.broker.Promise;
 		this.logger = this.opts.logger || this.tracer.logger;
 	}
 

--- a/src/tracing/exporters/event.js
+++ b/src/tracing/exporters/event.js
@@ -49,7 +49,6 @@ class EventTraceExporter extends BaseTraceExporter {
 	 */
 	init(tracer) {
 		super.init(tracer);
-		this.broker = tracer.broker;
 
 		if (this.opts.interval > 0) {
 			this.timer = setInterval(() => this.flush(), this.opts.interval * 1000);
@@ -67,7 +66,7 @@ class EventTraceExporter extends BaseTraceExporter {
 			clearInterval(this.timer);
 			this.timer = null;
 		}
-		return this.broker.Promise.resolve();
+		return this.Promise.resolve();
 	}
 
 	/**

--- a/test/unit/cachers/base.spec.js
+++ b/test/unit/cachers/base.spec.js
@@ -639,6 +639,8 @@ describe("Test middleware with lock enabled", () => {
 			expect(get).toHaveBeenCalledTimes(6);
 			expect(getWithTTL).toHaveBeenCalledTimes(0);
 			expect(lock).toHaveBeenCalledTimes(3);
+		}).then(() => {
+			return cacher.close();
 		});
 	});
 

--- a/test/unit/cachers/index.spec.js
+++ b/test/unit/cachers/index.spec.js
@@ -1,71 +1,77 @@
 const { MoleculerError } = require("../../../src/errors");
 const Cachers = require("../../../src/cachers");
 
-describe("Test Cacher resolver", () => {
-
-	it("should resolve null from undefined", () => {
-		let cacher = Cachers.resolve();
-		expect(cacher).toBeNull();
+describe("Test Cacher resolver with valid instances", () => {
+	let cacher;
+	afterEach(async () => {
+		await cacher.close();
 	});
 
 	it("should resolve MemoryCacher from true", () => {
-		let cacher = Cachers.resolve(true);
+		cacher = Cachers.resolve(true);
 		expect(cacher).toBeInstanceOf(Cachers.Memory);
 	});
 
 	it("should resolve MemoryCacher from string", () => {
-		let cacher = Cachers.resolve("memory");
+		cacher = Cachers.resolve("memory");
 		expect(cacher).toBeInstanceOf(Cachers.Memory);
 	});
 
 	it("should resolve MemoryLRUCacher from string", () => {
-		let cacher = Cachers.resolve("MemoryLRU");
+		cacher = Cachers.resolve("MemoryLRU");
 		expect(cacher).toBeInstanceOf(Cachers.MemoryLRU);
 	});
 
 	it("should resolve RedisCacher from string", () => {
-		let cacher = Cachers.resolve("Redis");
+		cacher = Cachers.resolve("Redis");
 		expect(cacher).toBeInstanceOf(Cachers.Redis);
 	});
 
 	it("should resolve MemoryCacher from obj without type", () => {
 		let options = { ttl: 100 };
-		let cacher = Cachers.resolve({ options });
+		cacher = Cachers.resolve({ options });
 		expect(cacher).toBeInstanceOf(Cachers.Memory);
 		expect(cacher.opts).toEqual({ keygen: null, maxParamsLength: null, ttl: 100 });
 	});
 
 	it("should resolve MemoryCacher from obj", () => {
 		let options = { ttl: 100 };
-		let cacher = Cachers.resolve({ type: "Memory", options });
+		cacher = Cachers.resolve({ type: "Memory", options });
 		expect(cacher).toBeInstanceOf(Cachers.Memory);
 		expect(cacher.opts).toEqual({ keygen: null, maxParamsLength: null, ttl: 100 });
 	});
 
 	it("should resolve MemoryLRUCacher from obj", () => {
 		let options = { ttl: 100, max: 1000 };
-		let cacher = Cachers.resolve({ type: "MemoryLRU", options });
+		cacher = Cachers.resolve({ type: "MemoryLRU", options });
 		expect(cacher).toBeInstanceOf(Cachers.MemoryLRU);
 		expect(cacher.opts).toEqual({ keygen: null, maxParamsLength: null, ttl: 100, max: 1000 });
 	});
 
 	it("should resolve RedisCacher from obj with Redis type", () => {
 		let options = { ttl: 100 };
-		let cacher = Cachers.resolve({ type: "Redis", options });
+		cacher = Cachers.resolve({ type: "Redis", options });
 		expect(cacher).toBeInstanceOf(Cachers.Redis);
 		expect(cacher.opts).toEqual({ prefix: null, keygen: null, maxParamsLength: null, ttl: 100 });
 	});
 
 	it("should resolve RedisCacher from obj with Redis type", () => {
 		let options = { ttl: 80, redis: { db: 3 } };
-		let cacher = Cachers.resolve({ type: "redis", options });
+		cacher = Cachers.resolve({ type: "redis", options });
 		expect(cacher).toBeInstanceOf(Cachers.Redis);
 		expect(cacher.opts).toEqual({ prefix: null, keygen: null, maxParamsLength: null, ttl: 80, redis: { db: 3 } });
 	});
 
 	it("should resolve RedisCacher from connection string", () => {
-		let cacher = Cachers.resolve("redis://localhost");
+		cacher = Cachers.resolve("redis://localhost");
 		expect(cacher).toBeInstanceOf(Cachers.Redis);
+	});
+});
+
+describe("Test Cacher resolver with invalid instances", () => {
+	it("should resolve null from undefined", () => {
+		const cacher = Cachers.resolve();
+		expect(cacher).toBeNull();
 	});
 
 	it("should throw error if type if not correct", () => {
@@ -77,5 +83,4 @@ describe("Test Cacher resolver", () => {
 			Cachers.resolve("xyz");
 		}).toThrowError(MoleculerError);
 	});
-
 });

--- a/test/unit/cachers/lock.spec.js
+++ b/test/unit/cachers/lock.spec.js
@@ -19,6 +19,8 @@ describe("Test lock method", () => {
 					expect(cacher._lock.release).toHaveBeenCalledTimes(1);
 					expect(e).toBe(err);
 				});
+			}).then(() => {
+				return cacher.close();
 			});
 		}));
 	});
@@ -49,6 +51,8 @@ describe("Test lock method", () => {
 							});
 						}, Math.random() * 500);
 					});
+				}).then(() => {
+					return cacher.close();
 				});
 			})).then(() => {
 				expect(lock).toHaveBeenCalledTimes(4);
@@ -76,6 +80,8 @@ describe("Test tryLock method", () => {
 			return cacher.tryLock(key).then(unlock => {
 				expect(cacher._lock.isLocked(key)).toBeTruthy();
 				return unlock();
+			}).then(() => {
+				return cacher.close();
 			});
 		}));
 	});
@@ -96,6 +102,8 @@ describe("Test tryLock method", () => {
 				return cacher.tryLock(key).catch(e => {
 					expect(e.message).toEqual("Locked.");
 				});
+			}).then(() => {
+				return cacher.close();
 			});
 		}));
 	});
@@ -116,6 +124,8 @@ describe("Test tryLock method", () => {
 					expect(cacher._lock.release).toHaveBeenCalledTimes(1);
 					expect(e).toBe(err);
 				});
+			}).then(() => {
+				return cacher.close();
 			});
 		}));
 	});

--- a/test/unit/loggers/datadog.spec.js
+++ b/test/unit/loggers/datadog.spec.js
@@ -72,9 +72,14 @@ describe("Test Datadog logger class", () => {
 
 	describe("Test init method", () => {
 		const loggerFactory = new LoggerFactory(broker);
+		let logger;
+
+		afterEach(async () => {
+			await logger.stop();
+		});
 
 		it("should init the logger", () => {
-			const logger = new DatadogLogger();
+			logger = new DatadogLogger();
 			logger.init(loggerFactory);
 
 			expect(logger.objectPrinter).toBeDefined();
@@ -82,7 +87,7 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should init the logger with custom options", () => {
-			const logger = new DatadogLogger({
+			logger = new DatadogLogger({
 				interval: 0
 			});
 			logger.init(loggerFactory);
@@ -92,7 +97,7 @@ describe("Test Datadog logger class", () => {
 
 		it("should use custom objectPrinter", () => {
 			const objectPrinter = jest.fn();
-			const logger = new DatadogLogger({
+			logger = new DatadogLogger({
 				objectPrinter
 			});
 
@@ -124,9 +129,15 @@ describe("Test Datadog logger class", () => {
 
 	describe("Test getTags method", () => {
 		const loggerFactory = new LoggerFactory(broker);
+		let logger;
+
+		afterEach(async () => {
+			await logger.stop();
+		});
+
 
 		it("should return tags from row", () => {
-			const logger = new DatadogLogger({
+			logger = new DatadogLogger({
 				env: "production"
 			});
 
@@ -146,6 +157,7 @@ describe("Test Datadog logger class", () => {
 	describe("Test getLogHandler method", () => {
 		const loggerFactory = new LoggerFactory(broker);
 		let clock;
+		let logger;
 
 		beforeAll(() => {
 			clock = lolex.install();
@@ -155,8 +167,12 @@ describe("Test Datadog logger class", () => {
 			clock.uninstall();
 		});
 
+		afterEach(async () => {
+			await logger.stop();
+		});
+
 		it("should create a child logger", () => {
-			const logger = new DatadogLogger({ level: "trace" });
+			logger = new DatadogLogger({ level: "trace" });
 			logger.init(loggerFactory);
 			logger.flush = jest.fn();
 
@@ -183,8 +199,9 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should not call console if level is lower", () => {
-			const logger = new DatadogLogger({ level: "info" });
+			logger = new DatadogLogger({ level: "info" });
 			logger.init(loggerFactory);
+			logger.flush = jest.fn();
 
 			const logHandler = logger.getLogHandler({ mod: "my-service", nodeID: "node-1" });
 			expect(logHandler).toBeInstanceOf(Function);
@@ -205,7 +222,7 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should not create child logger if level is null", () => {
-			const logger = new DatadogLogger();
+			logger = new DatadogLogger();
 			logger.init(loggerFactory);
 
 			logger.getLogLevel = jest.fn();
@@ -217,7 +234,7 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should not create child logger if bindings is null", () => {
-			const logger = new DatadogLogger();
+			logger = new DatadogLogger();
 			logger.init(loggerFactory);
 
 			logger.getLogLevel = jest.fn();
@@ -228,7 +245,7 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should call flush if not interval", () => {
-			const logger = new DatadogLogger({ level: "trace", interval: 0 });
+			logger = new DatadogLogger({ level: "trace", interval: 0 });
 			logger.init(loggerFactory);
 			logger.flush = jest.fn();
 
@@ -252,6 +269,7 @@ describe("Test Datadog logger class", () => {
 		const loggerFactory = new LoggerFactory(broker);
 
 		let clock;
+		let logger;
 
 		beforeAll(() => {
 			clock = lolex.install();
@@ -261,8 +279,12 @@ describe("Test Datadog logger class", () => {
 			clock.uninstall();
 		});
 
+		afterEach(async () => {
+			await logger.stop();
+		});
+
 		it("should do nothing if queue is empty", () => {
-			const logger = new DatadogLogger({ level: "trace", interval: 0 });
+			logger = new DatadogLogger({ level: "trace", interval: 0 });
 			logger.init(loggerFactory);
 
 			fetch.mockClear();
@@ -273,7 +295,7 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should render rows and call appendFile", () => {
-			const logger = new DatadogLogger({ level: "trace", eol: "\n", hostname: "my-host" });
+			logger = new DatadogLogger({ level: "trace", eol: "\n", hostname: "my-host" });
 			logger.init(loggerFactory);
 
 			const logHandler = logger.getLogHandler({ mod: "my-service", nodeID: "node-1" });
@@ -295,7 +317,7 @@ describe("Test Datadog logger class", () => {
 		});
 
 		it("should call flush after interval", () => {
-			const logger = new DatadogLogger({ level: "trace", interval: 2000 });
+			logger = new DatadogLogger({ level: "trace", interval: 2000 });
 			logger.init(loggerFactory);
 			logger.flush = jest.fn();
 

--- a/test/unit/loggers/file.spec.js
+++ b/test/unit/loggers/file.spec.js
@@ -22,11 +22,15 @@ const lolex = require("@sinonjs/fake-timers");
 const broker = new ServiceBroker({ logger: false, nodeID: "node-123", namespace: "test-ns" });
 
 describe("Test File logger class", () => {
+	let logger;
+	afterEach(async () => {
+		await logger.stop();
+	});
 
 	describe("Test Constructor", () => {
 
 		it("should create with default options", () => {
-			const logger = new FileLogger();
+			logger = new FileLogger();
 
 			expect(logger.opts).toEqual({
 				autoPadding: false,
@@ -48,7 +52,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should create with custom options", () => {
-			const logger = new FileLogger({
+			logger = new FileLogger({
 				createLogger: jest.fn(),
 				level: "debug",
 				folder: "/my-log",
@@ -79,7 +83,7 @@ describe("Test File logger class", () => {
 		const loggerFactory = new LoggerFactory(broker);
 
 		it("should init the logger", () => {
-			const logger = new FileLogger();
+			logger = new FileLogger();
 
 			logger.init(loggerFactory);
 
@@ -90,7 +94,7 @@ describe("Test File logger class", () => {
 		it("should init the logger with custom options", () => {
 			utils.makeDirs.mockClear();
 
-			const logger = new FileLogger({
+			logger = new FileLogger({
 				folder: "/logs/{namespace}/{nodeID}",
 				interval: 0
 			});
@@ -110,7 +114,7 @@ describe("Test File logger class", () => {
 		const loggerFactory = new LoggerFactory(broker);
 
 		it("should create a default logger", async () => {
-			const logger = new FileLogger();
+			logger = new FileLogger();
 
 			logger.init(loggerFactory);
 
@@ -139,7 +143,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should return interpolated filename", () => {
-			const logger = new FileLogger();
+			logger = new FileLogger();
 
 			logger.init(loggerFactory);
 
@@ -160,7 +164,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should create a child logger", () => {
-			const logger = new FileLogger({ level: "trace" });
+			logger = new FileLogger({ level: "trace" });
 			logger.init(loggerFactory);
 			logger.flush = jest.fn();
 
@@ -187,8 +191,9 @@ describe("Test File logger class", () => {
 		});
 
 		it("should not call console if level is lower", () => {
-			const logger = new FileLogger({ level: "info" });
+			logger = new FileLogger({ level: "info" });
 			logger.init(loggerFactory);
+			logger.flush = jest.fn();
 
 			const logHandler = logger.getLogHandler({ mod: "my-service", nodeID: "node-1" });
 			expect(logHandler).toBeInstanceOf(Function);
@@ -209,7 +214,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should not create child logger if level is null", () => {
-			const logger = new FileLogger();
+			logger = new FileLogger();
 			logger.init(loggerFactory);
 
 			logger.getLogLevel = jest.fn();
@@ -221,7 +226,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should not create child logger if bindings is null", () => {
-			const logger = new FileLogger();
+			logger = new FileLogger();
 			logger.init(loggerFactory);
 
 			logger.getLogLevel = jest.fn();
@@ -232,7 +237,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should call flush if not interval", () => {
-			const logger = new FileLogger({ level: "trace", interval: 0 });
+			logger = new FileLogger({ level: "trace", interval: 0 });
 			logger.init(loggerFactory);
 			logger.flush = jest.fn();
 
@@ -266,7 +271,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should do nothing if queue is empty", () => {
-			const logger = new FileLogger({ level: "trace", interval: 0 });
+			logger = new FileLogger({ level: "trace", interval: 0 });
 			logger.init(loggerFactory);
 
 			logger.renderRow = jest.fn();
@@ -279,7 +284,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should render rows and call appendFile", () => {
-			const logger = new FileLogger({ level: "trace", eol: "\n" });
+			logger = new FileLogger({ level: "trace", eol: "\n" });
 			logger.init(loggerFactory);
 
 			const logHandler = logger.getLogHandler({ mod: "my-service", nodeID: "node-1" });
@@ -296,7 +301,7 @@ describe("Test File logger class", () => {
 		});
 
 		it("should call flush after interval", () => {
-			const logger = new FileLogger({ level: "trace", interval: 2000 });
+			logger = new FileLogger({ level: "trace", interval: 2000 });
 			logger.init(loggerFactory);
 			logger.flush = jest.fn();
 

--- a/test/unit/metrics/reporters/prometheus.spec.js
+++ b/test/unit/metrics/reporters/prometheus.spec.js
@@ -62,20 +62,26 @@ describe("Test Prometheus Reporter class", () => {
 	});
 
 	describe("Test init method", () => {
+		let reporter;
+		let broker;
+		afterEach(async () => {
+			await reporter.stop();
+			await broker.stop();
+		});
 
 		it("should create HTTP server", () => {
-			const broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
+			broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
 			const registry = new MetricRegistry(broker);
-			const reporter = new PrometheusReporter({ port: 0 });
+			reporter = new PrometheusReporter({ port: 0 });
 			reporter.init(registry);
 
 			expect(reporter.server).toBeDefined();
 		});
 
 		it("should generate defaultLabels", () => {
-			const broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
+			broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
 			const registry = new MetricRegistry(broker);
-			const reporter = new PrometheusReporter({ port: 0 });
+			reporter = new PrometheusReporter({ port: 0 });
 			reporter.init(registry);
 
 			expect(reporter.defaultLabels).toStrictEqual({
@@ -85,9 +91,9 @@ describe("Test Prometheus Reporter class", () => {
 		});
 
 		it("should set static defaultLabels", () => {
-			const broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
+			broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
 			const registry = new MetricRegistry(broker);
-			const reporter = new PrometheusReporter({
+			reporter = new PrometheusReporter({
 				port: 0,
 				defaultLabels: {
 					a: 5,
@@ -105,8 +111,14 @@ describe("Test Prometheus Reporter class", () => {
 	});
 
 	describe("Test stop method", () => {
+		let broker;
+
+		afterEach(async () => {
+			await broker.stop();
+		});
+
 		it("should stop HTTP server", () => {
-			const broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
+			broker = new ServiceBroker({ logger: false, nodeID: "test-node", namespace: "test-ns" });
 			const registry = new MetricRegistry(broker);
 			const reporter = new PrometheusReporter({ port: 0 });
 			reporter.init(registry);
@@ -121,10 +133,21 @@ describe("Test Prometheus Reporter class", () => {
 
 		const broker = new ServiceBroker({ logger: false, nodeID: "node-123" });
 		const registry = new MetricRegistry(broker);
-		const reporter = new PrometheusReporter({ port: 0 });
-		reporter.init(registry);
+		let reporter;
+		beforeEach(() => {
+			reporter = new PrometheusReporter({ port: 0 });
+			reporter.init(registry);
 
-		reporter.generatePrometheusResponse = jest.fn(() => "Fake generatePrometheusResponse content.");
+			reporter.generatePrometheusResponse = jest.fn(() => "Fake generatePrometheusResponse content.");
+		});
+
+		afterEach(async () => {
+			reporter.stop();
+		});
+
+		afterAll(async () => {
+			broker.stop();
+		});
 
 		it("should return 404 if path is not match", async () => {
 			const res = await request(reporter.server).get("/");
@@ -163,10 +186,18 @@ describe("Test Prometheus Reporter class", () => {
 
 		const broker = new ServiceBroker({ logger: false, nodeID: "node-123" });
 		const registry = new MetricRegistry(broker);
+		let reporter;
+
+		afterEach(async () => {
+			await reporter.stop();
+		});
+
+		afterAll(async () => {
+			await broker.stop();
+		});
 
 		it("should call generatePrometheusResponse method but not fetch", () => {
-
-			const reporter = new PrometheusReporter({
+			reporter = new PrometheusReporter({
 				port: 0,
 				host: "test-host",
 				defaultLabels: {

--- a/test/unit/middlewares/circuit-breaker.spec.js
+++ b/test/unit/middlewares/circuit-breaker.spec.js
@@ -17,6 +17,10 @@ describe("Test CircuitBreakerMiddleware", () => {
 
 	const mw = Middleware(broker);
 
+	afterAll(() => {
+		mw.stopped.call(broker);
+	});
+
 	it("should register hooks", () => {
 		expect(mw.created).toBeInstanceOf(Function);
 		expect(mw.localAction).toBeInstanceOf(Function);

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -40,11 +40,16 @@ const MiddlewareHandler = require("../../src/middleware");
 const { MoleculerError, MoleculerServerError, ServiceNotFoundError, ServiceNotAvailableError } = require("../../src/errors");
 
 describe("Test ServiceBroker constructor", () => {
+	let broker;
+
+	afterEach(async () => {
+		await broker.stop();
+	});
 
 	it("should set default options", () => {
 		console.log = jest.fn();
 
-		let broker = new ServiceBroker();
+		broker = new ServiceBroker();
 		expect(broker).toBeDefined();
 		expect(broker.options).toEqual(ServiceBroker.defaultOptions);
 
@@ -91,7 +96,7 @@ describe("Test ServiceBroker constructor", () => {
 
 	it("should merge options", () => {
 
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			namespace: "test",
 			nodeID: "server-12",
 			transporter: null,
@@ -253,7 +258,7 @@ describe("Test ServiceBroker constructor", () => {
 	});
 
 	it("should create transit if transporter into options", () => {
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			transporter: "Fake"
 		});
@@ -266,7 +271,7 @@ describe("Test ServiceBroker constructor", () => {
 	it("should create cacher and call init", () => {
 		let cacher = new Cachers.Memory();
 		cacher.init = jest.fn();
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			cacher
 		});
@@ -280,7 +285,7 @@ describe("Test ServiceBroker constructor", () => {
 	it("should set serializer and call init", () => {
 		let serializer = new Serializers.JSON();
 		serializer.init = jest.fn();
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			serializer
 		});
@@ -292,23 +297,25 @@ describe("Test ServiceBroker constructor", () => {
 	});
 
 	it("should set validator", () => {
-		let broker = new ServiceBroker({ logger: false });
+		broker = new ServiceBroker({ logger: false });
 		expect(broker.validator).toBeDefined();
+		broker.stop();
 
 		broker = new ServiceBroker({ logger: false, validator: true });
 		expect(broker.validator).toBeDefined();
 	});
 
 	it("should not set validator", () => {
-		let broker = new ServiceBroker({ logger: false, validator: false });
+		broker = new ServiceBroker({ logger: false, validator: false });
 		expect(broker.validator).toBeUndefined();
+		broker.stop();
 
 		broker = new ServiceBroker({ logger: false, validator: null });
 		expect(broker.validator).toBeUndefined();
 	});
 
 	it("should disable balancer if transporter has no built-in balancer", () => {
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			transporter: "Fake",
 			disableBalancer: true
@@ -321,7 +328,7 @@ describe("Test ServiceBroker constructor", () => {
 		let tx = new Transporters.Fake();
 		tx.hasBuiltInBalancer = false;
 
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			transporter: tx,
 			disableBalancer: true
@@ -335,7 +342,7 @@ describe("Test ServiceBroker constructor", () => {
 		let started = jest.fn();
 		let stopped = jest.fn();
 
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			created,
 			started,
@@ -363,7 +370,7 @@ describe("Test ServiceBroker constructor", () => {
 	});
 
 	it("should load internal middlewares", () => {
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false
 		});
 
@@ -371,7 +378,7 @@ describe("Test ServiceBroker constructor", () => {
 	});
 
 	it("should not load internal middlewares", () => {
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			internalMiddlewares: false
 		});
@@ -382,7 +389,7 @@ describe("Test ServiceBroker constructor", () => {
 	it("should load user middlewares", () => {
 		let mw1 = { localAction: jest.fn(handler => handler) };
 		let mw2 = { localAction: jest.fn(handler => handler) };
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			internalMiddlewares: false,
 			middlewares: [
@@ -397,7 +404,7 @@ describe("Test ServiceBroker constructor", () => {
 	});
 
 	it("should register internal middlewares", () => {
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			cacher: "memory",
 			requestTimeout: 5000,
@@ -414,7 +421,7 @@ describe("Test ServiceBroker constructor", () => {
 	});
 
 	it("should register moleculer metrics", () => {
-		let broker = new ServiceBroker({
+		broker = new ServiceBroker({
 			logger: false,
 			metrics: false
 		});
@@ -782,9 +789,8 @@ describe("Test broker.stop", () => {
 
 describe("Test broker.repl", () => {
 
-	jest.mock("moleculer-repl");
-	let repl = require("moleculer-repl");
-	repl.mockImplementation(() => jest.fn());
+	jest.mock("moleculer-repl", () => jest.fn());
+	const repl = require("moleculer-repl");
 
 	it("should switch to repl mode", () => {
 		let broker = new ServiceBroker({ logger: false });

--- a/test/unit/tracing/exporters/base.spec.js
+++ b/test/unit/tracing/exporters/base.spec.js
@@ -31,6 +31,7 @@ describe("Test Base Reporter class", () => {
 
 		it("should set tracer & logger", () => {
 			const fakeTracer = {
+				broker: { Promise },
 				logger: {}
 			};
 			const exporter = new BaseExporter();
@@ -100,6 +101,7 @@ describe("Test Base Reporter class", () => {
 
 	describe("Test errorToObject method", () => {
 		const fakeTracer = {
+			broker: { Promise },
 			logger: {},
 			opts: {
 				errorFields: ["name", "message"]

--- a/test/unit/tracing/exporters/datadog.spec.js
+++ b/test/unit/tracing/exporters/datadog.spec.js
@@ -99,6 +99,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 	describe("Test init method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			getCurrentTraceID: jest.fn(),
 			getActiveSpanID: jest.fn(),
@@ -182,6 +183,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 	describe("Test spanStarted method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			opts: {
 				errorFields: ["name", "message", "retryable", "data", "code"]
@@ -354,6 +356,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 	describe("Test spanFinished method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			opts: {
 				errorFields: ["name", "message", "retryable", "data", "code"]
@@ -453,6 +456,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 	describe("Test addLogs method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			getCurrentTraceID: jest.fn(),
 			getActiveSpanID: jest.fn(),
@@ -480,6 +484,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 	describe("Test addTags method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			getCurrentTraceID: jest.fn(),
 			getActiveSpanID: jest.fn(),
@@ -550,6 +555,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 	describe("Test convertID method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			getCurrentTraceID: jest.fn(),
 			getActiveSpanID: jest.fn(),
@@ -574,6 +580,7 @@ describe("Test Datadog tracing exporter class", () => {
 		it("should retun with the original traceID", () => {
 			let oldGetCurrentTraceID = jest.fn(() => "old-trace-id");
 			const fakeTracer = {
+				broker,
 				getCurrentTraceID: oldGetCurrentTraceID,
 				getActiveSpanID: jest.fn(),
 			};
@@ -591,6 +598,7 @@ describe("Test Datadog tracing exporter class", () => {
 			fakeDdSpan.context.mockClear();
 			let oldGetCurrentTraceID = jest.fn();
 			const fakeTracer = {
+				broker,
 				getCurrentTraceID: oldGetCurrentTraceID,
 				getActiveSpanID: jest.fn(),
 			};
@@ -615,6 +623,7 @@ describe("Test Datadog tracing exporter class", () => {
 		it("should retun with the original spanID", () => {
 			let oldGetActiveSpanID = jest.fn(() => "old-trace-id");
 			const fakeTracer = {
+				broker,
 				getActiveSpanID: oldGetActiveSpanID,
 				getCurrentTraceID: jest.fn(),
 			};
@@ -634,6 +643,7 @@ describe("Test Datadog tracing exporter class", () => {
 
 			let oldGetActiveSpanID = jest.fn();
 			const fakeTracer = {
+				broker,
 				getActiveSpanID: oldGetActiveSpanID,
 				getCurrentTraceID: jest.fn(),
 			};

--- a/test/unit/tracing/exporters/jaeger.spec.js
+++ b/test/unit/tracing/exporters/jaeger.spec.js
@@ -102,7 +102,7 @@ describe("Test Jaeger tracing exporter class", () => {
 	});
 
 	describe("Test init method", () => {
-		const fakeTracer = { logger: broker.logger };
+		const fakeTracer = { broker, logger: broker.logger };
 
 		it("should flatten default tags", () => {
 			const exporter = new JaegerTraceExporter({ defaultTags: { a: { b: "c" } } });
@@ -153,7 +153,7 @@ describe("Test Jaeger tracing exporter class", () => {
 	});
 
 	describe("Test getReporter method", () => {
-		const fakeTracer = { logger: broker.logger };
+		const fakeTracer = { broker, logger: broker.logger };
 
 		it("should create an UDP sender", () => {
 			const exporter = new JaegerTraceExporter({
@@ -198,7 +198,7 @@ describe("Test Jaeger tracing exporter class", () => {
 	});
 
 	describe("Test getSampler method", () => {
-		const fakeTracer = { logger: broker.logger };
+		const fakeTracer = { broker, logger: broker.logger };
 		const exporter = new JaegerTraceExporter();
 		exporter.init(fakeTracer);
 
@@ -303,7 +303,7 @@ describe("Test Jaeger tracing exporter class", () => {
 	});
 
 	describe("Test getTracer method", () => {
-		const fakeTracer = { logger: broker.logger };
+		const fakeTracer = { broker, logger: broker.logger };
 		const exporter = new JaegerTraceExporter({
 			tracerOptions: {
 				b: "John"
@@ -357,7 +357,7 @@ describe("Test Jaeger tracing exporter class", () => {
 	});
 
 	describe("Test spanFinished method", () => {
-		const fakeTracer = { logger: broker.logger };
+		const fakeTracer = { broker, logger: broker.logger };
 		const exporter = new JaegerTraceExporter({});
 		exporter.init(fakeTracer);
 		exporter.generateJaegerSpan = jest.fn();
@@ -374,6 +374,7 @@ describe("Test Jaeger tracing exporter class", () => {
 
 	describe("Test addLogs method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger
 		};
 
@@ -399,6 +400,7 @@ describe("Test Jaeger tracing exporter class", () => {
 
 	describe("Test addTags method", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger
 		};
 
@@ -466,7 +468,7 @@ describe("Test Jaeger tracing exporter class", () => {
 	});
 
 	describe("Test convertID method", () => {
-		const fakeTracer = { logger: broker.logger };
+		const fakeTracer = { broker, logger: broker.logger };
 		const exporter = new JaegerTraceExporter({});
 		exporter.init(fakeTracer);
 
@@ -483,6 +485,7 @@ describe("Test Jaeger tracing exporter class", () => {
 
 	describe("Test generateJaegerSpan", () => {
 		const fakeTracer = {
+			broker,
 			logger: broker.logger,
 			opts: {
 				errorFields: ["name", "message", "retryable", "data", "code"]

--- a/test/unit/transporters/tcp.spec.js
+++ b/test/unit/transporters/tcp.spec.js
@@ -505,6 +505,7 @@ describe("Test TcpTransporter startUdpServer", () => {
 		expect(transporter.gossipTimer).toBeNull();
 		transporter.startTimers();
 		expect(transporter.gossipTimer).toBeDefined();
+		transporter.stopTimers(); // clean up handle
 	});
 
 	it("check startTimers", () => {


### PR DESCRIPTION
## :memo: Description

When running tests, I noticed that a large number of open handles were left behind which was being ignored due to the jest `--forceExit` flag.  I've made changes to ensure those handles are closed.

While researching this, I found some classes that did not implement a proper "cleanup" method and added implementations for those as well.

### :gem: Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
