### PR TITLE
Update return type of context's copy method.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -533,8 +533,8 @@ declare namespace Moleculer {
 		broadcast<D>(eventName: string, data: D): Promise<void>;
 		broadcast(eventName: string): Promise<void>;
 
-		copy(endpoint: Endpoint): Context;
-		copy(): Context;
+		copy(endpoint: Endpoint): this;
+		copy(): this;
 
 		startSpan(name: string, opts: GenericObject): Span;
 		finishSpan(span: Span, time?: number): void;


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently the `Context.copy` method is set up with a return type of `Context`. This PR changes the return type to be of type `this` to allow for the method to be used more easily with variations of the context type that are created by passing a custom `ContextFactory` to the broker options. 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
