### PR TITLE
replace slave with replica

### DIFF
--- a/test/integration/circuit-breaker.spec.js
+++ b/test/integration/circuit-breaker.spec.js
@@ -25,13 +25,13 @@ describe("Test circuit breaker", () => {
 	const cbOpenedHandler = jest.fn();
 	master1.localBus.on("$circuit-breaker.opened", cbOpenedHandler);
 
-	const slave1 = new ServiceBroker({
+	const replica1 = new ServiceBroker({
 		logger: false,
 		transporter: new FakeTransporter(),
-		nodeID: "slave-1",
+		nodeID: "replica-1",
 	});
 
-	slave1.createService({
+	replica1.createService({
 		name: "cb",
 		actions: {
 			happy() {
@@ -53,14 +53,14 @@ describe("Test circuit breaker", () => {
 
 	beforeAll(() => {
 		return master1.start()
-			.then(() => slave1.start())
+			.then(() => replica1.start())
 			.delay(100)
 			.then(() => clock = lolex.install());
 	});
 
 	afterAll(() => {
 		return master1.stop()
-			.then(() => slave1.stop())
+			.then(() => replica1.stop())
 			.then(() => clock.uninstall());
 	});
 
@@ -101,7 +101,7 @@ describe("Test circuit breaker", () => {
 				expect(err.name).toBe("ServiceNotAvailableError");
 				expect(cbOpenedHandler).toHaveBeenCalledTimes(1);
 				expect(cbOpenedHandler).toHaveBeenCalledWith({
-					nodeID: "slave-1",
+					nodeID: "replica-1",
 					service: "cb",
 					action: "cb.angry",
 					failures: 3,
@@ -124,7 +124,7 @@ describe("Test circuit breaker", () => {
 				expect(err.name).toBe("ServiceNotAvailableError");
 				expect(cbOpenedHandler).toHaveBeenCalledTimes(1);
 				expect(cbOpenedHandler).toHaveBeenCalledWith({
-					nodeID: "slave-1",
+					nodeID: "replica-1",
 					service: "cb",
 					action: "cb.angry",
 					failures: 4,

--- a/test/transporters/suites/streaming.js
+++ b/test/transporters/suites/streaming.js
@@ -35,23 +35,23 @@ module.exports = function(transporter, serializer)  {
 	describe("Test streaming", () => {
 
 		// Creater brokers
-		const [master, slaveA, slaveB] = createBrokers(["master", "slaveA", "slaveB"], {
+		const [master, replicaA, replicaB] = createBrokers(["master", "replicaA", "replicaB"], {
 			namespace: "streaming",
 			transporter,
 			serializer
 		});
 		// Load services
-		[slaveA, slaveB].forEach(broker => broker.createService(AESService));
+		[replicaA, replicaB].forEach(broker => broker.createService(AESService));
 
 		let originalHash;
 
 		// Start & Stop
 		beforeAll(() => {
-			return Promise.all([master.start(), slaveA.start(), slaveB.start()])
+			return Promise.all([master.start(), replicaA.start(), replicaB.start()])
 				.then(() => getSHA(filename))
 				.then(hash => originalHash = hash);
 		});
-		afterAll(() => Promise.all([master.stop(), slaveA.stop(), slaveB.stop()]));
+		afterAll(() => Promise.all([master.stop(), replicaA.stop(), replicaB.stop()]));
 
 		it("should encode & decode the data and send as streams", () => {
 			return master.waitForServices("aes")

--- a/test/unit/strategies/latency.spec.js
+++ b/test/unit/strategies/latency.spec.js
@@ -22,11 +22,11 @@ describe("Test LatencyStrategy constructor", () => {
 		expect(broker.localBus.on).toHaveBeenCalledTimes(7);
 		expect(broker.localBus.on).toHaveBeenCalledWith("$broker.started", jasmine.any(Function));
 		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencyMaster", jasmine.any(Function));
-		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencySlave", jasmine.any(Function));
+		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencyReplica", jasmine.any(Function));
 		expect(broker.localBus.on).toHaveBeenCalledWith("$node.pong", jasmine.any(Function));
 		expect(broker.localBus.on).toHaveBeenCalledWith("$node.connected", jasmine.any(Function));
 		expect(broker.localBus.on).toHaveBeenCalledWith("$node.disconnected", jasmine.any(Function));
-		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencySlave", jasmine.any(Function));
+		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencyReplica", jasmine.any(Function));
 
 		// Test callbacks
 		/* Can't work due to bindings
@@ -48,7 +48,7 @@ describe("Test LatencyStrategy constructor", () => {
 		});
 	});
 
-	it("should be the slave", () => {
+	it("should be the replica", () => {
 
 		const broker = new ServiceBroker({ logger: false, nodeID: "node-1", transporter: "fake" });
 		broker.localBus.listenerCount = jest.fn(() => 1);
@@ -57,8 +57,8 @@ describe("Test LatencyStrategy constructor", () => {
 		let strategy = new LatencyStrategy(broker.registry, broker, {});
 
 		expect(broker.localBus.on).toHaveBeenCalledTimes(2);
-		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencySlave.removeHost", jasmine.any(Function));
-		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencySlave", jasmine.any(Function));
+		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencyReplica.removeHost", jasmine.any(Function));
+		expect(broker.localBus.on).toHaveBeenCalledWith("$node.latencyReplica", jasmine.any(Function));
 
 		return broker.start().catch(protectReject).then(() => {
 			expect(strategy.hostMap.size).toBe(0);
@@ -177,7 +177,7 @@ describe("Test LatencyStrategy.processPong method", () => {
 	const broker = new ServiceBroker({ logger: false });
 	const strategy = new LatencyStrategy(broker.registry, broker);
 
-	it("should calc avg latency and send to slaves", () => {
+	it("should calc avg latency and send to replicas", () => {
 		broker.localBus.emit = jest.fn();
 		const mockNode = {
 			id: "node-a1",
@@ -197,7 +197,7 @@ describe("Test LatencyStrategy.processPong method", () => {
 		expect(strategy.getHostLatency).toHaveBeenCalledWith(mockNode);
 
 		expect(broker.localBus.emit).toHaveBeenCalledTimes(1);
-		expect(broker.localBus.emit).toHaveBeenCalledWith("$node.latencySlave", {
+		expect(broker.localBus.emit).toHaveBeenCalledWith("$node.latencyReplica", {
 			avgLatency: 56,
 			hostname: "host-a"
 		});
@@ -327,7 +327,7 @@ describe("Test LatencyStrategy.removeHostMap method", () => {
 		expect(strategy.hostMap.get("host-a")).toBeUndefined();
 
 		expect(broker.localBus.emit).toHaveBeenCalledTimes(1);
-		expect(broker.localBus.emit).toHaveBeenCalledWith("$node.latencySlave.removeHost", "host-a");
+		expect(broker.localBus.emit).toHaveBeenCalledWith("$node.latencyReplica.removeHost", "host-a");
 	});
 
 });


### PR DESCRIPTION
## :memo: Description

Removes antiquated word "slave" and replaces it with "replica".

Doesn't touch the word "master" since it might break things (dependency `cluster` defines `isMaster`).

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Since I've only renamed things, I haven't added any additional tests.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works **[N/A]**
- [x] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas **[N/A]**
