### PR TITLE
TS - Remove broker log options removed in 0.14.0

### DIFF
--- a/dev/action-hooks.js
+++ b/dev/action-hooks.js
@@ -4,7 +4,7 @@ let kleur = require("kleur");
 let ServiceBroker = require("../src/service-broker");
 
 // Create broker
-let broker = new ServiceBroker({ logFormatter: "simple" });
+let broker = new ServiceBroker();
 
 const mixin = {
 	hooks: {

--- a/dev/broadcast-groups.js
+++ b/dev/broadcast-groups.js
@@ -7,7 +7,6 @@ let broker1 = new ServiceBroker({
 	nodeID: "node-1",
 	transporter: "NATS",
 	logger: console,
-	logFormatter: "simple",
 	registry: {
 		//preferLocal: false
 	}
@@ -50,7 +49,6 @@ let broker2 = new ServiceBroker({
 	nodeID: "node-2",
 	transporter: "NATS",
 	logger: console,
-	logFormatter: "simple",
 	registry: {
 		//preferLocal: false
 	}

--- a/dev/bulkhead.js
+++ b/dev/bulkhead.js
@@ -5,7 +5,6 @@ const ServiceBroker = require("../src/service-broker");
 const E = require("../src/errors");
 
 const broker = new ServiceBroker({
-	logFormatter: "short",
 	bulkhead: {
 		enabled: false,
 		concurrency: 3,

--- a/dev/chain-1.js
+++ b/dev/chain-1.js
@@ -10,7 +10,6 @@ let broker = new ServiceBroker({
 	//transporter: "amqp://192.168.51.29:5672",
 	//serializer: "ProtoBuf",
 	logger: console,
-	logFormatter: "simple",
 	circuitBreaker: {
 		enabled: true,
 		threshold: 0.1,

--- a/dev/chain-2.js
+++ b/dev/chain-2.js
@@ -10,7 +10,6 @@ let broker = new ServiceBroker({
 	//transporter: "amqp://192.168.51.29:5672",
 	//serializer: "ProtoBuf",
 	logger: console,
-	logFormatter: "simple",
 	circuitBreaker: {
 		enabled: true,
 		threshold: 0.3,

--- a/dev/chain-3.js
+++ b/dev/chain-3.js
@@ -11,7 +11,6 @@ let broker = new ServiceBroker({
 	//transporter: "amqp://192.168.51.29:5672",
 	//serializer: "ProtoBuf",
 	logger: console,
-	logFormatter: "simple"
 });
 
 broker.createService({

--- a/dev/client.js
+++ b/dev/client.js
@@ -80,7 +80,6 @@ const broker = new ServiceBroker({
 
 	logger: console,
 	logLevel: "info",
-	logFormatter: "short",
 	middlewares: [
 		//Middlewares.Transmit.Encryption("moleculer", "aes-256-cbc"),
 		//Middlewares.Transmit.Compression(),

--- a/dev/current-context.js
+++ b/dev/current-context.js
@@ -1,7 +1,6 @@
 const { ServiceBroker } = require("../");
 
 const broker = new ServiceBroker({
-	logFormatter: "simple",
 	requestTimeout: 5000,
 	circuitBreaker: {
 		enabled: true

--- a/dev/event-ctx.js
+++ b/dev/event-ctx.js
@@ -10,7 +10,6 @@ const disableBalancer = false;
 // Create broker #1
 const broker1 = new ServiceBroker({
 	nodeID: "broker1",
-	logFormatter: "short",
 	transporter,
 	serializer,
 	disableBalancer,
@@ -64,7 +63,6 @@ broker1.createService({
 // Create broker #2
 const broker2 = new ServiceBroker({
 	nodeID: "broker2",
-	logFormatter: "short",
 	transporter,
 	serializer,
 	disableBalancer,

--- a/dev/event-receiver.js
+++ b/dev/event-receiver.js
@@ -10,7 +10,6 @@ let broker = new ServiceBroker({
 	//disableBalancer: true,
 	//serializer: "MsgPack",
 	logger: console,
-	logFormatter: "simple",
 	//hotReload: true
 });
 

--- a/dev/event-receiver2.js
+++ b/dev/event-receiver2.js
@@ -10,7 +10,6 @@ let broker = new ServiceBroker({
 	//disableBalancer: true,
 	//serializer: "ProtoBuf",
 	logger: console,
-	logFormatter: "simple"
 });
 
 broker.createService({

--- a/dev/event-sender.js
+++ b/dev/event-sender.js
@@ -10,7 +10,6 @@ let broker = new ServiceBroker({
 	//disableBalancer: true,
 	//serializer: "ProtoBuf",
 	logger: console,
-	logFormatter: "simple"
 });
 
 let c = 1;

--- a/dev/gossip-viz.js
+++ b/dev/gossip-viz.js
@@ -35,7 +35,6 @@ function createBroker(nodeID) {
 		},
 		//logger: console,
 		logLevel: "warn",
-		//logFormatter: "simple",
 	});
 
 	return broker;

--- a/dev/loglevel.js
+++ b/dev/loglevel.js
@@ -97,7 +97,6 @@ const broker = new ServiceBroker({
 		"**": "debug",
 	},
 	//logLevel: "info",
-	//logFormatter: "short",
 	transporter: "NATS",
 	cacher: "Memory"
 });

--- a/dev/meta-request.js
+++ b/dev/meta-request.js
@@ -7,7 +7,6 @@ let broker1 = new ServiceBroker({
 	nodeID: "node-1",
 	transporter: "NATS",
 	logger: console,
-	logFormatter: "simple"
 });
 
 broker1.createService({

--- a/dev/meta-response.js
+++ b/dev/meta-response.js
@@ -7,7 +7,6 @@ let broker2 = new ServiceBroker({
 	nodeID: "node-2",
 	transporter: "NATS",
 	logger: console,
-	logFormatter: "simple"
 });
 
 broker2.createService({

--- a/dev/method-mw.js
+++ b/dev/method-mw.js
@@ -19,7 +19,6 @@ const MW = {
 
 const broker = new ServiceBroker({
 	nodeID: "mw",
-	logFormatter: "short",
 	middlewares: [MW]
 });
 

--- a/dev/middleware_v2.js
+++ b/dev/middleware_v2.js
@@ -183,7 +183,6 @@ const broker = new ServiceBroker({
 	nodeID: "mw",
 	transporter: "NATS",
 	//logLevel: "debug",
-	logFormatter: "short",
 	middlewares: [MW]
 });
 

--- a/dev/namespace-a.js
+++ b/dev/namespace-a.js
@@ -6,7 +6,6 @@ const broker = new ServiceBroker({
 	namespace: "projectA",
 	nodeID: "node-1",
 	transporter: "NATS",
-	logFormatter: "short"
 });
 
 // Example greeter service in namespace "projectA"
@@ -31,7 +30,6 @@ broker.createService({
 		brokerOptions: {
 			nodeID: "ns-connector",
 			transporter: "NATS",
-			logFormatter: "short"
 		}
 	},
 	actions: {

--- a/dev/namespace-b.js
+++ b/dev/namespace-b.js
@@ -6,7 +6,6 @@ const broker = new ServiceBroker({
 	namespace: "projectB",
 	nodeID: "node-1",
 	transporter: "NATS",
-	logFormatter: "short"
 });
 
 // Example greeter service in namespace "projectB"

--- a/dev/retries.js
+++ b/dev/retries.js
@@ -5,7 +5,6 @@ const ServiceBroker = require("../src/service-broker");
 const E = require("../src/errors");
 
 const broker = new ServiceBroker({
-	logFormatter: "short",
 	retryPolicy: {
 		enabled: true,
 		delay: 100,

--- a/dev/retry-a.js
+++ b/dev/retry-a.js
@@ -11,7 +11,6 @@ let broker = new ServiceBroker({
 
 	logger: console,
 	logLevel: "info",
-	logFormatter: "short"
 });
 
 broker.createService({

--- a/dev/saga.js
+++ b/dev/saga.js
@@ -60,7 +60,6 @@ const SagaMiddleware = function() {
 
 // --- BROKER ---
 const broker = new ServiceBroker({
-	logFormatter: "short",
 	middlewares: [
 		SagaMiddleware()
 	]

--- a/dev/server.js
+++ b/dev/server.js
@@ -60,7 +60,6 @@ const broker = new ServiceBroker({
 
 	logger: console,
 	logLevel: "info",
-	logFormatter: "short",
 
 	middlewares: [
 		//Middlewares.Transmit.Encryption("moleculer", "aes-256-cbc"),

--- a/dev/timeout.js
+++ b/dev/timeout.js
@@ -4,7 +4,6 @@ const ServiceBroker = require("../src/service-broker");
 const E = require("../src/errors");
 
 const broker = new ServiceBroker({
-	logFormatter: "short",
 	requestTimeout: 5 * 1000,
 });
 

--- a/dev/trace-chain.js
+++ b/dev/trace-chain.js
@@ -14,7 +14,6 @@ const THROW_ERR = false;
 const broker = new ServiceBroker({
 	nodeID: "node-1",
 	logLevel: "info",
-	logObjectPrinter: o => inspect(o, { showHidden: false, depth: 4, colors: true, breakLength: 50 }),
 
 	tracing: {
 		actions: true,

--- a/dev/tracing.js
+++ b/dev/tracing.js
@@ -26,7 +26,6 @@ const broker = new ServiceBroker({
 	nodeID: "node-1",
 	logger: console,
 	logLevel: "info",
-	logObjectPrinter: o => inspect(o, { showHidden: false, depth: 4, colors: true, breakLength: 50 }),
 	//transporter: "redis://localhost:6379",
 	cacher: true, //"redis://localhost:6379",
 

--- a/dev/tracking.js
+++ b/dev/tracking.js
@@ -7,7 +7,6 @@ let broker1 = new ServiceBroker({
 	nodeID: "node-1",
 	transporter: "NATS",
 	logger: console,
-	//logFormatter: "simple",
 	tracking: {
 		enabled: true
 	}
@@ -36,7 +35,6 @@ let broker2 = new ServiceBroker({
 	nodeID: "node-2",
 	transporter: "NATS",
 	logger: console,
-	//logFormatter: "simple",
 	tracking: {
 		enabled: true
 	}

--- a/examples/client-server/client.js
+++ b/examples/client-server/client.js
@@ -22,7 +22,6 @@ let broker = new ServiceBroker({
 	},
 	logger: console,
 	logLevel: process.env.LOGLEVEL,
-	logFormatter: "simple"
 });
 
 broker.createService({

--- a/examples/client-server/server.js
+++ b/examples/client-server/server.js
@@ -17,7 +17,6 @@ let broker = new ServiceBroker({
 
 	logger: console,
 	logLevel: process.env.LOGLEVEL,
-	logFormatter: "simple"
 });
 
 broker.createService({

--- a/index.d.ts
+++ b/index.d.ts
@@ -774,8 +774,6 @@ declare namespace Moleculer {
 
 		logger?: LoggerConfig | Array<LoggerConfig> | boolean;
 		logLevel?: LogLevels | LogLevelConfig;
-		logFormatter?: Function | string;
-		logObjectPrinter?: Function;
 
 		transporter?: Transporter | string | GenericObject;
 		requestTimeout?: number;


### PR DESCRIPTION
## :memo: Description

In 0.14.0, the broker options `logFormatter` and `logObjectPrinter` were moved to the `logger.options` object

This PR removes those options from the TypeScript definitions from the Service Broker options.

Additionally, I removed these options from the service brokers in the `dev` directory.

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
