### PR TITLE
Add getServiceList, missing in typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1328,6 +1328,8 @@ declare namespace Moleculer {
 		services: any;
 		actions: any;
 		events: any;
+
+		getServiceList({withActions: bool}): ServiceSchema[]
 	}
 
 	class AsyncStorage {

--- a/index.d.ts
+++ b/index.d.ts
@@ -476,7 +476,7 @@ declare namespace Moleculer {
 		disconnected(): void;
 	}
 
-	class Context<P = unknown, M extends object = {}> {
+	class Context<P = unknown, M extends object = {[key: string]: any}> {
 		constructor(broker: ServiceBroker, endpoint: Endpoint);
 		id: string;
 		broker: ServiceBroker;


### PR DESCRIPTION
## :memo: Description

We are using this function in openapi.json auto-generate

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```js
this.broker.registry.getServiceList({ withActions: true }).forEach(this.logger.info);
``` 
