### PR TITLE
Allowing internal interfaces for udp-broadcaster;

### DIFF
--- a/src/metrics/commons.js
+++ b/src/metrics/commons.js
@@ -223,15 +223,28 @@ function updateCommonMetrics() {
 
 	// --- NETWORK INTERFACES ---
 
-	const interfaces = os.networkInterfaces();
-	for (let iface in interfaces) {
-		for (let i in interfaces[iface]) {
-			const f = interfaces[iface][i];
-			if (!f.internal) {
-				this.set(METRIC.OS_NETWORK_ADDRESS, f.address, { interface: iface, family: f.family });
-				this.set(METRIC.OS_NETWORK_MAC, f.mac, { interface: iface, family: f.family });
+
+	const getNetworkInterfaces = () =>{
+		const list = [];
+		const ilist = [];
+		const interfaces = os.networkInterfaces();
+		for (let iface in interfaces) {
+			for (let i in interfaces[iface]) {
+				const f = interfaces[iface][i];
+				if (f.internal) {
+					ilist.push({f,iface})
+				} else{
+					list.push({f,iface})
+				}
 			}
 		}
+		return list.length > 0 ? list : ilist;
+	}
+
+	const interfaces = getNetworkInterfaces();
+	for (let {f,iface} of interfaces) {
+		this.set(METRIC.OS_NETWORK_ADDRESS, f.address, { interface: iface, family: f.family });
+		this.set(METRIC.OS_NETWORK_MAC, f.mac, { interface: iface, family: f.family });
 	}
 
 	const d = new Date();

--- a/src/transporters/tcp/udp-broadcaster.js
+++ b/src/transporters/tcp/udp-broadcaster.js
@@ -260,7 +260,7 @@ class UdpServer extends EventEmitter {
 		for (let iface in interfaces) {
 			for (let i in interfaces[iface]) {
 				const f = interfaces[iface][i];
-				if (f.family === "IPv4" && !f.internal) {
+				if (f.family === "IPv4") {
 					list.push(ipaddr.IPv4.broadcastAddressFromCIDR(f.cidr).toString());
 				}
 			}
@@ -280,7 +280,7 @@ class UdpServer extends EventEmitter {
 		for (let iface in interfaces) {
 			for (let i in interfaces[iface]) {
 				const f = interfaces[iface][i];
-				if (f.family === "IPv4" && !f.internal) {
+				if (f.family === "IPv4") {
 					list.push(f.address);
 				}
 			}

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,17 +118,23 @@ const utils = {
 	 */
 	getIpList() {
 		const list = [];
+		const ilist = [];
 		const interfaces = os.networkInterfaces();
 		for (let iface in interfaces) {
 			for (let i in interfaces[iface]) {
 				const f = interfaces[iface][i];
-				if (f.family === "IPv4" && !f.internal) {
-					list.push(f.address);
-					break;
+				if (f.family === "IPv4") {
+					if (f.internal) {
+						ilist.push(f.address);
+						break;
+					} else {
+						list.push(f.address);
+						break;
+					}
 				}
 			}
 		}
-		return list;
+		return list.length > 0 ? list : ilist;
 	},
 
 	/**

--- a/test/unit/transporters/tcp/udp-broadcaster.spec.js
+++ b/test/unit/transporters/tcp/udp-broadcaster.spec.js
@@ -449,21 +449,6 @@ describe("Test UdpServer.close", () => {
 
 describe("Test UdpServer getBroadcastAddresses", () => {
 	os.networkInterfaces = jest.fn(() => ({
-		"Local": [
-			{
-				address: "fe80::29a9:ffeb:4a65:9f82",
-				netmask: "ffff:ffff:ffff:ffff::",
-				family: "IPv6",
-				internal: false,
-				cidr: "fe80::29a9:ffeb:4a65:9f82/64"
-			},
-			{ address: "192.168.2.100",
-				netmask: "255.255.255.0",
-				family: "IPv4",
-				internal: false,
-				cidr: "192.168.2.100/24"
-			}
-		],
 		"Loopback Pseudo-Interface 1": [
 			{
 				address: "::1",
@@ -478,6 +463,21 @@ describe("Test UdpServer getBroadcastAddresses", () => {
 				family: "IPv4",
 				internal: true,
 				cidr: "127.0.0.1/8"
+			}
+		],
+		"Local": [
+			{
+				address: "fe80::29a9:ffeb:4a65:9f82",
+				netmask: "ffff:ffff:ffff:ffff::",
+				family: "IPv6",
+				internal: false,
+				cidr: "fe80::29a9:ffeb:4a65:9f82/64"
+			},
+			{ address: "192.168.2.100",
+				netmask: "255.255.255.0",
+				family: "IPv4",
+				internal: false,
+				cidr: "192.168.2.100/24"
 			}
 		],
 		"VMware Network Adapter VMnet1": [
@@ -507,28 +507,13 @@ describe("Test UdpServer getBroadcastAddresses", () => {
 			}
 		};
 		let udp = new UdpServer(transporter);
-		expect(udp.getBroadcastAddresses()).toEqual(["192.168.2.255", "192.168.232.255"]);
+		expect(udp.getBroadcastAddresses()).toEqual(["127.255.255.255","192.168.2.255", "192.168.232.255"]);
 	});
 
 });
 
 describe("Test UdpServer getInterfaceAddresses", () => {
 	os.networkInterfaces = jest.fn(() => ({
-		"Local": [
-			{
-				address: "fe80::29a9:ffeb:4a65:9f82",
-				netmask: "ffff:ffff:ffff:ffff::",
-				family: "IPv6",
-				internal: false,
-				cidr: "fe80::29a9:ffeb:4a65:9f82/64"
-			},
-			{ address: "192.168.2.100",
-				netmask: "255.255.255.0",
-				family: "IPv4",
-				internal: false,
-				cidr: "192.168.2.100/24"
-			}
-		],
 		"Loopback Pseudo-Interface 1": [
 			{
 				address: "::1",
@@ -543,6 +528,21 @@ describe("Test UdpServer getInterfaceAddresses", () => {
 				family: "IPv4",
 				internal: true,
 				cidr: "127.0.0.1/8"
+			}
+		],
+		"Local": [
+			{
+				address: "fe80::29a9:ffeb:4a65:9f82",
+				netmask: "ffff:ffff:ffff:ffff::",
+				family: "IPv6",
+				internal: false,
+				cidr: "fe80::29a9:ffeb:4a65:9f82/64"
+			},
+			{ address: "192.168.2.100",
+				netmask: "255.255.255.0",
+				family: "IPv4",
+				internal: false,
+				cidr: "192.168.2.100/24"
 			}
 		],
 		"VMware Network Adapter VMnet1": [
@@ -572,7 +572,7 @@ describe("Test UdpServer getInterfaceAddresses", () => {
 			}
 		};
 		let udp = new UdpServer(transporter);
-		expect(udp.getInterfaceAddresses()).toEqual(["192.168.2.100", "192.168.232.1"]);
+		expect(udp.getInterfaceAddresses()).toEqual(["127.0.0.1","192.168.2.100", "192.168.232.1"]);
 	});
 
 });

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -77,6 +77,100 @@ describe("Test utils.getNodeID", () => {
 	});
 });
 
+describe("Test utils.getIpList", () => {
+	let os = require("os");
+	it("should give only IPv4 external interfaces", () => {
+		os.networkInterfaces = jest.fn(() => ({
+			"Loopback Pseudo-Interface 1": [
+				{
+					address: "::1",
+					netmask: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+					family: "IPv6",
+					internal: true,
+					cidr: "::1/128"
+				},
+				{
+					address: "127.0.0.1",
+					netmask: "255.0.0.0",
+					family: "IPv4",
+					internal: true,
+					cidr: "127.0.0.1/8"
+				}
+			],
+			"Local": [
+				{
+					address: "fe80::29a9:ffeb:4a65:9f82",
+					netmask: "ffff:ffff:ffff:ffff::",
+					family: "IPv6",
+					internal: false,
+					cidr: "fe80::29a9:ffeb:4a65:9f82/64"
+				},
+				{ address: "192.168.2.100",
+					netmask: "255.255.255.0",
+					family: "IPv4",
+					internal: false,
+					cidr: "192.168.2.100/24"
+				}
+			],
+			"VMware Network Adapter VMnet1": [
+				{
+					address: "fe80::3c63:fab8:e6be:8059",
+					netmask: "ffff:ffff:ffff:ffff::",
+					family: "IPv6",
+					internal: false,
+					cidr: "fe80::3c63:fab8:e6be:8059/64"
+				},
+				{
+					address: "192.168.232.1",
+					netmask: "255.255.255.0",
+					family: "IPv4",
+					internal: false,
+					cidr: "192.168.232.1/24"
+				}
+			]
+		}));
+		expect(utils.getIpList()).toEqual(["192.168.2.100", "192.168.232.1"]);
+	});
+	it("should give all IPv4 internal interfaces", () => {
+		os.networkInterfaces = jest.fn(() => ({
+			"Loopback Pseudo-Interface 1": [
+				{
+					address: "::1",
+					netmask: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+					family: "IPv6",
+					internal: true,
+					cidr: "::1/128"
+				},
+				{
+					address: "127.0.0.1",
+					netmask: "255.0.0.0",
+					family: "IPv4",
+					internal: true,
+					cidr: "127.0.0.1/8"
+				}
+			],
+			"Loopback Pseudo-Interface 2": [
+				{
+					address: "::2",
+					netmask: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+					family: "IPv6",
+					internal: true,
+					cidr: "::2/128"
+				},
+				{
+					address: "127.0.0.2",
+					netmask: "255.0.0.0",
+					family: "IPv4",
+					internal: true,
+					cidr: "127.0.0.2/8"
+				}
+			],
+
+		}));
+		expect(utils.getIpList()).toEqual(["127.0.0.1","127.0.0.2"]);
+	});
+});
+
 describe("Test match", () => {
 
 	expect(utils.match("1.2.3", "1.2.3")).toBe(true);


### PR DESCRIPTION
This fix: #732

Two additional comments:

I tested the `udp-broadcast `with and without external interfaces and i didn't see any drawback interacting with external ips; For Internal only, now its also possible to use the udp-broadcast;

To work seamlessly with the rest of the API, i changed the `utils.getIpList` and `metrics ip list` to show the internal IPs is the machine is "`offline`"; In this way will correctly show the internal IP instead a "??" on `repl`, `metrics`, and other places;