### PR TITLE
Remove Zipkin v1 annotations

### DIFF
--- a/src/tracing/exporters/zipkin.js
+++ b/src/tracing/exporters/zipkin.js
@@ -145,7 +145,7 @@ class ZipkinTraceExporter extends BaseTraceExporter {
 		const serviceName = span.service ? span.service.fullName : null;
 		const payload = {
 			name: span.name,
-			kind: "CONSUMER",
+			kind: "SERVER",
 
 			// Trace & span IDs
 			traceId: this.convertID(span.traceID),
@@ -155,10 +155,7 @@ class ZipkinTraceExporter extends BaseTraceExporter {
 			localEndpoint: { serviceName },
 			remoteEndpoint: { serviceName },
 
-			annotations: [
-				{ timestamp: this.convertTime(span.startTime), value: "sr" },
-				{ timestamp: this.convertTime(span.finishTime), value: "ss" },
-			],
+			annotations: [],
 
 			timestamp: this.convertTime(span.startTime),
 			duration: this.convertTime(span.duration),

--- a/test/unit/tracing/exporters/__snapshots__/zipkin.spec.js.snap
+++ b/test/unit/tracing/exporters/__snapshots__/zipkin.spec.js.snap
@@ -4,14 +4,6 @@ exports[`Test Zipkin tracing exporter class Test makePayload should convert erro
 Object {
   "annotations": Array [
     Object {
-      "timestamp": 1000000,
-      "value": "sr",
-    },
-    Object {
-      "timestamp": 1050000,
-      "value": "ss",
-    },
-    Object {
       "endpoint": Object {
         "ipv4": "",
         "port": 0,
@@ -24,7 +16,7 @@ Object {
   "debug": false,
   "duration": 50000,
   "id": "spanid1234567890",
-  "kind": "CONSUMER",
+  "kind": "SERVER",
   "localEndpoint": Object {
     "serviceName": "v1.posts",
   },
@@ -56,20 +48,11 @@ Object {
 
 exports[`Test Zipkin tracing exporter class Test makePayload should convert normal span to zipkin payload 1`] = `
 Object {
-  "annotations": Array [
-    Object {
-      "timestamp": 1000000,
-      "value": "sr",
-    },
-    Object {
-      "timestamp": 1050000,
-      "value": "ss",
-    },
-  ],
+  "annotations": Array [],
   "debug": false,
   "duration": 50000,
   "id": "spanid1234567890",
-  "kind": "CONSUMER",
+  "kind": "SERVER",
   "localEndpoint": Object {
     "serviceName": "v1.posts",
   },


### PR DESCRIPTION
#385  :memo: Description
This PR updates the Zipkin Exporter payload to conform to the V2 API. In the V2 API, annotations should be used for interesting events like errors or to indicate latency. The short codes like 'SS' and 'SR' are no longer used to infer the kind of span. Instead, the `kind` field should be used.

Removing these annotations resolves an issue we are experiencing when using the Honeycomb.io exporter in the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib) where these annotations are interpreted as "span events". A span event is a structured log without a duration that is associated with an actual span. So for things like errors that are also put into annotations, having the span event within the actual span is meaningful and interesting. Whereas the 'SS' and 'SR' annotations duplicate the start span timestamp and duration and add a lot of noise to our traces.

Please see the [annotation](https://zipkin.io/zipkin-api/#) section:
>Associates an event that explains latency with a timestamp.
Unlike log statements, annotations are often codes. Ex. “ws” for WireSend

>Zipkin v1 core annotations such as “cs” and “sr” have been replaced with
Span.Kind, which interprets timestamp and duration.

I also updated the span kind to be SERVER since I believe this is more accurate than CLIENT.

Please see the [span](https://zipkin.io/zipkin-api/#) section
> SERVER
    timestamp is the moment a client request was received. (in v1 “sr”)
    duration is the delay until a response was sent or an error. (in v1 “ss”-“sr”)



### :gem: Type of change

- [x] Bug fix. It's possible users of the Zipkin exporter were using these annotations but this data was already available as the span start time and duration.

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

I ran our service stack using the Zipkin exporter and confirmed that the spans were emitted correctly.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
