### PR TITLE
Safely handle disconnected state for transporters

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -61,6 +61,20 @@ class MoleculerRetryableError extends MoleculerError {
 }
 
 /**
+ * Moleculer Error class for Broker disconnections which is retryable.
+ *
+ * @class MoleculerServerError
+ * @extends {MoleculerRetryableError}
+ */
+class BrokerDisconnectedError extends MoleculerRetryableError {
+	constructor() {
+		super("The broker's transporter has disconnected. Please try again when a connection is reestablished.", 502, "BAD_GATEWAY");
+		// Stack trace is hidden because it creates a lot of logs and, in this case, won't help users find the issue
+		this.stack = "";
+	}
+}
+
+/**
  * Moleculer Error class for server error which is retryable.
  *
  * @class MoleculerServerError
@@ -423,6 +437,8 @@ module.exports = {
 
 	ProtocolVersionMismatchError,
 	InvalidPacketDataError,
+
+	BrokerDisconnectedError,
 
 	recreateError
 };

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -569,7 +569,7 @@ class ServiceBroker {
 			let opts = null;
 			const delimiter = this.options.replDelimiter;
 			const customCommands = this.options.replCommands;
-			delimiter && (opts = {delimiter}) 
+			delimiter && (opts = {delimiter})
 			customCommands && (opts = {...opts,customCommands})
 			return repl(this, opts);
 		}
@@ -1309,7 +1309,7 @@ class ServiceBroker {
 			}
 
 			if (groups.length == 0)
-				return;
+				return this.Promise.resolve();
 
 			ctx.eventGroups = groups;
 			return this.transit.sendEvent(ctx);

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -32,6 +32,21 @@ describe("Test Errors", () => {
 		expect(err.retryable).toBe(true);
 	});
 
+	it("test BrokerDisconnectedError", () => {
+		let err = new errors.BrokerDisconnectedError();
+		expect(err).toBeDefined();
+		expect(err).toBeInstanceOf(Error);
+		expect(err).toBeInstanceOf(errors.MoleculerError);
+		expect(err).toBeInstanceOf(errors.MoleculerRetryableError);
+		expect(err).toBeInstanceOf(errors.BrokerDisconnectedError);
+		expect(err.name).toBe("BrokerDisconnectedError");
+		expect(err.message).toBe("The broker's transporter has disconnected. Please try again when a connection is reestablished.");
+		expect(err.code).toBe(502);
+		expect(err.type).toBe("BAD_GATEWAY");
+		expect(err.data).toEqual(undefined);
+		expect(err.retryable).toBe(true);
+	});
+
 	it("test MoleculerServerError", () => {
 		let err = new errors.MoleculerServerError("Something went wrong!", 555, "ERR_TYPE", { a: 5 });
 		expect(err).toBeDefined();


### PR DESCRIPTION
## :memo: Description

### First commit
#### Issue
@icebob found that when connection is lost, some transporters queue messages in memory and send them when a connection is recovered. This is useful in some cases, but for Moleculer it can lead to queueing up many heartbeat packets and potentially requests.

#### Solution
If the connection is lost, BrokerDisconnectedError will be thrown for user-initiated packets when transporter disconnects (PING, REQ, EVENT). For internal packets (HEARTBEAT, INFO, etc) we will simply not send and no error will be thrown.

If the disconnection is long enough, heartbeats will be skipped and the remote nodes will be removed from the registry. After this happens, actions will start failing with ServiceNotAvailableError and RequestRejectedError like normally.

### Second commit
Address AMQP reconnection issue. See commit for more details.

### Third commit
Make sure `ServiceBroker.emit()` always returns a promise.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran two nodes. One called actions on, emitted events to, and pinged the other node. Restarted message broker and confirmed that errors were thrown for the correct packets.


## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
