### PR TITLE
Adding MoleculerRepl type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { EventEmitter2 } from "eventemitter2";
+import Vorpal from "vorpal";
 
 declare namespace Moleculer {
 	/**
@@ -12,6 +13,7 @@ declare namespace Moleculer {
 	 *     type Promise<T> = Bluebird<T>;
 	 *   }
 	 */
+
 	type GenericObject = { [name: string]: any };
 
 	type LogLevels = "fatal" | "error" | "warn" | "info" | "debug" | "trace";
@@ -894,6 +896,11 @@ declare namespace Moleculer {
 		version?: string|number;
 	}
 
+	interface MoleculerRepl extends Vorpal{
+		removeIfExist(command:string);
+	}
+
+
 	class ServiceBroker {
 		constructor(options?: BrokerOptions);
 
@@ -933,7 +940,7 @@ declare namespace Moleculer {
 		start(): Promise<void>;
 		stop(): Promise<void>;
 
-		repl(): void;
+		repl(): MoleculerRepl;
 
 		errorHandler(err: Error, info: GenericObject): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -896,7 +896,7 @@ declare namespace Moleculer {
 	}
 
 	interface MoleculerRepl extends Vorpal{
-		removeIfExist(command:string);
+		removeIfExist(command:string): void;
 	}
 
 
@@ -1348,7 +1348,7 @@ declare namespace Moleculer {
 	const CIRCUIT_HALF_OPEN: string;
 	const CIRCUIT_OPEN: string;
 
-	declare class Vorpal {
+	class Vorpal {
 		parse(argv: ReadonlyArray<string>): this;
 		delimiter(value: string): this;
 		show(): this;
@@ -1370,7 +1370,7 @@ declare namespace Moleculer {
 		activeCommand: Vorpal.CommandInstance;
 	}
 	
-	declare namespace Vorpal {
+	namespace Vorpal {
 		interface Args {
 			[key: string]: any;
 			options: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 import { EventEmitter2 } from "eventemitter2";
-import Vorpal from "vorpal";
 
 declare namespace Moleculer {
 	/**
@@ -1348,6 +1347,85 @@ declare namespace Moleculer {
 	const CIRCUIT_CLOSE: string;
 	const CIRCUIT_HALF_OPEN: string;
 	const CIRCUIT_OPEN: string;
+
+	declare class Vorpal {
+		parse(argv: ReadonlyArray<string>): this;
+		delimiter(value: string): this;
+		show(): this;
+		hide(): this;
+		find(command: string): Vorpal.Command;
+		exec(command: string): Promise<{}>;
+		execSync(command: string): Promise<{}>;
+		log(value: string, ...values: string[]): this;
+		history(id: string): this;
+		localStorage(id: string): object;
+		help(value: (cmd: string) => string): this;
+		pipe(value: (stdout: string) => string): this;
+		use(extension: Vorpal.Extension): this;
+		catch(command: string, description?: string): Vorpal.Catch;
+		command(command: string, description?: string): Vorpal.Command;
+		version(version: string): this;
+		sigint(value: () => void): this;
+		ui: Vorpal.UI;
+		activeCommand: Vorpal.CommandInstance;
+	}
+	
+	declare namespace Vorpal {
+		interface Args {
+			[key: string]: any;
+			options: {
+				[key: string]: any;
+			};
+		}
+	
+		interface PromptObject {
+			[key: string]: any;
+		}
+	
+		type Action = (args: Args) => Promise<void>;
+		type Cancel = () => void;
+	
+		class Command {
+			_name: string;
+			_fn: Action;
+			_cancel: Cancel | undefined;
+			alias(command: string): this;
+			parse(value: (command: string, args: Args) => string): this;
+			option(option: string, description: string, autocomplete?: ReadonlyArray<string>): this;
+			types(types: { string?: ReadonlyArray<string> }): this;
+			hidden(): this;
+			remove(): this;
+			help(value: (args: Args) => void): this;
+			validate(value: (args: Args) => boolean | string): this;
+			autocomplete(values: ReadonlyArray<string> | { data: () => Promise<ReadonlyArray<string>> }): this;
+			action(action: Action): this;
+			cancel(cancel: Cancel): this;
+			allowUnknownOptions(): this;
+		}
+	
+		class Catch extends Command { }
+	
+		class Extension { }
+	
+		class UI {
+			delimiter(text?: string): string;
+			input(text?: string): string;
+			imprint(): void;
+			submit(command: string): string;
+			cancel(): void;
+			redraw: {
+				(text: string, ...texts: string[]): void;
+				clear(): void;
+				done(): void;
+			};
+		}
+	
+		class CommandInstance {
+			log(value: string, ...values: string[]): void;
+			prompt(prompt: object | ReadonlyArray<object>): Promise<PromptObject>;
+			delimiter(value: string): void;
+		}
+	}
 }
 
 export = Moleculer;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/ioredis": "^4.14.7",
     "@types/node": "^13.7.0",
     "@types/pino": "^5.15.5",
+    "@types/vorpal": "^1.12.0",
     "amqplib": "^0.5.5",
     "avsc": "^5.4.18",
     "benchmarkify": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@types/ioredis": "^4.14.7",
     "@types/node": "^13.7.0",
     "@types/pino": "^5.15.5",
-    "@types/vorpal": "^1.12.0",
     "amqplib": "^0.5.5",
     "avsc": "^5.4.18",
     "benchmarkify": "^2.1.2",


### PR DESCRIPTION
Sorry about that, just forgot the repl return on type definition.

Now i think is complete.

Edit: For some reason Travis-CI did not install @type/vorpal. For this reason i just copy the type definition. Vorpal is not maintained anymore, and changes will be from MoleculerRepl not Vorpal. Also, Moleculer-repl uses moleculerjs/vorpal, not the original project.