### PR TITLE
Sanitize utils.safetyObject output from big objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 # [Unreleased](https://github.com/moleculerjs/moleculer/compare/v0.14.3...v0.14.4)
 
 ## Changes
+- add `maxSafeObjectSize` to service broker options. Fixes [#697](https://github.com/moleculerjs/moleculer/pull/697)
 - add `stop` method to tracing exporters. Fixes [#689](https://github.com/moleculerjs/moleculer/issues/689)
 - fix `EventLegacy` tracing exporter. Fixes  [#676](https://github.com/moleculerjs/moleculer/issues/676)
 - the `defaultTags` property in `tracer` options can be a `Function`, as well.

--- a/src/internals.js
+++ b/src/internals.js
@@ -83,7 +83,7 @@ module.exports = function() {
 				tracing: false,
 				params: {},
 				handler() {
-					return utils.safetyObject(this.broker.options, { maxSafeObjectSize: 1024 });
+					return utils.safetyObject(this.broker.options, { maxSafeObjectSize: 1024 * 1024 });
 				}
 			},
 

--- a/src/internals.js
+++ b/src/internals.js
@@ -83,7 +83,7 @@ module.exports = function() {
 				tracing: false,
 				params: {},
 				handler() {
-					return utils.safetyObject(this.broker.options, { maxSafeObjectSize: 1024 * 1024 });
+					return utils.safetyObject(this.broker.options, this.broker.options);
 				}
 			},
 

--- a/src/internals.js
+++ b/src/internals.js
@@ -83,7 +83,7 @@ module.exports = function() {
 				tracing: false,
 				params: {},
 				handler() {
-					return utils.safetyObject(this.broker.options);
+					return utils.safetyObject(this.broker.options, { maxSafeObjectSize: 1024 });
 				}
 			},
 

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -373,7 +373,7 @@ class Registry {
 			rawInfo.services = [];
 
 		// Make to be safety
-		node.rawInfo = utils.safetyObject(rawInfo);
+		node.rawInfo = utils.safetyObject(rawInfo, { maxSafeObjectSize: 1024 * 1024 });
 
 		return node.rawInfo;
 	}

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -373,7 +373,7 @@ class Registry {
 			rawInfo.services = [];
 
 		// Make to be safety
-		node.rawInfo = utils.safetyObject(rawInfo, { maxSafeObjectSize: 1024 * 1024 });
+		node.rawInfo = utils.safetyObject(rawInfo, this.broker.options);
 
 		return node.rawInfo;
 	}

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -115,6 +115,15 @@ const defaultOptions = {
 
 	skipProcessEventRegistration: false,
 
+	/**
+	 * Maximum size of objects that can be serialized
+	 *
+	 * On serialization process, check each object property size (based on length or size property value)
+	 * and trim it, if object size bigger than maxSafeObjectSize value
+	 *
+	 * @type {(number|null)}
+	 */
+	maxSafeObjectSize: null,
 	// ServiceFactory: null,
 	// ContextFactory: null
 	// Promise: null

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,11 +46,11 @@ function circularReplacer(options = { maxSafeObjectSize: Infinity }) {
 		if (typeof value === "object" && value !== null) {
 			const objectType = value.constructor && value.constructor.name || typeof value;
 
-			if ("length" in value && value.length > options.maxSafeObjectSize) {
+			if (options.maxSafeObjectSize && "length" in value && value.length > options.maxSafeObjectSize) {
 				return `[${objectType} ${value.length}]`;
 			}
 
-			if ("size" in value && value.size > options.maxSafeObjectSize) {
+			if (options.maxSafeObjectSize && "size" in value && value.size > options.maxSafeObjectSize) {
 				return `[${objectType} ${value.size}]`;
 			}
 
@@ -312,7 +312,7 @@ const utils = {
 	 * @param {number=} options.maxSafeObjectSize List of options to change circularReplacer behaviour
 	 * @returns {Object|Array}
 	 */
-	safetyObject(obj, options = { maxSafeObjectSize: Infinity }) {
+	safetyObject(obj, options) {
 		return JSON.parse(JSON.stringify(obj, circularReplacer(options)));
 	},
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,10 +33,27 @@ const parseByteStringRe = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
 
 class TimeoutError extends ExtendableError {}
 
-function circularReplacer() {
+/**
+ * Circular replacing of unsafe properties in object
+ *
+ * @param {Object=} options List of options to change circularReplacer behaviour
+ * @param {number=} options.maxSafeObjectSize Maximum size of objects for safe object converting
+ * @return {function(...[*]=)}
+ */
+function circularReplacer(options = { maxSafeObjectSize: Infinity }) {
 	const seen = new WeakSet();
 	return function(key, value) {
 		if (typeof value === "object" && value !== null) {
+			const objectType = value.constructor && value.constructor.name || typeof value;
+
+			if ("length" in value && value.length > options.maxSafeObjectSize) {
+				return `[${objectType} ${value.length}]`;
+			}
+
+			if ("size" in value && value.size > options.maxSafeObjectSize) {
+				return `[${objectType} ${value.size}]`;
+			}
+
 			if (seen.has(value)) {
 				//delete this[key];
 				return;
@@ -291,10 +308,12 @@ const utils = {
 	 * Remove circular references & Functions from the JS object
 	 *
 	 * @param {Object|Array} obj
+	 * @param {Object=} options List of options to change circularReplacer behaviour
+	 * @param {number=} options.maxSafeObjectSize List of options to change circularReplacer behaviour
 	 * @returns {Object|Array}
 	 */
-	safetyObject(obj) {
-		return JSON.parse(JSON.stringify(obj, circularReplacer()));
+	safetyObject(obj, options = { maxSafeObjectSize: Infinity }) {
+		return JSON.parse(JSON.stringify(obj, circularReplacer(options)));
 	},
 
 	/**

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -226,6 +226,7 @@ describe("Test ServiceBroker constructor", () => {
 			},
 			requestTimeout: 5000,
 			maxCallLevel: 10,
+			maxSafeObjectSize: null,
 			contextParamsCloning: true,
 			validator: false,
 			internalServices: false,

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -156,6 +156,40 @@ describe("Test utils.safetyObject", () => {
 		expect(res).toEqual(obj);
 	});
 
+	it("should skip converting into JSON large objects", () => {
+		const bigData = Array.from({ length: 2048 }).map((_, index) => index);
+
+		const bigBuffer = Buffer.from(bigData);
+		const bigSet = new Set(bigData);
+		const obj = {
+			a: 5,
+			b: "Hello",
+			c: [0,1,2],
+			d: {
+				e: false,
+				f: 1.23
+			},
+			bigBuffer,
+			bigSet,
+		};
+		const res = utils.safetyObject(obj, { maxSafeObjectSize: 1024 });
+		expect(res).not.toBe(obj);
+		expect(res).toEqual({
+			a: 5,
+			b: "Hello",
+			c: [0,1,2],
+			d: {
+				e: false,
+				f: 1.23
+			},
+			bigBuffer: {
+				data: "[Array 2048]",
+				type: "Buffer",
+			},
+			bigSet: "[Set 2048]",
+		});
+	});
+
 	it("should return a same object without circular refs & Function", () => {
 		const obj = {
 			a: 5,


### PR DESCRIPTION
## :memo: Sanitize utils.safetyObject output from big objects

In some cases, we should pass into service `schemaMods` parameters a big amount of data. To example: some instances of [SharedArrayBuffer](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) class with data more than 100MB. In that case on service starting Moleculer.js tries to post that data into output/databus and it causes performance in `utils.safetyObject` to convert this amount of data into JSON.

### :dart: Relevant issues
- No related issues

### :gem: Type of change
- [x] New feature (non-breaking change which adds functionality)

### :scroll: Example code
```js
    const broker = new ServiceBroker({ logLevel: "debug" });
    broker.createService(Service, {
        name: 'maxmind',
        settings: {
            service: {
                database: new Buffer(Array.from({ length: 100 * 1024 * 1024 })),
            },
        },
    });
    broker.start();
``` 

## :vertical_traffic_light: How Has This Been Tested?

Example of code to reproduce that issue provided in "Example code" section

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
