### PR TITLE
update Cacher.prototype._generateKeyFromObject to distinguish x=[1] and x=1

### DIFF
--- a/src/cachers/base.js
+++ b/src/cachers/base.js
@@ -220,7 +220,7 @@ class Cacher {
 
 	_generateKeyFromObject(obj) {
 		if (Array.isArray(obj)) {
-			return obj.map(o => this._generateKeyFromObject(o)).join("|");
+			return "[" + obj.map(o => this._generateKeyFromObject(o)).join("|") + "]";
 		}
 		else if (isObject(obj)) {
 			return Object.keys(obj).map(key => [key, this._generateKeyFromObject(obj[key])].join("|")).join("|");


### PR DESCRIPTION
## :memo: Description

This PR updates default keygen logic to make key for array as "param|[x|y|z]" rather than "param|x|y|z". It was required for me to distinguish the result of param=[1] and param=1 for same action while integrate moleculer service actions with Dataloader (facebook) batching requests.

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :checkered_flag: Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
