### PR TITLE
force scanning only master redis nodes for deletion

### DIFF
--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -325,7 +325,9 @@ class RedisCacher extends BaseCacher {
 
 	_clusterScanDel(pattern) {
 		const scanDelPromises = [];
-		const nodes = this.client.nodes();
+		// get only master nodes to scan for deletion,
+		// if we get slave nodes, it would be failed for deletion.
+		const nodes = this.client.nodes("master");
 
 		nodes.forEach(node => {
 			scanDelPromises.push(this._nodeScanDel(node, pattern));


### PR DESCRIPTION
## :memo: Description

If we use Redis cluster (master + slave) for cacher. After calling broker.cacher.clean, it would show error because it will try to delete in all nodes including slave. It would be better to get only master nodes for deletion.

### :dart: Relevant issues

[#864](https://github.com/moleculerjs/moleculer/issues/864)

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```
_clusterScanDel(pattern) {
  const scanDelPromises = [];
  const nodes = this.client.nodes("master");

  nodes.forEach(node => {
    scanDelPromises.push(this._nodeScanDel(node, pattern));
  });

  return this.broker.Promise.all(scanDelPromises);
}
``` 

## :vertical_traffic_light: How Has This Been Tested?

It is quite hard for me to write tests for this issue because it is just a configuration change. Please suggest me any ideas for unit tests.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] **I have added tests that prove my fix is effective or that my feature works**
