### PR TITLE
Fix version string build when an integer value is passed in string form

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -772,7 +772,7 @@ class Service {
 	 */
 	static getVersionedFullName(name, version) {
 		if (version != null) {
-			if (typeof(version) === 'number' || !isNaN(parseInt(version))) {
+			if (typeof(version) === 'number' || !isNaN(Number(version))) {
 				return `v${version}.${name}`;
 			}
 			return `${version}.${name}`;

--- a/src/service.js
+++ b/src/service.js
@@ -771,8 +771,12 @@ class Service {
 	 * @param {String|Number?} version
 	 */
 	static getVersionedFullName(name, version) {
-		if (version != null)
-			return (typeof(version) == "number" ? "v" + version : version) + "." + name;
+		if (version != null) {
+			if (typeof(version) === 'number' || !isNaN(parseInt(version))) {
+				return `v${version}.${name}`;
+			}
+			return `${version}.${name}`;
+		}
 
 		return name;
 	}

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -1925,6 +1925,7 @@ describe("Test Service class", () => {
 			expect(Service.getVersionedFullName("posts")).toBe("posts");
 			expect(Service.getVersionedFullName("posts", 5)).toBe("v5.posts");
 			expect(Service.getVersionedFullName("posts", "testing")).toBe("testing.posts");
+			expect(Service.getVersionedFullName("posts", '5')).toBe("v5.posts");
 		});
 	});
 

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -1926,6 +1926,7 @@ describe("Test Service class", () => {
 			expect(Service.getVersionedFullName("posts", 5)).toBe("v5.posts");
 			expect(Service.getVersionedFullName("posts", "testing")).toBe("testing.posts");
 			expect(Service.getVersionedFullName("posts", '5')).toBe("v5.posts");
+			expect(Service.getVersionedFullName("posts", '123abc')).toBe("123abc.posts");
 		});
 	});
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I got tripped up on something (that was my fault) when using the `broker.waitForServices()` method and passing an array of objects. In my case, serviceVersion was a string even though I thought it was a number. Below is an example as to how you can see how that might have occurred. I'm just hoping this change might prevent the pain for anyone else in the future.

```ts
    await broker.waitForServices([
      { name: serviceName, version: serviceVersion },
    ]);
```

### :dart: Relevant issues
<!-- Please add relevant opened issues -->
N/A

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
  /**
   * This will now await for the following services to become available:
   * v1.foo & v2.bar
   * 
   * Previously this would wait for
   * v1.foo & 2.bar
   */ 
    await broker.waitForServices([
      { name: 'foo', version: 1 },
      { name: 'bar', version: '2` }
    ]);
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A - I added to the version string building static method tests with a case that demonstrated the problem, then made it work

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
