### PR TITLE
[TS] Allow mixins to accept partial service schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -619,7 +619,7 @@ declare namespace Moleculer {
 		dependencies?: string | ServiceDependency | Array<string | ServiceDependency>;
 		metadata?: GenericObject;
 		actions?: ServiceActionsSchema;
-		mixins?: Array<ServiceSchema>;
+		mixins?: Array<Partial<ServiceSchema>>;
 		methods?: ServiceMethods;
 		hooks?: ServiceHooks;
 


### PR DESCRIPTION
## :memo: Description

A slight change in `index.d.ts` that allows `mixins` to accept service schema without the `name` property. 
Related issue: https://github.com/moleculerjs/moleculer-template-project-typescript/pull/20