### PR TITLE
"merged" service hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,37 @@
 <a name="Unreleased"></a>
 # [Unreleased](https://github.com/moleculerjs/moleculer/compare/v0.14.10...master)
 
+## New `merged` service lifecycle hook
+Service has a new `merged` lifecycle hook which is called after the service schemas (including mixins) has been merged but before service is registered. It means you can manipulate the merged service schema before it's processed.
+
+**Example**
+```js
+// posts.service.js
+module.exports = {
+    name: "posts",
+
+    settings: {},
+
+    actions: {
+        find: {
+            params: {
+                limit: "number"
+            }
+            handler(ctx) {
+                // ...
+            }
+        }
+    },
+
+    merged(schema) {
+        // Modify the service settings
+        schema.settings.myProp = "myValue";
+        // Modify the param validation schema in an action schema
+        schema.actions.find.params.offset = "number";
+    }
+};
+```
+
 --------------------------------------------------
 <a name="0.14.10"></a>
 # [0.14.10](https://github.com/moleculerjs/moleculer/compare/v0.14.9...v0.14.10) (2020-08-23)

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -15,13 +15,30 @@ broker.createService({
 	name: "greeter",
 	actions: {
 		welcome: {
-			params: {
+			/*params: {
 				name: "string"
-			},
+			},*/
 			handler(ctx) {
 				return `Hello ${ctx.params.name}`;
 			}
 		}
+	},
+
+	merged(schema) {
+		this.broker.logger.info("Service merged. I can modify the schema before service registration.");
+		schema.actions.welcome.params = { name: "string" };
+	},
+
+	created() {
+		this.logger.info("Service created.");
+	},
+
+	started() {
+		this.logger.info("Service started.");
+	},
+
+	stopped() {
+		this.logger.info("Service stopped.");
 	}
 });
 

--- a/src/service.js
+++ b/src/service.js
@@ -555,7 +555,7 @@ class Service {
 				// Merge & concat by groups
 				res[key] = Service.mergeSchemaEvents(mods[key], res[key] || {});
 
-			} else if (["created", "started", "stopped"].indexOf(key) !== -1) {
+			} else if (["merged", "created", "started", "stopped"].indexOf(key) !== -1) {
 				// Concat lifecycle event handlers
 				res[key] = Service.mergeSchemaLifecycleHandlers(mods[key], res[key]);
 

--- a/src/service.js
+++ b/src/service.js
@@ -78,6 +78,12 @@ class Service {
 			schema = Service.applyMixins(schema);
 		}
 
+		if (isFunction(schema.merged)) {
+			schema.merged.call(this, schema);
+		} else if (Array.isArray(schema.merged)) {
+			schema.merged.forEach(fn => fn.call(this, schema));
+		}
+
 		this.broker.callMiddlewareHookSync("serviceCreating", [this, schema]);
 
 		if (!schema.name) {

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -5,6 +5,7 @@ const { protectReject } = require("../unit/utils");
 
 describe("Test Service mixins", () => {
 
+	let flowMerged = [];
 	let flowCreated = [];
 	let flowStarted = [];
 	let flowStopped = [];
@@ -82,6 +83,7 @@ describe("Test Service mixins", () => {
 			}
 		},
 
+		merged: jest.fn(() => flowMerged.push("mixinL2")),
 		created: jest.fn(() => flowCreated.push("mixinL2")),
 		started: jest.fn(() => flowStarted.push("mixinL2")),
 		stopped: jest.fn(() => flowStopped.push("mixinL2"))
@@ -147,6 +149,7 @@ describe("Test Service mixins", () => {
 			}
 		},
 
+		merged: jest.fn(() => flowMerged.push("mixin1L1")),
 		created: jest.fn(() => flowCreated.push("mixin1L1")),
 		stopped: jest.fn(() => flowStopped.push("mixin1L1"))
 	};
@@ -210,6 +213,7 @@ describe("Test Service mixins", () => {
 			"hydrogen": jest.fn()
 		},
 
+		merged: jest.fn(() => flowMerged.push("mixin2L1")),
 		created: jest.fn(() => flowCreated.push("mixin2L1")),
 		started: jest.fn(() => flowStarted.push("mixin2L1"))
 	};
@@ -319,6 +323,7 @@ describe("Test Service mixins", () => {
 			"nitrogen": jest.fn()
 		},
 
+		merged: jest.fn(() => flowMerged.push("main")),
 		created: jest.fn(() => flowCreated.push("main")),
 		started: jest.fn(() => flowStarted.push("main")),
 		stopped: jest.fn(() => flowStopped.push("main"))
@@ -330,6 +335,14 @@ describe("Test Service mixins", () => {
 	svc.waitForServices = jest.fn(() => Promise.resolve());
 
 	// console.log(svc.schema);
+
+	it("should call every merged handler", () => {
+		expect(mainSchema.merged).toHaveBeenCalledTimes(1);
+		expect(mixin1L1.merged).toHaveBeenCalledTimes(1);
+		expect(mixin2L1.merged).toHaveBeenCalledTimes(1);
+		expect(mixinL2.merged).toHaveBeenCalledTimes(2);
+		expect(flowMerged.join("-")).toBe("mixinL2-mixin2L1-mixinL2-mixin1L1-main");
+	});
 
 	it("should call every created handler", () => {
 		expect(mainSchema.created).toHaveBeenCalledTimes(1);

--- a/test/integration/service.lifecycle.spec.js
+++ b/test/integration/service.lifecycle.spec.js
@@ -3,6 +3,7 @@ const { protectReject } = require("../unit/utils");
 
 describe("Test Service handlers", () => {
 
+	let mergedHandler = jest.fn();
 	let createdHandler = jest.fn();
 	let startedHandler = jest.fn();
 	let stoppedHandler = jest.fn();
@@ -13,6 +14,7 @@ describe("Test Service handlers", () => {
 	broker.createService({
 		name: "posts",
 
+		merged: mergedHandler,
 		created: createdHandler,
 		started: startedHandler,
 		stopped: stoppedHandler,
@@ -20,6 +22,10 @@ describe("Test Service handlers", () => {
 		events: {
 			"user.*": eventHandler
 		}
+	});
+
+	it("should call merged handler", () => {
+		expect(mergedHandler).toHaveBeenCalledTimes(1);
 	});
 
 	it("should call created handler", () => {
@@ -47,6 +53,7 @@ describe("Test Service handlers", () => {
 
 describe("Test Service handlers after broker.start", () => {
 
+	let mergedHandler = jest.fn();
 	let createdHandler = jest.fn();
 	let startedHandler = jest.fn();
 	let stoppedHandler = jest.fn();
@@ -60,6 +67,7 @@ describe("Test Service handlers after broker.start", () => {
 		broker.createService({
 			name: "posts",
 
+			merged: mergedHandler,
 			created: createdHandler,
 			started: startedHandler,
 			stopped: stoppedHandler,
@@ -70,8 +78,9 @@ describe("Test Service handlers after broker.start", () => {
 		});
 	});
 
-	it("should call created & started handler", () => {
+	it("should call merged, created & started handler", () => {
 		return broker.Promise.delay(100).then(() => {
+			expect(mergedHandler).toHaveBeenCalledTimes(1);
 			expect(createdHandler).toHaveBeenCalledTimes(1);
 			expect(startedHandler).toHaveBeenCalledTimes(1);
 		});

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -339,6 +339,37 @@ describe("Test Service class", () => {
 			expect(schema.events["user.created"]).toBeCalledWith(fakeCtx);
 		});
 
+		it("should call service single 'merged' hook", () => {
+			const merged = jest.fn();
+			const schema = {
+				name: "posts",
+				merged
+			};
+			svc.parseServiceSchema(schema);
+
+			expect(merged).toBeCalledTimes(1);
+			expect(merged).toBeCalledWith(schema);
+		});
+
+		it("should call service multi 'merged' hook", () => {
+			let FLOW = [];
+			const merged1 = jest.fn(() => FLOW.push("C1"));
+			const merged2 = jest.fn(() => FLOW.push("C2"));
+			const schema = {
+				name: "posts",
+				merged: [merged1, merged2]
+			};
+			svc.parseServiceSchema(schema);
+
+			expect(merged1).toBeCalledTimes(1);
+			expect(merged1).toBeCalledWith(schema);
+
+			expect(merged2).toBeCalledTimes(1);
+			expect(merged2).toBeCalledWith(schema);
+
+			expect(FLOW.join("-")).toBe("C1-C2");
+		});
+
 	});
 
 	describe("Test _getPublicSettings", () => {


### PR DESCRIPTION
## :memo: Description

### New `merged` service lifecycle hook
Service has a new `merged` lifecycle hook which is called after the service schemas (including mixins) has been merged but before service is registered. It means you can manipulate the merged service schema before it's processed.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
// posts.service.js
module.exports = {
    name: "posts",

    settings: {},

    actions: {
        find: {
            params: {
                limit: "number"
            }
            handler(ctx) {
                // ...
            }
        }
    },

    merged(schema) {
        // Modify the service settings
        schema.settings.myProp = "myValue";
        // Modify the param validation schema in an action schema
        schema.actions.find.params.offset = "number";
    }
};
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
