### PR TITLE
Fix TS types in the tracing module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare namespace Moleculer {
 		exporter?: TracerExporterOptions | Array<TracerExporterOptions> | null;
 		sampling?: {
 			rate?: number | null;
-			tracerPerSecond?: number | null;
+			tracesPerSecond?: number | null;
 			minPriority?: number | null;
 		}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,7 +104,7 @@ declare namespace Moleculer {
 		isEnabled(): boolean;
 		shouldSample(span: Span): boolean;
 
-		startSpan(name: string, opts: GenericObject): Span;
+		startSpan(name: string, opts?: GenericObject): Span;
 
 		//getCurrentSpan(): Span | null;
 		getCurrentTraceID(): string | null;
@@ -153,7 +153,7 @@ declare namespace Moleculer {
 		log(name: string, fields?: GenericObject, time?: number): Span;
 		setError(err: Error): Span;
 		finish(time?: number): Span;
-		startSpan(name: string, opts: GenericObject): Span;
+		startSpan(name: string, opts?: GenericObject): Span;
 	}
 
 	type TracingTagsFuncType = (ctx: Context, response?: any) => any;
@@ -536,7 +536,7 @@ declare namespace Moleculer {
 		copy(endpoint: Endpoint): this;
 		copy(): this;
 
-		startSpan(name: string, opts: GenericObject): Span;
+		startSpan(name: string, opts?: GenericObject): Span;
 		finishSpan(span: Span, time?: number): void;
 
 		toJSON(): GenericObject;


### PR DESCRIPTION
## :memo: Description

This PR fixes a few TypeScript type issues related to the tracing module.

I fixed a typo in the tracing/sampling options. I also made the `opts` parameter in the `startSpan` method in the `Context`, `Tracer`, and `Span` class to be optional. This matches the JSDocs and the behavior of the methods.

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

I tested the changes against our Moleculer services stack.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
