### PR TITLE
Fix: Add "locals" member for Context class in types definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -527,6 +527,8 @@ declare namespace Moleculer {
 		needAck: boolean | null;
 		ackID: string | null;
 
+		locals: any | null;
+
 		level: number;
 
 		params: P;

--- a/index.d.ts
+++ b/index.d.ts
@@ -527,7 +527,7 @@ declare namespace Moleculer {
 		needAck: boolean | null;
 		ackID: string | null;
 
-		locals: any | null;
+		locals: GenericObject;
 
 		level: number;
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Add "locals" member for Context class in types definitions as it present in the context but not in its type definition.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code (TypeScript)
```ts
// before:
    function (this: Service, context: Context<any, any>, response: any): any {
      // Error: Property 'locals' does not exist on type 'Context<any, any>'.ts(2339)
      // context.locals.orderAction = "activate";
      (context as any).locals.orderAction = "activate";
      return response;
    },

// after:
    function (this: Service, context: Context<any, any>, response: any): any {
      // OK now
      context.locals.orderAction = "activate";
      return response;
    },
``` 

## :vertical_traffic_light: How Has This Been Tested?
Not needed.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project