### PR TITLE
Add maxChunkSize to BrokerTransitOptions definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -751,6 +751,7 @@ declare namespace Moleculer {
 		maxQueueSize?: number;
 		disableReconnect?: boolean;
 		disableVersionCheck?: boolean;
+		maxChunkSize?: number;
 	}
 
 	interface BrokerTrackingOptions {


### PR DESCRIPTION
## :memo: Description

Added the missing config property maxChunkSize to the BrokerTransitOptions definition in index.d.ts