### PR TITLE
tracer: adds NewRelic zipkin v2 tracer

### DIFF
--- a/src/tracing/exporters/index.js
+++ b/src/tracing/exporters/index.js
@@ -17,7 +17,8 @@ const Exporters = {
 	Event: require("./event"),
 	EventLegacy: require("./event-legacy"),
 	Jaeger: require("./jaeger"),
-	Zipkin: require("./zipkin")
+	Zipkin: require("./zipkin"),
+	NewRelic: require("./newrelic")
 };
 
 function getByName(name) {

--- a/src/tracing/exporters/newrelic.js
+++ b/src/tracing/exporters/newrelic.js
@@ -1,0 +1,205 @@
+"use strict";
+
+const _ 					= require("lodash");
+const fetch 				= require("node-fetch");
+const BaseTraceExporter 	= require("./base");
+
+/**
+ * Trace Exporter for NewRelic using Zipkin data.
+ *
+ * NewRelic zipkin tracer: https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api
+ * API v2: https://zipkin.io/zipkin-api/#/
+ *
+ * @class NewRelicTraceExporter
+ */
+class NewRelicTraceExporter extends BaseTraceExporter {
+
+	/**
+	 * Creates an instance of NewRelicTraceExporter.
+	 * @param {Object?} opts
+	 * @memberof NewRelicTraceExporter
+	 */
+	constructor(opts) {
+		super(opts);
+
+		this.opts = _.defaultsDeep(this.opts, {
+			/** @type {String} Base URL for NewRelic server. */
+			baseURL:
+			process.env.NEW_RELIC_TRACE_API_URL || 'https://trace-api.newrelic.com',
+
+		  /** @type {String} NewRelic Insert API Key */
+		  insertKey: '',
+
+		  /** @type {Number} Batch send time interval in seconds. */
+		  interval: 5,
+
+		  /** @type {Object} Additional payload options. */
+		  payloadOptions: {
+			/** @type {Boolean} Set `debug` property in v2 payload. */
+			debug: false,
+
+			/** @type {Boolean} Set `shared` property in v2 payload. */
+			shared: false,
+		  },
+
+		  /** @type {Object?} Default span tags */
+		  defaultTags: null,
+		});
+
+		this.queue = [];
+	}
+
+	/**
+	 * Initialize Trace Exporter.
+	 *
+	 * @param {Tracer} tracer
+	 * @memberof NewRelicTraceExporter
+	 */
+	init(tracer) {
+		super.init(tracer);
+
+		fetch.Promise = this.broker.Promise;
+
+		if (this.opts.interval > 0) {
+			this.timer = setInterval(() => this.flush(), this.opts.interval * 1000);
+			this.timer.unref();
+		}
+
+		this.defaultTags = _.isFunction(this.opts.defaultTags) ? this.opts.defaultTags.call(this, tracer) : this.opts.defaultTags;
+		if (this.defaultTags) {
+			this.defaultTags = this.flattenTags(this.defaultTags, true);
+		}
+	}
+
+	/**
+	 * Span is finished.
+	 *
+	 * @param {Span} span
+	 * @memberof NewRelicTraceExporter
+	 */
+	spanFinished(span) {
+		this.queue.push(span);
+	}
+
+	/**
+	 * Flush tracing data to NewRelic Zipkin api endpoint
+	 *
+	 * @memberof NewRelicTraceExporter
+	 */
+	flush() {
+		if (this.queue.length == 0) return;
+
+		const data = this.generateTracingData();
+		this.queue.length = 0;
+
+		fetch(`${this.opts.baseURL}/trace/v1`,
+		{
+			method: "post",
+			body: JSON.stringify(data),
+			headers: {
+				"Content-Type": "application/json",
+				"Api-Key": this.opts.insertKey,
+ 				"Data-Format": "zipkin",
+ 				"Data-Format-Version": "2"
+			}
+		}).then(res => {
+			if (res.status >= 400) {
+				this.logger.warn(`Unable to upload tracing spans to NewRelic. Status: ${res.status} ${res.statusText}`);
+			} else {
+				this.logger.debug(`Tracing spans (${data.length} spans) uploaded to NewRelic. Status: ${res.statusText}`);
+			}
+		}).catch(err => {
+			this.logger.warn("Unable to upload tracing spans to NewRelic. Error:" + err.message, err);
+		});
+	}
+
+	/**
+	 * Generate tracing data for NewRelic
+	 *
+	 * @returns {Array<Object>}
+	 * @memberof NewRelicTraceExporter
+	 */
+	generateTracingData() {
+		return this.queue.map(span => this.makePayload(span));
+	}
+
+	/**
+	 * Create Zipkin v2 payload from metric event
+	 *
+	 * @param {Span} span
+	 * @returns {Object}
+	 */
+	makePayload(span) {
+		const serviceName = span.service ? span.service.fullName : null;
+		const payload = {
+			name: span.name,
+			kind: "CONSUMER",
+
+			// Trace & span IDs
+			traceId: this.convertID(span.traceID),
+			id: this.convertID(span.id),
+			parentId: this.convertID(span.parentID),
+
+			localEndpoint: { serviceName },
+			remoteEndpoint: { serviceName },
+
+			annotations: [
+				{ timestamp: this.convertTime(span.startTime), value: "sr" },
+				{ timestamp: this.convertTime(span.finishTime), value: "ss" },
+			],
+
+			timestamp: this.convertTime(span.startTime),
+			duration: this.convertTime(span.duration),
+
+			tags: {
+				service: serviceName,
+				"span.type": span.type,
+			},
+
+			debug: this.opts.payloadOptions.debug,
+			shared: this.opts.payloadOptions.shared
+		};
+
+		if (span.error) {
+			payload.tags["error"] = span.error.message;
+
+			payload.annotations.push({
+				value: "error",
+				endpoint: { serviceName: serviceName, ipv4: "", port: 0 },
+				timestamp: this.convertTime(span.finishTime)
+			});
+		}
+
+		Object.assign(
+			payload.tags,
+			this.defaultTags || {},
+			this.flattenTags(span.tags, true),
+			this.flattenTags(this.errorToObject(span.error), true, "error") || {}
+		);
+
+		return payload;
+	}
+
+	/**
+	 * Convert Context ID to Zipkin format
+	 *
+	 * @param {String} id
+	 * @returns {String}
+	 */
+	convertID(id) {
+		return id ? id.replace(/-/g, "").substring(0, 16) : null;
+	}
+
+	/**
+	 * Convert JS timestamp to microseconds
+	 *
+	 * @param {Number} ts
+	 * @returns {Number}
+	 */
+	convertTime(ts) {
+		return ts != null ? Math.round(ts * 1000) : null;
+	}
+
+}
+
+module.exports = NewRelicTraceExporter;

--- a/src/tracing/exporters/newrelic.js
+++ b/src/tracing/exporters/newrelic.js
@@ -71,6 +71,17 @@ class NewRelicTraceExporter extends BaseTraceExporter {
 		}
 	}
 
+		/**
+	 * Stop Trace exporter
+	 */
+	stop() {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		return this.broker.Promise.resolve();
+	}
+
 	/**
 	 * Span is finished.
 	 *

--- a/test/unit/tracing/exporters/__snapshots__/newrelic.spec.js.snap
+++ b/test/unit/tracing/exporters/__snapshots__/newrelic.spec.js.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test NewRelic tracing exporter class Test makePayload should convert errored span to newrelic payload 1`] = `
+Object {
+  "annotations": Array [
+    Object {
+      "timestamp": 1000000,
+      "value": "sr",
+    },
+    Object {
+      "timestamp": 1050000,
+      "value": "ss",
+    },
+    Object {
+      "endpoint": Object {
+        "ipv4": "",
+        "port": 0,
+        "serviceName": "v1.posts",
+      },
+      "timestamp": 1050000,
+      "value": "error",
+    },
+  ],
+  "debug": false,
+  "duration": 50000,
+  "id": "spanid1234567890",
+  "kind": "CONSUMER",
+  "localEndpoint": Object {
+    "serviceName": "v1.posts",
+  },
+  "name": "Test Span",
+  "parentId": "parentid12345678",
+  "remoteEndpoint": Object {
+    "serviceName": "v1.posts",
+  },
+  "shared": true,
+  "tags": Object {
+    "a": "5",
+    "b": "John",
+    "c": "true",
+    "d": "null",
+    "def": "ault",
+    "error": "Something happened",
+    "error.code": "512",
+    "error.data.a": "5",
+    "error.message": "Something happened",
+    "error.name": "MoleculerRetryableError",
+    "error.retryable": "true",
+    "service": "v1.posts",
+    "span.type": "action",
+  },
+  "timestamp": 1000000,
+  "traceId": "traceid123456789",
+}
+`;
+
+exports[`Test NewRelic tracing exporter class Test makePayload should convert normal span to newrelic payload 1`] = `
+Object {
+  "annotations": Array [
+    Object {
+      "timestamp": 1000000,
+      "value": "sr",
+    },
+    Object {
+      "timestamp": 1050000,
+      "value": "ss",
+    },
+  ],
+  "debug": false,
+  "duration": 50000,
+  "id": "spanid1234567890",
+  "kind": "CONSUMER",
+  "localEndpoint": Object {
+    "serviceName": "v1.posts",
+  },
+  "name": "Test Span",
+  "parentId": "parentid12345678",
+  "remoteEndpoint": Object {
+    "serviceName": "v1.posts",
+  },
+  "shared": true,
+  "tags": Object {
+    "a": "5",
+    "b": "John",
+    "c": "true",
+    "d": "null",
+    "def": "ault",
+    "service": "v1.posts",
+    "span.type": "custom",
+  },
+  "timestamp": 1000000,
+  "traceId": "traceid123456789",
+}
+`;

--- a/test/unit/tracing/exporters/newrelic.spec.js
+++ b/test/unit/tracing/exporters/newrelic.spec.js
@@ -120,6 +120,21 @@ describe("Test NewRelic tracing exporter class", () => {
 
 	});
 
+	describe("Test stop method", () => {
+		const fakeTracer = { logger: broker.logger, broker };
+
+		it("should flatten default tags", async () => {
+			const exporter = new NewRelicTraceExporter({ defaultTags: { a: { b: "c" } } });
+			exporter.init(fakeTracer);
+
+			expect(exporter.timer).toBeDefined();
+
+			await exporter.stop();
+
+			expect(exporter.timer).toBeNull();
+		});
+	});
+
 	describe("Test spanFinished method", () => {
 		const fakeTracer = { logger: broker.logger, broker };
 		const exporter = new NewRelicTraceExporter({});

--- a/test/unit/tracing/exporters/newrelic.spec.js
+++ b/test/unit/tracing/exporters/newrelic.spec.js
@@ -1,0 +1,311 @@
+"use strict";
+
+const lolex = require("@sinonjs/fake-timers");
+
+jest.mock("node-fetch");
+const fetch = require("node-fetch");
+fetch.mockImplementation(() => Promise.resolve({ statusText: "" }));
+
+const NewRelicTraceExporter = require("../../../../src/tracing/exporters/newrelic");
+const ServiceBroker = require("../../../../src/service-broker");
+const { MoleculerRetryableError } = require("../../../../src/errors");
+
+const broker = new ServiceBroker({ logger: false });
+
+describe("Test NewRelic tracing exporter class", () => {
+
+	describe("Test Constructor", () => {
+
+		it("should create with default options", () => {
+			const exporter = new NewRelicTraceExporter();
+
+			expect(exporter.opts).toEqual({
+				baseURL: "https://trace-api.newrelic.com",
+				defaultTags: null,
+				insertKey: '',
+				interval: 5,
+				payloadOptions: {
+					debug: false,
+					shared: false
+				}
+			});
+
+			expect(exporter.queue).toBeInstanceOf(Array);
+		});
+
+		it("should create with custom options", () => {
+			const exporter = new NewRelicTraceExporter({
+				baseURL: "https://trace-api.newrelic.com",
+				interval: 10,
+				insertKey: 'mock-newrelic-insert-key',
+				payloadOptions: {
+					debug: true
+				},
+
+				defaultTags: {
+					a: 5
+				}
+			});
+
+			expect(exporter.opts).toEqual({
+				baseURL: "https://trace-api.newrelic.com",
+				interval: 10,
+				insertKey: 'mock-newrelic-insert-key',
+				payloadOptions: {
+					debug: true,
+					shared: false
+				},
+
+				defaultTags: {
+					a: 5
+				}
+			});
+		});
+
+	});
+
+	describe("Test init method", () => {
+		const fakeTracer = { logger: broker.logger, broker };
+
+		let clock;
+		beforeAll(() => clock = lolex.install());
+		afterAll(() => clock.uninstall());
+
+		it("should create timer", () => {
+			const exporter = new NewRelicTraceExporter({});
+			exporter.flush = jest.fn();
+			exporter.init(fakeTracer);
+
+			expect(exporter.timer).toBeDefined();
+			expect(exporter.flush).toBeCalledTimes(0);
+
+			clock.tick(5500);
+
+			expect(exporter.flush).toBeCalledTimes(1);
+		});
+
+		it("should not create timer", () => {
+			const exporter = new NewRelicTraceExporter({ interval: 0 });
+			exporter.init(fakeTracer);
+
+			expect(exporter.timer).toBeUndefined();
+		});
+
+		it("should flatten default tags", () => {
+			const exporter = new NewRelicTraceExporter({ defaultTags: { a: { b: "c" } } });
+			jest.spyOn(exporter, "flattenTags");
+			exporter.init(fakeTracer);
+
+			expect(exporter.defaultTags).toEqual({
+				"a.b": "c"
+			});
+
+			expect(exporter.flattenTags).toHaveBeenCalledTimes(2);
+			expect(exporter.flattenTags).toHaveBeenNthCalledWith(2, { b: "c" }, true, "a");
+			expect(exporter.flattenTags).toHaveBeenNthCalledWith(1, { a: { b: "c" } }, true);
+		});
+
+		it("should call defaultTags function", () => {
+			const fn = jest.fn(() => ({ a: { b: 5 } }));
+			const exporter = new NewRelicTraceExporter({ defaultTags: fn });
+			exporter.init(fakeTracer);
+
+			expect(exporter.defaultTags).toEqual({
+				"a.b": "5"
+			});
+
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(fn).toHaveBeenNthCalledWith(1, fakeTracer);
+		});
+
+	});
+
+	describe("Test spanFinished method", () => {
+		const fakeTracer = { logger: broker.logger, broker };
+		const exporter = new NewRelicTraceExporter({});
+		exporter.init(fakeTracer);
+
+		it("should push spans to the queue", () => {
+			expect(exporter.queue).toEqual([]);
+
+			const span1 = {};
+			const span2 = {};
+
+			exporter.spanFinished(span1);
+			exporter.spanFinished(span2);
+
+			expect(exporter.queue).toEqual([span1, span2]);
+		});
+
+	});
+
+	describe("Test flush method", () => {
+		const fakeTracer = {
+			logger: broker.logger,
+			broker
+		};
+
+		const exporter = new NewRelicTraceExporter({
+			baseURL: "https://trace-api.newrelic.com",
+			insertKey: "mock-newrelic-insert-key"
+		});
+		exporter.init(fakeTracer);
+
+		exporter.generateTracingData = jest.fn(() => ({ a: 5 }));
+
+		it("should not generate data if queue is empty", () => {
+			exporter.flush();
+
+			expect(exporter.generateTracingData).toHaveBeenCalledTimes(0);
+		});
+
+		it("should generate & send data if queue is not empty", () => {
+			exporter.spanFinished({});
+
+			exporter.flush();
+
+			expect(exporter.generateTracingData).toHaveBeenCalledTimes(1);
+			expect(exporter.queue.length).toEqual(0);
+			expect(fetch).toHaveBeenCalledTimes(1);
+			expect(fetch).toHaveBeenCalledWith("https://trace-api.newrelic.com/trace/v1", {
+				method: "post",
+				headers: {
+					"Content-Type": "application/json",
+					"Api-Key": "mock-newrelic-insert-key",
+ 					"Data-Format": "zipkin",
+ 					"Data-Format-Version": "2"
+				},
+				body: "{\"a\":5}"
+			});
+		});
+
+	});
+
+	describe("Test generateTracingData method", () => {
+		const fakeTracer = {
+			logger: broker.logger,
+			broker
+		};
+
+		const exporter = new NewRelicTraceExporter({});
+		exporter.init(fakeTracer);
+
+		exporter.makePayload = jest.fn(span => span);
+
+		it("should call makePayload", () => {
+			exporter.spanFinished({ a: 5 });
+			exporter.spanFinished({ b: 10 });
+
+			const res = exporter.generateTracingData();
+
+			expect(exporter.makePayload).toHaveBeenCalledTimes(2);
+			expect(exporter.makePayload).toHaveBeenNthCalledWith(1, { a: 5 });
+			expect(exporter.makePayload).toHaveBeenNthCalledWith(2, { b: 10 });
+
+			expect(res).toEqual([
+				{ a: 5 },
+				{ b: 10 }
+			]);
+		});
+	});
+
+	describe("Test convertID & convertTime methods", () => {
+		const fakeTracer = { logger: broker.logger, broker };
+		const exporter = new NewRelicTraceExporter({});
+		exporter.init(fakeTracer);
+
+		it("should truncate ID", () => {
+			expect(exporter.convertID()).toBeNull();
+			expect(exporter.convertID("")).toBeNull();
+			expect(exporter.convertID("12345678")).toBe("12345678");
+			expect(exporter.convertID("123456789-0123456")).toBe("1234567890123456");
+			expect(exporter.convertID("123456789-0123456789-0")).toBe("1234567890123456");
+		});
+
+		it("should convert time", () => {
+			expect(exporter.convertTime()).toBeNull();
+			expect(exporter.convertTime(0)).toBe(0);
+			expect(exporter.convertTime(10)).toBe(10000);
+			expect(exporter.convertTime(12345678)).toBe(12345678000);
+		});
+	});
+
+	describe("Test makePayload", () => {
+		const fakeTracer = {
+			logger: broker.logger,
+			broker,
+			opts: {
+				errorFields: ["name", "message", "retryable", "data", "code"]
+			}
+		};
+		const exporter = new NewRelicTraceExporter({
+			defaultTags: {
+				def: "ault"
+			},
+			payloadOptions: {
+				shared: true
+			}
+		});
+		exporter.init(fakeTracer);
+
+		it("should convert normal span to newrelic payload", () => {
+			const span = {
+				name: "Test Span",
+				type: "custom",
+				id: "span-id-12345678901234567890",
+				traceID: "trace-id-12345678901234567890",
+				parentID: "parent-id-12345678901234567890",
+
+				service: {
+					fullName: "v1.posts"
+				},
+
+				startTime: 1000,
+				finishTime: 1050,
+				duration: 50,
+
+				tags: {
+					a: 5,
+					b: "John",
+					c: true,
+					d: null
+				}
+			};
+
+			expect(exporter.makePayload(span)).toMatchSnapshot();
+		});
+
+		it("should convert errored span to newrelic payload", () => {
+			const err = new MoleculerRetryableError("Something happened", 512, "SOMETHING", { a: 5 });
+
+			const span = {
+				name: "Test Span",
+				type: "action",
+				id: "span-id-12345678901234567890",
+				traceID: "trace-id-12345678901234567890",
+				parentID: "parent-id-12345678901234567890",
+
+				service: {
+					fullName: "v1.posts"
+				},
+
+				startTime: 1000,
+				finishTime: 1050,
+				duration: 50,
+
+				tags: {
+					a: 5,
+					b: "John",
+					c: true,
+					d: null
+				},
+
+				error: err
+			};
+
+			expect(exporter.makePayload(span)).toMatchSnapshot();
+		});
+
+	});
+
+});


### PR DESCRIPTION
## :memo: Description

Adds a NewRelic tracer exporter using Zipkin v2 payloads. NewRelic distributed tracing uses two data formats: NewRelic, and Zipkin. Since moleculer already includes a Zipkin tracer, this PR adds a NewRelic tracer that uses the zipkin format to export the spans to NewRelic servers.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### :scroll: Example code
```js
tracing: {
  enabled: true,
  events: true,
  exporter: [
    {
      type: 'NewRelic',
      options: {
        // NewRelic Insert Key
        insertKey: process.env.NEW_RELIC_INSERT_KEY,
        // Sending time interval in seconds.
        interval: 5,
        // Additional payload options.
        payloadOptions: {
          // Set `debug` property in payload.
          debug: false,
          // Set `shared` property in payload.
          shared: false,
        },
        // Default tags. They will be added into all span tags.
        defaultTags: null,
      },
    },
  ],
},
``` 

## :vertical_traffic_light: How Has This Been Tested?

NewRelic Zipkin Tracing API: [https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api)

You'll need a NewRelic Insert API key to get NewRelic to accept the data. To create this key: 

1. go to insights.newrelic.com
2. select Manage data
3. select API keys from the upper navigation. 
4. create a new key by selecting Insert keys +.

Then in your app pass the key to the `tracing` config object options in the `insertKey` property, see example above using `process.env`;

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
