### PR TITLE
A few type fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -344,6 +344,7 @@ declare namespace Moleculer {
 		labelNames?: Array<string>;
 		unit?: string;
 		aggregator?: string;
+		[key: string]: unknown;
 	}
 
 	interface MetricListOptions {
@@ -1223,7 +1224,8 @@ declare namespace Moleculer {
 		MsgPack: Serializer,
 		ProtoBuf: Serializer,
 		Thrift: Serializer,
-		Notepack: Serializer
+		Notepack: Serializer,
+		resolve: (type: string | GenericObject | Serializer) => Serializer,
 	};
 
 	class BaseValidator {
@@ -1281,8 +1283,8 @@ declare namespace Moleculer {
 		heartbeatReceived(nodeID:string, payload:GenericObject): void;
 		processRemoteNodeInfo(nodeID:string, payload:GenericObject): BrokerNode;
 		sendHeartbeat(): Promise<void>;
-		discoverNode(nodeID: string): Promise<void>;
-		discoverAllNodes(): Promise<void>;
+		discoverNode(nodeID: string): Promise<BrokerNode | void>;
+		discoverAllNodes(): Promise<BrokerNode[] | void>;
 		localNodeReady(): Promise<void>;
 		sendLocalNodeInfo(nodeID: string): Promise<void>;
 		localNodeDisconnected(): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,11 +28,11 @@ declare namespace Moleculer {
 	}
 
 	interface LoggerBindings {
-		nodeID: string;
-		ns: string;
-		mod: string;
-		svc: string;
-		ver: string | void;
+  		nodeID: string;
+  		ns: string;
+  		mod: string;
+  		svc: string;
+  		ver: string | void;
 	}
 
 	class LoggerInstance {
@@ -437,10 +437,14 @@ declare namespace Moleculer {
 
 	type ActionVisibility = "published" | "public" | "protected" | "private";
 
+	type ActionHookBefore = (ctx: Context<any, any>) => Promise<void> | void;
+	type ActionHookAfter = (ctx: Context<any, any>, res: any) => Promise<any> | any;
+	type ActionHookError = (ctx: Context<any, any>, err: Error) => Promise<void> | void;
+
 	interface ActionHooks {
-		before?: (ctx: Context<any, any>) => Promise<void> | void;
-		after?: (ctx: Context<any, any>, res: any) => Promise<any> | any;
-		error?: (ctx: Context<any, any>, err: Error) => Promise<void> | void;
+		before?: string | ActionHookBefore | Array<string | ActionHookBefore>;
+		after?: string | ActionHookAfter | Array<string | ActionHookAfter>;
+		error?: string | ActionHookError | Array<string | ActionHookError>;
 	}
 
 	interface ActionSchema {
@@ -527,6 +531,8 @@ declare namespace Moleculer {
 
 		needAck: boolean | null;
 		ackID: string | null;
+
+		locals: GenericObject;
 
 		level: number;
 
@@ -624,16 +630,22 @@ declare namespace Moleculer {
 		wrapMethod(method: string, handler: ActionHandler, bindTo: any, opts: MiddlewareCallHandlerOptions): typeof handler;
 	}
 
+	interface ServiceHooksBefore {
+		[key: string]: string | ActionHookBefore | Array<string | ActionHookBefore>;
+	}
+
+	interface ServiceHooksAfter {
+		[key: string]: string | ActionHookAfter | Array<string | ActionHookAfter>;
+	}
+
+	interface ServiceHooksError {
+		[key: string]: string | ActionHookError | Array<string | ActionHookError>;
+	}
+
 	interface ServiceHooks {
-		before?: {
-			[key: string]: ((ctx: Context<any, any>) => Promise<void> | void) | string | string[]
-		},
-		after?: {
-			[key: string]: ((ctx: Context<any, any>, res: any) => Promise<any> | any) | string | string[]
-		},
-		error?: {
-			[key: string]: ((ctx: Context<any, any>, err: Error) => Promise<void> | void) | string | string[]
-		},
+		before?: ServiceHooksBefore,
+		after?: ServiceHooksAfter,
+		error?: ServiceHooksError,
 	}
 
 	interface ServiceDependency {
@@ -1102,7 +1114,7 @@ declare namespace Moleculer {
 
 		interface Packet {
 			type: PACKET_UNKNOWN | PACKET_EVENT | PACKET_DISCONNECT | PACKET_DISCOVER |
-				PACKET_INFO | PACKET_HEARTBEAT | PACKET_REQUEST | PACKET_PING | PACKET_PONG | PACKET_RESPONSE | PACKET_GOSSIP_REQ | PACKET_GOSSIP_RES | PACKET_GOSSIP_HELLO;
+			PACKET_INFO | PACKET_HEARTBEAT | PACKET_REQUEST | PACKET_PING | PACKET_PONG | PACKET_RESPONSE | PACKET_GOSSIP_REQ | PACKET_GOSSIP_RES | PACKET_GOSSIP_HELLO;
 			target?: string;
 			payload: PacketPayload
 		}

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,11 +28,11 @@ declare namespace Moleculer {
 	}
 
 	interface LoggerBindings {
-  		nodeID: string;
-  		ns: string;
-  		mod: string;
-  		svc: string;
-  		ver: string | void;
+		nodeID: string;
+		ns: string;
+		mod: string;
+		svc: string;
+		ver: string | void;
 	}
 
 	class LoggerInstance {
@@ -437,14 +437,10 @@ declare namespace Moleculer {
 
 	type ActionVisibility = "published" | "public" | "protected" | "private";
 
-	type ActionHookBefore = (ctx: Context<any, any>) => Promise<void> | void;
-	type ActionHookAfter = (ctx: Context<any, any>, res: any) => Promise<any> | any;
-	type ActionHookError = (ctx: Context<any, any>, err: Error) => Promise<void> | void;
-
 	interface ActionHooks {
-		before?: string | ActionHookBefore | Array<string | ActionHookBefore>;
-		after?: string | ActionHookAfter | Array<string | ActionHookAfter>;
-		error?: string | ActionHookError | Array<string | ActionHookError>;
+		before?: (ctx: Context<any, any>) => Promise<void> | void;
+		after?: (ctx: Context<any, any>, res: any) => Promise<any> | any;
+		error?: (ctx: Context<any, any>, err: Error) => Promise<void> | void;
 	}
 
 	interface ActionSchema {
@@ -531,8 +527,6 @@ declare namespace Moleculer {
 
 		needAck: boolean | null;
 		ackID: string | null;
-
-		locals: GenericObject;
 
 		level: number;
 
@@ -630,22 +624,16 @@ declare namespace Moleculer {
 		wrapMethod(method: string, handler: ActionHandler, bindTo: any, opts: MiddlewareCallHandlerOptions): typeof handler;
 	}
 
-	interface ServiceHooksBefore {
-		[key: string]: string | ActionHookBefore | Array<string | ActionHookBefore>;
-	}
-
-	interface ServiceHooksAfter {
-		[key: string]: string | ActionHookAfter | Array<string | ActionHookAfter>;
-	}
-
-	interface ServiceHooksError {
-		[key: string]: string | ActionHookError | Array<string | ActionHookError>;
-	}
-
 	interface ServiceHooks {
-		before?: ServiceHooksBefore,
-		after?: ServiceHooksAfter,
-		error?: ServiceHooksError,
+		before?: {
+			[key: string]: ((ctx: Context<any, any>) => Promise<void> | void) | string | string[]
+		},
+		after?: {
+			[key: string]: ((ctx: Context<any, any>, res: any) => Promise<any> | any) | string | string[]
+		},
+		error?: {
+			[key: string]: ((ctx: Context<any, any>, err: Error) => Promise<void> | void) | string | string[]
+		},
 	}
 
 	interface ServiceDependency {
@@ -1114,7 +1102,7 @@ declare namespace Moleculer {
 
 		interface Packet {
 			type: PACKET_UNKNOWN | PACKET_EVENT | PACKET_DISCONNECT | PACKET_DISCOVER |
-			PACKET_INFO | PACKET_HEARTBEAT | PACKET_REQUEST | PACKET_PING | PACKET_PONG | PACKET_RESPONSE | PACKET_GOSSIP_REQ | PACKET_GOSSIP_RES | PACKET_GOSSIP_HELLO;
+				PACKET_INFO | PACKET_HEARTBEAT | PACKET_REQUEST | PACKET_PING | PACKET_PONG | PACKET_RESPONSE | PACKET_GOSSIP_REQ | PACKET_GOSSIP_RES | PACKET_GOSSIP_HELLO;
 			target?: string;
 			payload: PacketPayload
 		}
@@ -1420,7 +1408,7 @@ declare namespace Moleculer {
 		sendResponse(nodeID: string, id: string, data: GenericObject): Promise<void>;
 		discoverNodes(): Promise<void>;
 		discoverNode(nodeID: string): Promise<void>;
-		sendNodeInfo(nodeID: string): Promise<void | Array<void>>;
+		sendNodeInfo(info: BrokerNode, nodeID?: string): Promise<void | Array<void>>;
 		sendPing(nodeID: string, id?: string): Promise<void>;
 		sendPong(payload: GenericObject): Promise<void>;
 		processPong(payload: GenericObject): void;


### PR DESCRIPTION
## :memo: Description
While building a new discoverer module, I ran across a few typing issues. 

-----
## ISSUE: Register function expects args depending on metrics type
```javascript
this.broker.metrics.register({
      name: MOLECULER_DISCOVERER_REDIS_COLLECT_TOTAL,
      type: METRIC.TYPE_COUNTER,
      rate: true, // TODO This value is not typed in BaseMetricOptions (as well as others)
      description: "Number of Service Registry fetching from Redis",
    })
```
Adding additional key/values to BaseMetricOptions to support existing metics libs (quick fix)

Ideally, there should be a base interface, then interfaces made for each Metric Type, then union them with the `type` key identifying which union it is. Or, have a declarative pattern. 

## Missing function type
Adding resolve function to the Serializers object. 

## Missing return types
Adding `BrokerNode` as a return type for the methods `disoverNode` and `discoveryAllNodes`

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :checkered_flag: Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
