### PR TITLE
Improve type definition for service hooks.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -441,9 +441,9 @@ declare namespace Moleculer {
 	type ActionHookError = (ctx: Context<any, any>, err: Error) => Promise<void> | void;
 
 	interface ActionHooks {
-		before?: ActionHookBefore;
-		after?: ActionHookAfter;
-		error?: ActionHookError;
+		before?: string | ActionHookBefore | Array<string | ActionHookBefore>;
+		after?: string | ActionHookAfter | Array<string | ActionHookAfter>;
+		error?: string | ActionHookError | Array<string | ActionHookError>;
 	}
 
 	interface ActionSchema {

--- a/index.d.ts
+++ b/index.d.ts
@@ -625,16 +625,26 @@ declare namespace Moleculer {
 		wrapMethod(method: string, handler: ActionHandler, bindTo: any, opts: MiddlewareCallHandlerOptions): typeof handler;
 	}
 
+	type ServiceHookBeforeHandler = (ctx: Context<any, any>) => Promise<void> | void
+	type ServiceHookAfterHandler = (ctx: Context<any, any>, res: any) => Promise<any> | any
+	type ServiceHookErrorHandler = (ctx: Context<any, any>, err: Error) => Promise<void> | void
+
+	interface ServiceHooksBefore {
+		[key: string]: string | ServiceHookBeforeHandler | Array<string | ServiceHookBeforeHandler>
+	}
+
+	interface ServiceHooksAfter {
+		[key: string]: string | ServiceHookAfterHandler | Array<string | ServiceHookAfterHandler>
+	}
+
+	interface ServiceHooksError {
+		[key: string]: string | ServiceHookErrorHandler | Array<string | ServiceHookErrorHandler>
+	}
+
 	interface ServiceHooks {
-		before?: {
-			[key: string]: ((ctx: Context<any, any>) => Promise<void> | void) | string | string[]
-		},
-		after?: {
-			[key: string]: ((ctx: Context<any, any>, res: any) => Promise<any> | any) | string | string[]
-		},
-		error?: {
-			[key: string]: ((ctx: Context<any, any>, err: Error) => Promise<void> | void) | string | string[]
-		},
+		before?: ServiceHooksBefore,
+		after?: ServiceHooksAfter,
+		error?: ServiceHooksError,
 	}
 
 	interface ServiceDependency {

--- a/index.d.ts
+++ b/index.d.ts
@@ -436,10 +436,14 @@ declare namespace Moleculer {
 
 	type ActionVisibility = "published" | "public" | "protected" | "private";
 
+	type ActionHookBefore = (ctx: Context<any, any>) => Promise<void> | void;
+	type ActionHookAfter = (ctx: Context<any, any>, res: any) => Promise<any> | any;
+	type ActionHookError = (ctx: Context<any, any>, err: Error) => Promise<void> | void;
+
 	interface ActionHooks {
-		before?: (ctx: Context<any, any>) => Promise<void> | void;
-		after?: (ctx: Context<any, any>, res: any) => Promise<any> | any;
-		error?: (ctx: Context<any, any>, err: Error) => Promise<void> | void;
+		before?: ActionHookBefore;
+		after?: ActionHookAfter;
+		error?: ActionHookError;
 	}
 
 	interface ActionSchema {
@@ -625,20 +629,16 @@ declare namespace Moleculer {
 		wrapMethod(method: string, handler: ActionHandler, bindTo: any, opts: MiddlewareCallHandlerOptions): typeof handler;
 	}
 
-	type ServiceHookBeforeHandler = (ctx: Context<any, any>) => Promise<void> | void
-	type ServiceHookAfterHandler = (ctx: Context<any, any>, res: any) => Promise<any> | any
-	type ServiceHookErrorHandler = (ctx: Context<any, any>, err: Error) => Promise<void> | void
-
 	interface ServiceHooksBefore {
-		[key: string]: string | ServiceHookBeforeHandler | Array<string | ServiceHookBeforeHandler>
+		[key: string]: string | ActionHookBefore | Array<string | ActionHookBefore>
 	}
 
 	interface ServiceHooksAfter {
-		[key: string]: string | ServiceHookAfterHandler | Array<string | ServiceHookAfterHandler>
+		[key: string]: string | ActionHookAfter | Array<string | ActionHookAfter>
 	}
 
 	interface ServiceHooksError {
-		[key: string]: string | ServiceHookErrorHandler | Array<string | ServiceHookErrorHandler>
+		[key: string]: string | ActionHookError | Array<string | ActionHookError>
 	}
 
 	interface ServiceHooks {

--- a/index.d.ts
+++ b/index.d.ts
@@ -630,15 +630,15 @@ declare namespace Moleculer {
 	}
 
 	interface ServiceHooksBefore {
-		[key: string]: string | ActionHookBefore | Array<string | ActionHookBefore>
+		[key: string]: string | ActionHookBefore | Array<string | ActionHookBefore>;
 	}
 
 	interface ServiceHooksAfter {
-		[key: string]: string | ActionHookAfter | Array<string | ActionHookAfter>
+		[key: string]: string | ActionHookAfter | Array<string | ActionHookAfter>;
 	}
 
 	interface ServiceHooksError {
-		[key: string]: string | ActionHookError | Array<string | ActionHookError>
+		[key: string]: string | ActionHookError | Array<string | ActionHookError>;
 	}
 
 	interface ServiceHooks {

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -2,7 +2,7 @@
 
 import { Service } from "../../../";
 import { Context } from "../../../";
-import { ServiceHooks, ServiceHooksAfter, ServiceSchema } from "../../../";
+import { ActionHooks, ServiceHooks, ServiceHooksAfter, ServiceSchema } from "../../../";
 
 type GreeterWelcomeParams = {
 	name: string
@@ -43,7 +43,22 @@ export default class GreeterService extends Service {
 				}
 			} as ServiceHooks,
 			actions: {
-				hello: this.hello,
+				hello: {
+					handler: this.hello,
+					hooks: {
+						after: [
+							function (ctx: Context<GreeterWelcomeParams>, res: any): any {
+								// console.log("Action sync hook \"after\".");
+								return res;
+							},
+							async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
+								// console.log("Action async hook \"after\".");
+								return await Promise.resolve(res);
+							},
+							"anotherHookAfter"
+						]
+					} as ActionHooks
+				},
 				welcome: this.welcome
 			}
 		} as ServiceSchema);
@@ -68,7 +83,7 @@ export default class GreeterService extends Service {
 	}
 
 	async anotherHookAfter(ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> {
-		// console.log("Service another async hook \"after\".");
+		// console.log("Another async hook \"after\".");
 		return await Promise.resolve(res);
 	}
 };

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -17,7 +17,7 @@ export default class GreeterService extends Service {
 			hooks: {
 				before: {
 					welcome(ctx: Context<GreeterWelcomeParams>): void {
-						// console.log("Service hook \"before\".");
+						// console.log(`Service hook "before".`);
 						ctx.params.name = ctx.params.name.toUpperCase();
 					}
 				},
@@ -25,11 +25,11 @@ export default class GreeterService extends Service {
 					hello: "anotherHookAfter",
 					welcome: [
 						function (ctx: Context<GreeterWelcomeParams>, res: any): any {
-							// console.log("Service sync hook \"after\".");
+							// console.log(`Service sync hook "after".`);
 							return res;
 						},
 						async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
-							// console.log("Service async hook \"after\".");
+							// console.log(`Service async hook "after".`);
 							return await Promise.resolve(res);
 						},
 						"anotherHookAfter"
@@ -37,7 +37,7 @@ export default class GreeterService extends Service {
 				} as ServiceHooksAfter,
 				error: {
 					welcome(ctx: Context<GreeterWelcomeParams>, err: Error): void {
-						// console.log("Service hook \"error\".");
+						// console.log(`Service hook "error".`);
 						throw err;
 					}
 				}
@@ -48,11 +48,11 @@ export default class GreeterService extends Service {
 					hooks: {
 						after: [
 							function (ctx: Context<GreeterWelcomeParams>, res: any): any {
-								// console.log("Action sync hook \"after\".");
+								// console.log(`Action sync hook "after".`);
 								return res;
 							},
 							async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
-								// console.log("Action async hook \"after\".");
+								// console.log(`Action async hook "after".`);
 								return await Promise.resolve(res);
 							},
 							"anotherHookAfter"
@@ -83,7 +83,7 @@ export default class GreeterService extends Service {
 	}
 
 	async anotherHookAfter(ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> {
-		// console.log("Another async hook \"after\".");
+		// console.log(`Another async hook "after".`);
 		return await Promise.resolve(res);
 	}
 };

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -17,7 +17,7 @@ export default class GreeterService extends Service {
 			hooks: {
 				before: {
 					welcome(ctx: Context<GreeterWelcomeParams>): void {
-						console.log("Service hook \"before\".");
+						// console.log("Service hook \"before\".");
 						ctx.params.name = ctx.params.name.toUpperCase();
 					}
 				},
@@ -25,11 +25,11 @@ export default class GreeterService extends Service {
 					hello: "anotherHookAfter",
 					welcome: [
 						function (ctx: Context<GreeterWelcomeParams>, res: any): any {
-							console.log("Service sync hook \"after\".");
+							// console.log("Service sync hook \"after\".");
 							return res;
 						},
 						async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
-							console.log("Service async hook \"after\".");
+							// console.log("Service async hook \"after\".");
 							return await Promise.resolve(res);
 						},
 						"anotherHookAfter"
@@ -37,7 +37,7 @@ export default class GreeterService extends Service {
 				} as ServiceHooksAfter,
 				error: {
 					welcome(ctx: Context<GreeterWelcomeParams>, err: Error): void {
-						console.log("Service hook \"error\".");
+						// console.log("Service hook \"error\".");
 						throw err;
 					}
 				}
@@ -68,7 +68,7 @@ export default class GreeterService extends Service {
 	}
 
 	async anotherHookAfter(ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> {
-		console.log("Service another async hook \"after\".");
+		// console.log("Service another async hook \"after\".");
 		return await Promise.resolve(res);
 	}
 };

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -2,6 +2,7 @@
 
 import { Service } from "../../../";
 import { Context } from "../../../";
+import { ServiceHooks, ServiceHooksAfter, ServiceSchema } from "../../../";
 
 type GreeterWelcomeParams = {
 	name: string
@@ -15,16 +16,37 @@ export default class GreeterService extends Service {
 			name: "greeter",
 			hooks: {
 				before: {
-					welcome(ctx: Context<GreeterWelcomeParams>) {
+					welcome(ctx: Context<GreeterWelcomeParams>): void {
+						console.log("Service hook \"before\".");
 						ctx.params.name = ctx.params.name.toUpperCase();
 					}
+				},
+				after: {
+					hello: "anotherHookAfter",
+					welcome: [
+						function (ctx: Context<GreeterWelcomeParams>, res: any): any {
+							console.log("Service sync hook \"after\".");
+							return res;
+						},
+						async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
+							console.log("Service async hook \"after\".");
+							return await Promise.resolve(res);
+						},
+						"anotherHookAfter"
+					],
+				} as ServiceHooksAfter,
+				error: {
+					welcome(ctx: Context<GreeterWelcomeParams>, err: Error): void {
+						console.log("Service hook \"error\".");
+						throw err;
+					}
 				}
-			},
+			} as ServiceHooks,
 			actions: {
 				hello: this.hello,
 				welcome: this.welcome
 			}
-		});
+		} as ServiceSchema);
 	}
 
 	/**
@@ -43,5 +65,10 @@ export default class GreeterService extends Service {
 	 */
 	welcome(ctx: Context<GreeterWelcomeParams>) {
 		return `Welcome, ${ctx.params.name}!`;
+	}
+
+	async anotherHookAfter(ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> {
+		console.log("Service another async hook \"after\".");
+		return await Promise.resolve(res);
 	}
 };

--- a/test/typescript/hello-world/index.ts
+++ b/test/typescript/hello-world/index.ts
@@ -28,7 +28,7 @@ broker.loadService(path.join(__dirname, "greeter.service.ts"));
 		await broker.start();
 
 		await broker.call("greeter.hello");
-		const res = await broker.call("greeter.welcome", { name: "Typescript"});
+		const res = await broker.call("greeter.welcome", { name: "Typescript" });
 		broker.logger.info("");
 		broker.logger.info("Result: ", res);
 		broker.logger.info("");

--- a/test/typescript/hello-world/index.ts
+++ b/test/typescript/hello-world/index.ts
@@ -27,6 +27,7 @@ broker.loadService(path.join(__dirname, "greeter.service.ts"));
 	try {
 		await broker.start();
 
+		await broker.call("greeter.hello");
 		const res = await broker.call("greeter.welcome", { name: "Typescript"});
 		broker.logger.info("");
 		broker.logger.info("Result: ", res);


### PR DESCRIPTION
## :memo: Description
Improve type definition for Service hooks: it is allowed to specify arrays of the hooks (even mixed with string names) via Typescript too.
Now as in docs: https://moleculer.services/docs/0.14/actions.html#Service-level-declaration

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code (TypeScript)
```ts
// see details in https://github.com/moleculerjs/moleculer/blob/master/test/typescript/hello-world/greeter.service.ts
hooks: {
	before: {
		welcome(ctx: Context<GreeterWelcomeParams>): void {
			console.log("Service hook \"before\".");
			ctx.params.name = ctx.params.name.toUpperCase();
		}
	},
	after: {
		hello: "anotherHookAfter",
		welcome: [
			function (ctx: Context<GreeterWelcomeParams>, res: any): any {
				console.log("Service sync hook \"after\".");
				return res;
			},
			async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
				console.log("Service async hook \"after\".");
				return await Promise.resolve(res);
			},
			"anotherHookAfter"
		],
	} as ServiceHooksAfter,
	error: {
		welcome(ctx: Context<GreeterWelcomeParams>, err: Error): void {
			console.log("Service hook \"error\".");
			throw err;
		}
	}
} as ServiceHooks,

``` 

## :vertical_traffic_light: How Has This Been Tested?
Extended typescript test in https://github.com/moleculerjs/moleculer/blob/master/test/typescript/hello-world/greeter.service.ts


## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] **I have added tests that prove my fix is effective or that my feature works**
