### PR TITLE
broker.repl() now behaves as described on moleculer-repl repo.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -775,6 +775,7 @@ declare namespace Moleculer {
 		middlewares?: Array<Middleware | string>;
 
 		replCommands?: Array<GenericObject>;
+		replDelimiter?: string;
 
 		metadata?: GenericObject;
 

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -110,6 +110,7 @@ const defaultOptions = {
 	middlewares: null,
 
 	replCommands: null,
+	replDelimiter: null,
 
 	metadata: {},
 
@@ -540,8 +541,7 @@ class ServiceBroker {
 	 *
 	 * @example
 	 * broker.start().then(() => broker.repl());
-	 *
-	 * @memberof ServiceBroker
+	 * @returns {object}
 	 */
 	repl() {
 		let repl;
@@ -556,7 +556,12 @@ class ServiceBroker {
 		}
 
 		if (repl)
-			repl(this, this.options.replCommands);
+		{
+			const opts = {} // Send replDelimiter = null to moleculer-repl will make a 'null' delimiter 
+			this.options.replDelimiter && (opts.delimiter = this.options.replDelimiter) 
+			this.options.replCommands && (opts.customCommands = this.options.replCommands)
+			return repl(this, opts);
+		}
 	}
 
 	/**

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -557,9 +557,11 @@ class ServiceBroker {
 
 		if (repl)
 		{
-			const opts = {} // Send replDelimiter = null to moleculer-repl will make a 'null' delimiter 
-			this.options.replDelimiter && (opts.delimiter = this.options.replDelimiter) 
-			this.options.replCommands && (opts.customCommands = this.options.replCommands)
+			let opts = null;
+			const delimiter = this.options.replDelimiter;
+			const customCommands = this.options.replCommands;
+			delimiter && (opts = {delimiter}) 
+			customCommands && (opts = {...opts,customCommands})
 			return repl(this, opts);
 		}
 	}

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -798,7 +798,7 @@ describe("Test broker.repl", () => {
 		broker.repl();
 
 		expect(repl).toHaveBeenCalledTimes(1);
-		expect(repl).toHaveBeenCalledWith(broker, {});
+		expect(repl).toHaveBeenCalledWith(broker,null);
 	});
 
 	it("should switch to repl mode with custom commands", () => {
@@ -810,7 +810,18 @@ describe("Test broker.repl", () => {
 		broker.repl();
 
 		expect(repl).toHaveBeenCalledTimes(1);
-		expect(repl).toHaveBeenCalledWith(broker, {customCommands: broker.options.replCommands});
+		expect(repl).toHaveBeenCalledWith(broker, { customCommands: broker.options.replCommands });
+	});
+	it("should switch to repl mode with delimiter", () => {
+		repl.mockClear();
+		let broker = new ServiceBroker({
+			logger: false,
+			replDelimiter: 'mol # '
+		});
+		broker.repl();
+
+		expect(repl).toHaveBeenCalledTimes(1);
+		expect(repl).toHaveBeenCalledWith(broker, { delimiter: broker.options.replDelimiter });
 	});
 });
 

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -233,7 +233,7 @@ describe("Test ServiceBroker constructor", () => {
 			hotReload: true,
 			middlewares: null,
 			replCommands: null,
-
+			replDelimiter: null,
 			metadata: {
 				region: "eu-west1"
 			},
@@ -798,7 +798,7 @@ describe("Test broker.repl", () => {
 		broker.repl();
 
 		expect(repl).toHaveBeenCalledTimes(1);
-		expect(repl).toHaveBeenCalledWith(broker, null);
+		expect(repl).toHaveBeenCalledWith(broker, {});
 	});
 
 	it("should switch to repl mode with custom commands", () => {
@@ -810,7 +810,7 @@ describe("Test broker.repl", () => {
 		broker.repl();
 
 		expect(repl).toHaveBeenCalledTimes(1);
-		expect(repl).toHaveBeenCalledWith(broker, broker.options.replCommands);
+		expect(repl).toHaveBeenCalledWith(broker, {customCommands: broker.options.replCommands});
 	});
 });
 


### PR DESCRIPTION
Adding the same behavior described on  moleculer-repl repo.

Creating replDelimiter option to setup delimiter on Repl, and passing replCommands on customCommands not direct as Repl option argument.