### PR TITLE
configurable interval in waitForServices function

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -104,6 +104,7 @@ const defaultOptions = {
 
 	internalServices: true,
 	internalMiddlewares: true,
+	dependencyInterval: 1000,
 
 	hotReload: false,
 
@@ -977,7 +978,7 @@ class ServiceBroker {
 				if (timeout && Date.now() - startTime > timeout)
 					return reject(new E.MoleculerServerError("Services waiting is timed out.", 500, "WAITFOR_SERVICES", { services: serviceNames }));
 
-				setTimeout(check, interval || 1000);
+				setTimeout(check, interval || this.options.dependencyInterval || 1000);
 			};
 
 			check();

--- a/src/service.js
+++ b/src/service.js
@@ -238,7 +238,7 @@ class Service {
 			.then(() => {
 				// Wait for dependent services
 				if (this.schema.dependencies)
-					return this.waitForServices(this.schema.dependencies, this.settings.$dependencyTimeout || 0);
+					return this.waitForServices(this.schema.dependencies, this.settings.$dependencyTimeout || 0, this.settings.$dependencyInterval || 1000);
 			})
 			.then(() => {
 				if (isFunction(this.schema.started))

--- a/src/service.js
+++ b/src/service.js
@@ -238,7 +238,7 @@ class Service {
 			.then(() => {
 				// Wait for dependent services
 				if (this.schema.dependencies)
-					return this.waitForServices(this.schema.dependencies, this.settings.$dependencyTimeout || 0, this.settings.$dependencyInterval || 0);
+					return this.waitForServices(this.schema.dependencies, this.settings.$dependencyTimeout || 0, this.settings.$dependencyInterval || this.broker.options.dependencyInterval);
 			})
 			.then(() => {
 				if (isFunction(this.schema.started))

--- a/src/service.js
+++ b/src/service.js
@@ -238,7 +238,7 @@ class Service {
 			.then(() => {
 				// Wait for dependent services
 				if (this.schema.dependencies)
-					return this.waitForServices(this.schema.dependencies, this.settings.$dependencyTimeout || 0, this.settings.$dependencyInterval || 1000);
+					return this.waitForServices(this.schema.dependencies, this.settings.$dependencyTimeout || 0, this.settings.$dependencyInterval || 0);
 			})
 			.then(() => {
 				if (isFunction(this.schema.started))

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -366,7 +366,7 @@ describe("Test Service mixins", () => {
 			"math"
 		]);
 		expect(svc.waitForServices).toHaveBeenCalledTimes(1);
-		expect(svc.waitForServices).toHaveBeenCalledWith(["posts", { name: "users", version: 2 }, "math"], 0, 0);
+		expect(svc.waitForServices).toHaveBeenCalledWith(["posts", { name: "users", version: 2 }, "math"], 0, 1000);
 	});
 
 	it("should merge metadata", () => {

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -366,7 +366,7 @@ describe("Test Service mixins", () => {
 			"math"
 		]);
 		expect(svc.waitForServices).toHaveBeenCalledTimes(1);
-		expect(svc.waitForServices).toHaveBeenCalledWith(["posts", { name: "users", version: 2 }, "math"], 0);
+		expect(svc.waitForServices).toHaveBeenCalledWith(["posts", { name: "users", version: 2 }, "math"], 0, 0);
 	});
 
 	it("should merge metadata", () => {

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -244,6 +244,7 @@ describe("Test ServiceBroker constructor", () => {
 			validator: false,
 			internalServices: false,
 			internalMiddlewares: true,
+			dependencyInterval: 1000,
 			hotReload: true,
 			middlewares: null,
 			replCommands: null,

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -514,7 +514,7 @@ describe("Test Service class", () => {
 			expect(broker.registerLocalService).toBeCalledWith(svc._serviceSpecification);
 
 			expect(svc.waitForServices).toBeCalledTimes(1);
-			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 0);
+			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 0, 0);
 		});
 
 		it("should call waitForServices if dependencies are defined & $dependencyTimeout", async () => {
@@ -531,7 +531,24 @@ describe("Test Service class", () => {
 			await svc._start();
 
 			expect(svc.waitForServices).toBeCalledTimes(1);
-			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 3000);
+			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 3000, 0);
+		});
+
+		it("should call waitForServices if dependencies are defined & $dependencyInterval", async () => {
+			svc.parseServiceSchema({
+				name: "posts",
+				settings: {
+					$dependencyInterval: 100
+				},
+				dependencies: ["users", "auth"]
+			});
+
+			svc.waitForServices.mockClear();
+
+			await svc._start();
+
+			expect(svc.waitForServices).toBeCalledTimes(1);
+			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 0, 100);
 		});
 
 		it("should call single started lifecycle event handler", async () => {
@@ -1835,4 +1852,3 @@ describe("Test Service class", () => {
 	});
 
 });
-

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -514,7 +514,7 @@ describe("Test Service class", () => {
 			expect(broker.registerLocalService).toBeCalledWith(svc._serviceSpecification);
 
 			expect(svc.waitForServices).toBeCalledTimes(1);
-			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 0, 0);
+			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 0, 1000);
 		});
 
 		it("should call waitForServices if dependencies are defined & $dependencyTimeout", async () => {
@@ -531,7 +531,7 @@ describe("Test Service class", () => {
 			await svc._start();
 
 			expect(svc.waitForServices).toBeCalledTimes(1);
-			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 3000, 0);
+			expect(svc.waitForServices).toBeCalledWith(["users", "auth"], 3000, 1000);
 		});
 
 		it("should call waitForServices if dependencies are defined & $dependencyInterval", async () => {


### PR DESCRIPTION
First, many thanks to @icebob and the community for this amazing framework. This is my first contribution to an open-source project, so I hope that I've respected the workflow.

## :memo: Description
In noticed that moleculer could take several seconds(1) to startup due to the dependency interval that is hard-coded to 1000 ms. Using the following ServiceFactory, I managed to reduce the startup time a lot when dependencies are involved.
```js
class FastService extends Service {
  constructor(broker, schema) {
    super(broker, schema)
  }
  waitForServices(serviceNames, timeout, interval) {
    return this.broker.waitForServices(serviceNames, timeout, this.settings.$dependencyInterval || 1000, this.logger)
  }
}
```
This pull request slightly changes the code of waitForServices for both service and service-broker, in order to allow the configuration of the interval parameter.

(1) `~1000 * n ms`, where n is the depth of the dependency chain

### :dart: Relevant issues

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

I add a test in service.spec "should call waitForServices if dependencies are defined & $dependencyInterval". It tests that adding $dependencyInterval in service.settings calls waitForServices with correct arguments

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
