### PR TITLE
fix: disableHeartbeatChecks should be under opts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6726,7 +6726,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gtoken": {
       "version": "5.1.0",
@@ -7416,6 +7417,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -10585,6 +10587,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -10599,6 +10602,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10607,13 +10611,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -13061,7 +13067,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shimmer": {
       "version": "1.2.1",

--- a/src/registry/discoverers/base.js
+++ b/src/registry/discoverers/base.js
@@ -172,7 +172,7 @@ class BaseDiscoverer {
 	 * Check offline nodes. Remove which is older than 10 minutes.
 	 */
 	checkOfflineNodes() {
-		if (this.disableOfflineNodeRemoving || !this.opts.cleanOfflineNodesTimeout) return;
+		if (this.opts.disableOfflineNodeRemoving || !this.opts.cleanOfflineNodesTimeout) return;
 
 		const now = Math.round(process.uptime());
 		this.registry.nodes.toArray().forEach(node => {

--- a/src/registry/discoverers/base.js
+++ b/src/registry/discoverers/base.js
@@ -150,7 +150,7 @@ class BaseDiscoverer {
 	 * Check all registered remote nodes are available.
 	 */
 	checkRemoteNodes() {
-		if (this.disableHeartbeatChecks) return;
+		if (this.opts.disableHeartbeatChecks) return;
 
 		const now = Math.round(process.uptime());
 		this.registry.nodes.toArray().forEach(node => {

--- a/test/unit/registry/discoverers/base.spec.js
+++ b/test/unit/registry/discoverers/base.spec.js
@@ -362,7 +362,7 @@ describe("Test BaseDiscoverer 'checkRemoteNodes' method", () => {
 		discoverer.logger.warn.mockClear();
 		registry.nodes.disconnected.mockClear();
 
-		discoverer.disableHeartbeatChecks = true;
+		discoverer.opts.disableHeartbeatChecks = true;
 		node.local = false;
 
 		discoverer.checkRemoteNodes();

--- a/test/unit/registry/discoverers/base.spec.js
+++ b/test/unit/registry/discoverers/base.spec.js
@@ -457,7 +457,7 @@ describe("Test BaseDiscoverer 'checkOfflineNodes' method", () => {
 		discoverer.logger.warn.mockClear();
 		registry.nodes.delete.mockClear();
 
-		discoverer.disableOfflineNodeRemoving = true;
+		discoverer.opts.disableOfflineNodeRemoving = true;
 		node.local = false;
 
 		discoverer.checkOfflineNodes();


### PR DESCRIPTION
## :memo: Description
Currently we have `if (this.disableHeartbeatChecks) return`  in `BaseDiscoverer`, but `disableHeartbeatChecks` only exists inside `opts` object

If I set `disableHeartbeatChecks` to `true` in `moleculer.config.js`, `this.disableHeartbeatChecks` would be `undefined` anyway, the flag is located at `this.opts.disableHeartbeatChecks`
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `should not call disconnected if disabled`

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
