### PR TITLE
fix: export BaseLogger and add type to logger options for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -785,7 +785,7 @@ declare namespace Moleculer {
 		namespace?: string;
 		nodeID?: string;
 
-		logger?: LoggerConfig | Array<LoggerConfig> | boolean;
+		logger?: BaseLogger | LoggerConfig | Array<LoggerConfig> | boolean;
 		logLevel?: LogLevels | LogLevelConfig;
 
 		transporter?: Transporter | string | GenericObject;
@@ -959,6 +959,13 @@ declare namespace Moleculer {
 		removeIfExist(command:string): void;
 	}
 
+	class BaseLogger {
+		constructor(opts?: GenericObject);
+		init(loggerFactory: LoggerFactory): void
+		stop(): void;
+		getLogLevel(mod: string)
+		getLogHandler(bindings: GenericObject) 
+	}
 
 	class ServiceBroker {
 		constructor(options?: BrokerOptions);

--- a/index.d.ts
+++ b/index.d.ts
@@ -785,7 +785,7 @@ declare namespace Moleculer {
 		namespace?: string;
 		nodeID?: string;
 
-		logger?: BaseLogger | LoggerConfig | Array<LoggerConfig> | boolean;
+		logger?: Loggers.Base | LoggerConfig | Array<LoggerConfig> | boolean;
 		logLevel?: LogLevels | LogLevelConfig;
 
 		transporter?: Transporter | string | GenericObject;
@@ -959,12 +959,16 @@ declare namespace Moleculer {
 		removeIfExist(command:string): void;
 	}
 
-	class BaseLogger {
-		constructor(opts?: GenericObject);
-		init(loggerFactory: LoggerFactory): void
-		stop(): void;
-		getLogLevel(mod: string)
-		getLogHandler(bindings: GenericObject) 
+
+
+	namespace Loggers {
+		class Base {
+			constructor(opts?: GenericObject);
+			init(loggerFactory: LoggerFactory): void
+			stop(): void;
+			getLogLevel(mod: string): string
+			getLogHandler(bindings: GenericObject): GenericObject
+		}
 	}
 
 	class ServiceBroker {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const {
 module.exports = {
 	ServiceBroker: require("./src/service-broker"),
 	Loggers: require("./src/loggers"),
+	BaseLogger: require('./src/loggers').Base,
 	Service: require("./src/service"),
 	Context: require("./src/context"),
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const {
 module.exports = {
 	ServiceBroker: require("./src/service-broker"),
 	Loggers: require("./src/loggers"),
-	BaseLogger: require('./src/loggers').Base,
 	Service: require("./src/service"),
 	Context: require("./src/context"),
 


### PR DESCRIPTION
## :memo: Description

- add Loggers.Base to typescript's definitions
- add Loggers.Base as one of the optional types in BrokerOptions

### :dart: Relevant issues
closes issues #839 and #716 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
javascript: unchanged

typescript:
```ts
import { Loggers } from "moleculer"

export class MyLogger extends Loggers.Base {
    public getLogHandler(bindings) {
        return (type, args) => console[type](`[MYLOG-${bindings.mod}]`, ...args);
    }
}
``` 

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
