### PR TITLE
Fix stream chunking

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -787,12 +787,8 @@ class Transit {
 
 							this.logger.debug(`=> Send stream chunk to ${nodeName} node. Seq: ${copy.seq}`);
 
-							try {
-								this.publish(new Packet(P.PACKET_REQUEST, ctx.nodeID, copy));
-							} catch(e) {
-								publishCatch(e);
-								break;
-							}
+							this.publish(new Packet(P.PACKET_REQUEST, ctx.nodeID, copy))
+								.catch(publishCatch);
 						}
 						stream.resume();
 						return;
@@ -977,12 +973,8 @@ class Transit {
 
 					this.logger.debug(`=> Send stream chunk to ${nodeID} node. Seq: ${copy.seq}`);
 
-					try {
-						this.publish(new Packet(P.PACKET_RESPONSE, nodeID, copy));
-					} catch(e) {
-						publishCatch(e);
-						break;
-					}
+					this.publish(new Packet(P.PACKET_RESPONSE, nodeID, copy))
+						.catch(publishCatch);
 				}
 				stream.resume();
 				return;

--- a/src/transit.js
+++ b/src/transit.js
@@ -767,7 +767,7 @@ class Transit {
 					}
 
 					const stream = ctx.params;
-					stream.on("data", async (chunk) => {
+					stream.on("data", (chunk) => {
 						stream.pause();
 						const chunks = [];
 						if (chunk instanceof Buffer && this.opts.maxChunkSize > 0 && chunk.length > this.opts.maxChunkSize) {
@@ -788,7 +788,7 @@ class Transit {
 							this.logger.debug(`=> Send stream chunk to ${nodeName} node. Seq: ${copy.seq}`);
 
 							try {
-								await this.publish(new Packet(P.PACKET_REQUEST, ctx.nodeID, copy));
+								this.publish(new Packet(P.PACKET_REQUEST, ctx.nodeID, copy));
 							} catch(e) {
 								publishCatch(e);
 								break;
@@ -957,7 +957,7 @@ class Transit {
 			const stream = data;
 			stream.pause();
 
-			stream.on("data", async (chunk) => {
+			stream.on("data", (chunk) => {
 				stream.pause();
 				const chunks = [];
 				if (chunk instanceof Buffer && this.opts.maxChunkSize > 0 && chunk.length > this.opts.maxChunkSize) {
@@ -978,7 +978,7 @@ class Transit {
 					this.logger.debug(`=> Send stream chunk to ${nodeID} node. Seq: ${copy.seq}`);
 
 					try {
-						await this.publish(new Packet(P.PACKET_RESPONSE, nodeID, copy));
+						this.publish(new Packet(P.PACKET_RESPONSE, nodeID, copy));
 					} catch(e) {
 						publishCatch(e);
 						break;


### PR DESCRIPTION
## :memo: Description

With Pull request https://github.com/moleculerjs/moleculer/pull/683 splitting of stream chunks was introduced to prevent transit packet sizes that could exceed the maximum messages size of some transports.
If a stream was ended with a last chunk with a length greater than the configured maxChunkSize, the data chunks were sent asynchronously, while the stream end notification was sent synchronously after the first chunk.
As a solution the splitted chunks are sent synchronously.

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/711

### :gem: Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Added unit test.

## :checkered_flag: Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] **I have added tests that prove my fix is effective or that my feature works**
- [*] **New and existing unit tests pass locally with my changes**
- [*] I have commented my code, particularly in hard-to-understand areas
