### PR TITLE
Add support for rediss:// cacher

### DIFF
--- a/src/cachers/index.js
+++ b/src/cachers/index.js
@@ -42,7 +42,7 @@ function resolve(opt) {
 		if (CacherClass)
 			return new CacherClass();
 
-		if (opt.startsWith("redis://"))
+		if (opt.startsWith("redis://") || opt.startsWith("rediss://"))
 			CacherClass = Cachers.Redis;
 
 		if (CacherClass)


### PR DESCRIPTION
## :memo: Description

A small change to support redis:// side by side with redis://. I see it's already supported into transporter but not into cacher.

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/commit/9427aa3593db9747660640e2187ffc534dde3e57#diff-f0d36baff69f0d684934490cccfffb2190224294b0a0e9cc2d6138ef65425c0bR52

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

I'm using DigitalOcean managed Redis services which already using rediss://, working fine on staging now

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
