### PR TITLE
fix: use config file with "export default"

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -154,7 +154,7 @@ class MoleculerRunner {
 							else
 								return content;
 						})
-						.then(res => this.configFile = res);
+						.then(res => this.configFile = res.default != null && res.__esModule ? res.default : res);
 				}
 				default: return Promise.reject(new Error(`Not supported file extension: ${ext}`));
 			}


### PR DESCRIPTION
## :memo: Description

This change is to support config file as module and use of typescript

### :dart: Relevant issues

Enhancement

### :gem: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
const brokerConfig = { ... };
export default brokerConfig;
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
