### PR TITLE
Raising an info log event instead of warn on node expected disconnection

### DIFF
--- a/src/registry/node-catalog.js
+++ b/src/registry/node-catalog.js
@@ -194,7 +194,10 @@ class NodeCatalog {
 
 			this.registry.updateMetrics();
 
-			this.logger.warn(`Node '${node.id}' disconnected${isUnexpected ? " unexpectedly" : ""}.`);
+			if (isUnexpected)
+				this.logger.warn(`Node '${node.id}' disconnected unexpectedly.`);
+			else
+				this.logger.info(`Node '${node.id}' disconnected.`);
 
 			if (this.broker.transit)
 				this.broker.transit.removePendingRequestByNodeID(nodeID);

--- a/test/unit/registry/node-catalog.spec.js
+++ b/test/unit/registry/node-catalog.spec.js
@@ -191,6 +191,10 @@ describe("Test NodeCatalog.processNodeInfo", () => {
 describe("Test NodeCatalog.disconnected", () => {
 	const broker = new ServiceBroker({ logger: false, transporter: "Fake" });
 	const catalog = new NodeCatalog(broker.registry, broker);
+	catalog.logger = {
+		info: jest.fn(),
+		warn: jest.fn(),
+	};
 	broker.registry.unregisterServicesByNode = jest.fn();
 	broker.broadcastLocal = jest.fn();
 	broker.transit.removePendingRequestByNodeID = jest.fn();
@@ -205,6 +209,11 @@ describe("Test NodeCatalog.disconnected", () => {
 	catalog.processNodeInfo(payload);
 	const node = catalog.get("node-11");
 	node.disconnected = jest.fn();
+
+	beforeEach(() => {
+		catalog.logger.info.mockClear();
+		catalog.logger.warn.mockClear();
+	});
 
 	it("should call disconnected & unregister services", () => {
 		broker.broadcastLocal.mockClear();
@@ -229,6 +238,10 @@ describe("Test NodeCatalog.disconnected", () => {
 
 		expect(broker.registry.unregisterServicesByNode).toHaveBeenCalledTimes(1);
 		expect(broker.registry.unregisterServicesByNode).toHaveBeenCalledWith(node.id);
+
+		expect(catalog.logger.info).toHaveBeenCalledTimes(1);
+		expect(catalog.logger.info).toHaveBeenCalledWith("Node 'node-11' disconnected.");
+		expect(catalog.logger.warn).toHaveBeenCalledTimes(0);
 	});
 
 	it("should call disconnected & unregister services (unexpected)", () => {
@@ -253,6 +266,10 @@ describe("Test NodeCatalog.disconnected", () => {
 
 		expect(broker.registry.unregisterServicesByNode).toHaveBeenCalledTimes(1);
 		expect(broker.registry.unregisterServicesByNode).toHaveBeenCalledWith(node.id);
+
+		expect(catalog.logger.info).toHaveBeenCalledTimes(0);
+		expect(catalog.logger.warn).toHaveBeenCalledTimes(1);
+		expect(catalog.logger.warn).toHaveBeenCalledWith("Node 'node-11' disconnected unexpectedly.");
 	});
 });
 


### PR DESCRIPTION
## :memo: Description

Without this change we're raising a warn event in logger when any node is gracefully disconnected. But this event does not require any attention, so it should not be warning, but just an info level event.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] "Test NodeCatalog.disconnected" -> "should call disconnected & unregister services": the `info` is called with a particular text, the `warn` is not called;
- [x] "Test NodeCatalog.disconnected" -> "should call disconnected & unregister services (unexpected)": the `info` is not called, the `warn` is called with a particular text;

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
