### PR TITLE
Constrain service settings in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -543,12 +543,15 @@ declare namespace Moleculer {
 		static create(broker: ServiceBroker): Context;
 	}
 
-	interface ServiceSettingSchema {
+	interface ServiceSettingBaseSchema {
 		$noVersionPrefix?: boolean;
 		$noServiceNamePrefix?: boolean;
 		$dependencyTimeout?: number;
 		$shutdownTimeout?: number;
 		$secureSettings?: Array<string>;
+	}
+
+	interface ServiceSettingSchema extends ServiceSettingBaseSchema {
 		[name: string]: any;
 	}
 
@@ -614,7 +617,7 @@ declare namespace Moleculer {
 		version?: string | number;
 	}
 
-	interface ServiceSchema<S = ServiceSettingSchema> {
+	interface ServiceSchema<S extends ServiceSettingBaseSchema = ServiceSettingSchema> {
 		name: string;
 		version?: string | number;
 		settings?: S;
@@ -639,7 +642,7 @@ declare namespace Moleculer {
 		[name: string]: ServiceAction;
 	}
 
-	class Service<S = ServiceSettingSchema> implements ServiceSchema {
+	class Service<S extends ServiceSettingBaseSchema = ServiceSettingSchema> implements ServiceSchema {
 		constructor(broker: ServiceBroker, schema?: ServiceSchema<S>);
 
 		protected parseServiceSchema(schema: ServiceSchema<S>): void;


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently a TS consumer is allowed to provide a generic to describe the `ServiceSettingSchema` for both the `ServiceSchema` and the `Service`.  This will result in a strongly typed `settings` property object which then can guarantee type safety on `this.settings` in the service rather than a free-form `any` result being returned from all properties.

However, the generic is not constrained and thus use of this can cause the loss of the built-in `$` prefixed values that are provided by default with moleculer.  In practicality, any override of the generic needs to extend an interface which includes those built-in types.

This PR splits those built-in properties into a `ServiceSettingBaseSchema`.  The existing `ServiceSettingSchema` then extends from that base but adds an index signature to allow an object with any type for its properties (that is, no type safety, but flexible).  The generic still defaults from this flexible `ServiceSettingSchema` so consumers who were not providing an override for the generic will see no change.  However, a constraint was added to the generic that it must extend `ServiceSettingBaseSchema`.  This means that any generic provided must extend that interface.  This will guarantee that any provider of an override to the generic will have access to the built-in properties as well.

This is a minor breaking change to any consumers currently providing an override for this generic which does not extend `ServiceSettingSchema` or provide types for the built-in properties.  The fix is merely to add `extends ServiceSettingBaseSchema` to those existing interfaces.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```ts
import { ServiceSettingBaseSchema } from 'moleculer';

interface FooServiceSettingSchema extends ServiceSettingBaseSchema {
  foo: number;
  bar: string;
}

class FooService extends Service<FooServiceSettingSchema > {
  public constructor(broker: ServiceBroker) {
    super(broker);

    this.parseServiceSchema({
      settings: {
        foo: 1337,
        bar: 'bar',
      },
      ...
    });
  }
...
}
``` 

## :vertical_traffic_light: How Has This Been Tested?

Ran in local environment with services that both defined overrides for the generic and those that did not.  All types worked properly once the interface was extended.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
