### PR TITLE
Add availability marker to ServiceBroker#waitForServices API

### DIFF
--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1612,7 +1612,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait service", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices("posts", 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices("posts", 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['posts'], statuses: [{ name: 'posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts");
 		});
@@ -1627,7 +1628,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as an array of string", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices(["posts"], 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices(["posts"], 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['posts'], statuses: [{ name: 'posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts");
 		});
@@ -1642,7 +1644,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as an array of object", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices([{ name: "posts" }], 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices([{ name: "posts" }], 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['posts'], statuses: [{ name: 'posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts");
 		});
@@ -1657,7 +1660,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as an object", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices({ name: "posts" }, 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices({ name: "posts" }, 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['posts'], statuses: [{ name: 'posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts");
 		});
@@ -1672,7 +1676,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as an array of object with version", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices([{ name: "posts", version: 1 }], 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices([{ name: "posts", version: 1 }], 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['v1.posts'], statuses: [{ name: 'v1.posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("v1.posts");
 		});
@@ -1687,7 +1692,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as an array of object with version and unrelated property", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices([{ name: "posts", version: 1, meta: true }], 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices([{ name: "posts", version: 1, meta: true }], 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['v1.posts'], statuses: [{ name: 'v1.posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("v1.posts");
 		});
@@ -1702,7 +1708,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as a versioned string", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices("v1.posts", 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices("v1.posts", 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['v1.posts'], statuses: [{ name: 'v1.posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("v1.posts");
 		});
@@ -1717,7 +1724,8 @@ describe("Test broker.waitForServices", () => {
 	it("should wait for service when service is passed as an array of versioned strings", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices(["v1.posts"], 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices(["v1.posts"], 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({ services: ['v1.posts'], statuses: [{ name: 'v1.posts', available: true }] });
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(6);
 			expect(broker.registry.hasService).toHaveBeenLastCalledWith("v1.posts");
 		});
@@ -1732,7 +1740,14 @@ describe("Test broker.waitForServices", () => {
 	it("should skip duplicated services", () => {
 		res = false;
 		broker.registry.hasService.mockClear();
-		let p = broker.waitForServices(["v2.posts", "users", { name: "posts", version: 2 }], 10 * 1000, 100).catch(protectReject).then(() => {
+		let p = broker.waitForServices(["v2.posts", "users", { name: "posts", version: 2 }], 10 * 1000, 100).catch(protectReject).then(result => {
+			expect(result).toEqual({
+				services: ['v2.posts', 'users'],
+				statuses: [
+					{ name: 'v2.posts', available: true },
+					{ name: 'users', available: true },
+				],
+			});
 			expect(broker.registry.hasService).toHaveBeenCalledTimes(12);
 			expect(broker.registry.hasService).toHaveBeenCalledWith("v2.posts");
 			expect(broker.registry.hasService).toHaveBeenCalledWith("users");
@@ -1778,6 +1793,7 @@ describe("Test broker.waitForServices", () => {
 		broker.registry.hasService.mockClear();
 		let p = broker.waitForServices("posts", 300, 100).then(protectReject).catch(err => {
 			expect(err).toBeInstanceOf(MoleculerError);
+			expect(err.data).toEqual({ services: ['posts'], statuses: [{ name: 'posts', available: false }] });
 		});
 
 		clock.tick(450);


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, both the return value and data included on the error thrown did not inform us which services we requested to watch became available or remained unavailable. Here we enhance the API to include that information so consumers can take informed next steps.

The selected API is what I believe to be the best way forwards _but_ it is breaking. Here is an example of a non-breaking alternative:
```js
try {
  await broker.waitForServices([
    { serviceName: 'posts', version: 2 },
    { serviceName: 'users', version: 1 },
  ]);
} catch (error) {
  // error.data.unavailable === ['v2.posts']
  // error.data.available === ['v1.users']
  logger.error(`Oh no, "${error.data.unavailable.join(', ')}" didn't make it`);				
}
``` 


### :dart: Relevant issues
<!-- Please add relevant opened issues -->
None. I couldn't find any issue discussing anything similar either.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
try {
  await broker.waitForServices([
    { serviceName: 'posts', version: 2 },
    { serviceName: 'users', version: 1 },
  ]);
} catch (error) {
  const unavailableServices = error.data.statuses.filter(s => !s.available).map(s => s.name);
  logger.error(`Oh no, "${unavailableServices.join(', ')}" didn't make it`);				
}
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Uh, not sure what to put here but I wrote unit tests? Hasn't been tested in an integration yet.
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
   - I followed the style around the changed code.. let me know if something looks off. An auto-formatter would be helpful.
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
