### PR TITLE
fix: datadog tracer scope

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -140,6 +140,12 @@ class Context {
 		else if (opts.parentCtx != null && opts.parentCtx.requestID != null)
 			ctx.requestID = opts.parentCtx.requestID;
 
+		// TraceID
+		if (opts.traceID != null)
+			ctx.traceID = opts.traceID;
+		else if (opts.parentCtx != null && opts.parentCtx.traceID != null)
+			ctx.traceID = opts.parentCtx.traceID;
+
 		// Meta
 		if (opts.parentCtx != null && opts.parentCtx.meta != null)
 			ctx.meta = Object.assign({}, opts.parentCtx.meta || {}, opts.meta || {});
@@ -169,6 +175,7 @@ class Context {
 		if (opts.parentSpan != null) {
 			ctx.parentID = opts.parentSpan.id;
 			ctx.requestID = opts.parentSpan.traceID;
+			ctx.traceID = opts.parentSpan.traceID;
 			ctx.tracing = opts.parentSpan.sampled;
 		}
 
@@ -198,6 +205,7 @@ class Context {
 		newCtx.meta = this.meta;
 		newCtx.locals = this.locals;
 		newCtx.requestID = this.requestID;
+		newCtx.traceID = this.traceID;
 		newCtx.tracing = this.tracing;
 		newCtx.span = this.span;
 		newCtx.needAck = this.needAck;
@@ -459,6 +467,7 @@ class Context {
 			"meta",
 			//"locals",
 			"requestID",
+			"traceID",
 			"tracing",
 			"span",
 			"needAck",

--- a/src/tracing/span.js
+++ b/src/tracing/span.js
@@ -54,6 +54,7 @@ class Span {
 
 		this.priority = this.opts.priority != null ? this.opts.priority : 5;
 		this.sampled = this.opts.sampled != null ? this.opts.sampled : this.tracer.shouldSample(this);
+		defProp(this, "autoActivate", this.opts.autoActivate != null ? this.opts.autoActivate : true);
 
 		this.startTime = null;
 		this.startTicks = null;

--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -208,6 +208,27 @@ class Tracer {
 	}
 
 	/**
+	 * Call a function with the provided span activated in the exporters' context
+	 *
+	 * @param {Span} span
+	 * @param {Function} fn
+	 */
+	activate(span, fn) {
+		if (this.exporter) {
+			const handler = this.exporter.reduce((next, exporter) => {
+				if (typeof exporter.activate === "function") {
+					return exporter.activate.bind(exporter, span, next);
+				}
+				return next;
+			}, fn);
+
+			return handler();
+		} else {
+			return fn();
+		}
+	}
+
+	/**
 	 * Invoke Exporter method.
 	 *
 	 * @param {String} method

--- a/src/transit.js
+++ b/src/transit.js
@@ -384,6 +384,7 @@ class Transit {
 		ctx.level = payload.level;
 		ctx.tracing = !!payload.tracing;
 		ctx.parentID = payload.parentID;
+		ctx.traceID = payload.traceID;
 		ctx.requestID = payload.requestID;
 		ctx.caller = payload.caller;
 		ctx.nodeID = payload.sender;
@@ -422,6 +423,7 @@ class Transit {
 			ctx.id = payload.id;
 			ctx.setParams(pass ? pass : payload.params, this.broker.options.contextParamsCloning);
 			ctx.parentID = payload.parentID;
+			ctx.traceID = payload.traceID;
 			ctx.requestID = payload.requestID;
 			ctx.caller = payload.caller;
 			ctx.meta = payload.meta || {};
@@ -736,6 +738,7 @@ class Transit {
 			level: ctx.level,
 			tracing: ctx.tracing,
 			parentID: ctx.parentID,
+			traceID: ctx.traceID,
 			requestID: ctx.requestID,
 			caller: ctx.caller,
 			stream: isStream,
@@ -855,6 +858,7 @@ class Transit {
 			level: ctx.level,
 			tracing: ctx.tracing,
 			parentID: ctx.parentID,
+			traceID: ctx.traceID,
 			requestID: ctx.requestID,
 			caller: ctx.caller,
 			needAck: ctx.needAck

--- a/test/integration/tracing-datadog.spec.js
+++ b/test/integration/tracing-datadog.spec.js
@@ -1,0 +1,396 @@
+"use strict";
+
+const _ = require("lodash");
+const H = require("./helpers");
+const semver = require("semver");
+const BaseLogger = require("../../src/loggers/base");
+
+// Mock agent exporter to avoid failed network requests
+jest.mock("dd-trace/packages/dd-trace/src/exporters/agent");
+
+/**
+ * A logger that captures records associated with an active trace
+ */
+class TraceCaptureLogger extends BaseLogger {
+	constructor(opts) {
+		super(opts);
+		this.logs = [];
+	}
+	getLogHandler(bindings) {
+		const level = bindings ? this.getLogLevel(bindings.mod) : null;
+		if (!level) return null;
+
+		const levelIdx = BaseLogger.LEVELS.indexOf(level);
+
+		return (type, args) => {
+			const typeIdx = BaseLogger.LEVELS.indexOf(type);
+			if (typeIdx > levelIdx) return;
+
+			const record = {
+				ts: Date.now(),
+				level: type,
+				msg: args.join(" "),
+				dd: {},
+				...bindings,
+			};
+
+			const traceId =
+				this.broker.tracer && this.broker.tracer.getCurrentTraceID();
+			if (traceId && record.mod !== "tracer") {
+				record.dd.trace_id = traceId;
+				record.dd.span_id = this.broker.tracer.getActiveSpanID();
+				this.logs.push(record);
+			}
+		};
+	}
+}
+
+// Build list of supported Scope implementations to test
+let supportedScopes = ["async_hooks"];
+if (semver.satisfies(process.versions.node, ">=14.5 || ^12.19.0")) {
+	supportedScopes.push("async_resource");
+	supportedScopes.push("async_local_storage");
+}
+
+supportedScopes.forEach((scope) => {
+	describe(`Test Tracing Datadog exporter - ${scope} scope`, () => {
+		let STORE = [];
+		let broker = null;
+
+		const COMMON_SETTINGS = {
+			logger: false,
+			logLevel: "debug",
+			namespace: `tracing-${scope}`,
+			tracing: {
+				enabled: true,
+				actions: true,
+				events: true,
+				sampling: {
+					rate: 1,
+				},
+				exporter: [
+					{
+						type: "Datadog",
+						options: {
+							tracerOptions: {
+								scope,
+							},
+							defaultTags: {
+								scope,
+							},
+						},
+					},
+					{
+						type: "Event",
+						options: {
+							interval: 0,
+						},
+					},
+				],
+			},
+		};
+
+		const TestTracingService = {
+			name: "tracing-collector",
+			events: {
+				"$tracing.spans"(ctx) {
+					STORE.push(...ctx.params);
+				},
+				async "some.event"(ctx) {
+					STORE.push(this.getActiveSpan());
+					const span = ctx.startSpan("custom span");
+					STORE.push(this.getActiveSpan());
+					await new Promise((r) => setTimeout(r, 100));
+					STORE.push(this.getActiveSpan());
+					ctx.finishSpan(span);
+					STORE.push(this.getActiveSpan());
+				},
+			},
+			actions: {
+				async echo(ctx) {
+					await new Promise((r) => setTimeout(r, 100));
+					return ctx.params;
+				},
+
+				async getSpan() {
+					return this.getActiveSpan();
+				},
+
+				async triggerEvent(ctx) {
+					STORE.push(this.getActiveSpan());
+					await ctx.emit("some.event", { foo: "bar" });
+				},
+
+				async log(ctx) {
+					this.logger.info(
+						`Called with param value=${ctx.params.value}`
+					);
+					if (ctx.params.recurse) {
+						await ctx.call(ctx.action.name, {
+							value: `double ${ctx.params.value}`,
+							recurse: false,
+						});
+					}
+				},
+
+				async customSpans(ctx) {
+					const spans = [this.getActiveSpan()];
+
+					// parent
+					const span1 = ctx.startSpan("span1");
+					await new Promise((r) => setTimeout(r, 100));
+					spans.push(this.getActiveSpan());
+
+					// child
+					const span2 = ctx.startSpan("span2");
+					await new Promise((r) => setTimeout(r, 50));
+					spans.push(this.getActiveSpan());
+					ctx.finishSpan(span2);
+
+					spans.push(this.getActiveSpan());
+					ctx.finishSpan(span1);
+
+					// independent
+					const span3 = ctx.startSpan("span3");
+					await new Promise((r) => setTimeout(r, 250)).then(() => {
+						spans.push(this.getActiveSpan());
+						ctx.finishSpan(span3);
+
+						spans.push(this.getActiveSpan());
+					});
+
+					// spans == [action, span1, span2, span1, span3, action]
+					return spans;
+				},
+			},
+
+			methods: {
+				getActiveSpan() {
+					const span = this.broker.tracer.exporter[0].ddTracer
+						.scope()
+						.active();
+
+					if (!span) return null;
+
+					const context = span.context();
+
+					return {
+						traceId: context.toTraceId(),
+						spanId: context.toSpanId(),
+						parentId: context._parentId
+							? context._parentId.toString(10)
+							: null,
+						name: context._name,
+						tags: context._tags,
+					};
+				},
+			},
+		};
+
+		beforeAll(() => {
+			// Reset dd-trace module so it can be reinitialized with the new scope setting
+			jest.resetModules();
+			broker = H.createNode(
+				_.defaultsDeep(
+					{ nodeID: `broker-${scope}-0` },
+					COMMON_SETTINGS
+				),
+				[TestTracingService]
+			);
+			return broker.start();
+		});
+
+		afterAll(() => broker.stop());
+
+		beforeEach(() => {
+			jest.resetAllMocks();
+			STORE = [];
+		});
+
+		it("sets the span as active in dd-trace", async () => {
+			// Get the active span from dd tracer
+			const span = await broker.call("tracing-collector.getSpan", {
+				foo: "bar",
+			});
+
+			// Compare dd tracer span to moleculer span
+			expect(STORE).toHaveLength(1);
+			expect(span).not.toBeNull();
+			expect(span.traceId).toBe(
+				broker.tracer.exporter[0]
+					.convertID(STORE[0].traceID)
+					.toString(10)
+			);
+			expect(span.spanId).toBe(
+				broker.tracer.exporter[0].convertID(STORE[0].id).toString(10)
+			);
+			expect(span.parentId).toBeNull();
+			expect(span.tags).toEqual(
+				expect.objectContaining({
+					requestID: STORE[0].tags.requestID,
+					"action.name": "tracing-collector.getSpan",
+					"params.foo": "bar",
+				})
+			);
+		});
+
+		it("has an isolated async context", async () => {
+			const ddScope = broker.tracer.exporter[0].ddTracer.scope();
+			expect(ddScope.active()).toBeNull();
+
+			const request = broker.call("tracing-collector.echo", {
+				phrase: "hello",
+			});
+
+			// Check sync context
+			expect(ddScope.active()).toBeNull();
+
+			await request;
+
+			expect(ddScope.active()).toBeNull();
+		});
+
+		it("can be used with log injector", async () => {
+			const loggerInstance = new TraceCaptureLogger();
+			const logTestBroker = H.createNode(
+				_.defaultsDeep(
+					{
+						nodeID: "broker-log-1",
+						logLevel: "info",
+						logger: loggerInstance,
+					},
+					COMMON_SETTINGS
+				),
+				[TestTracingService]
+			);
+
+			await logTestBroker.start();
+			await logTestBroker.call("tracing-collector.log", {
+				value: "test",
+				recurse: true,
+			});
+			await logTestBroker.stop();
+
+			// Expect only 2 logs. If more, span context is not being properly deactivated
+			expect(loggerInstance.logs).toHaveLength(2);
+
+			// Expect logger to be called with injected log
+			const log1 = loggerInstance.logs[0];
+			expect(log1).toEqual({
+				ts: expect.any(Number),
+				level: "info",
+				msg: "Called with param value=test",
+				dd: {
+					trace_id: expect.any(String),
+					span_id: expect.any(String),
+				},
+				nodeID: "broker-log-1",
+				ns: `tracing-${scope}`,
+				mod: "tracing-collector",
+				svc: "tracing-collector",
+			});
+
+			const log2 = loggerInstance.logs[1];
+			expect(log2).toEqual({
+				ts: expect.any(Number),
+				level: "info",
+				msg: "Called with param value=double test",
+				dd: {
+					trace_id: expect.any(String),
+					span_id: expect.any(String),
+				},
+				nodeID: "broker-log-1",
+				ns: `tracing-${scope}`,
+				mod: "tracing-collector",
+				svc: "tracing-collector",
+			});
+
+			// Expect trace ids to be equal and span ids to be different
+			expect(log1.dd.trace_id).toEqual(log1.dd.span_id);
+			expect(log1.dd.trace_id).toEqual(log2.dd.trace_id);
+			expect(log1.dd.span_id).not.toEqual(log2.dd.span_id);
+		});
+
+		it("uses an external span as a parent", async () => {
+			const ddTracer = broker.tracer.exporter[0].ddTracer;
+
+			const [result, spanContext] = await ddTracer.trace(
+				"test-external",
+				async (span) => {
+					const r = await broker.call(
+						"tracing-collector.getSpan",
+						{}
+					);
+					return [r, span.context()];
+				}
+			);
+
+			expect(result).not.toBeNull();
+			expect(result).toHaveProperty("traceId", spanContext.toTraceId());
+			expect(result).toHaveProperty("parentId", spanContext.toSpanId());
+		});
+
+		it("works with custom spans in action handler", async () => {
+			const ddTracer = broker.tracer.exporter[0].ddTracer;
+			let span = ddTracer.scope().active();
+			expect(span).toBeNull();
+
+			const spans = await broker.call("tracing-collector.customSpans");
+
+			// spans == [action, span1, span2, span1, span3, action]
+			expect(spans).toHaveLength(6);
+
+			// expect all the spans to be part of the same trace
+			expect(_.uniq(spans.map((s) => s.traceId))).toHaveLength(1);
+
+			// expect correct names and parent ids
+			expect(spans[0]).toHaveProperty(
+				"name",
+				"action 'tracing-collector.customSpans'"
+			);
+			expect(spans[0]).toEqual(spans[5]);
+			expect(spans[0]).toHaveProperty("parentId", null);
+
+			expect(spans[1]).toHaveProperty("name", "span1");
+			expect(spans[1]).toEqual(spans[3]);
+			expect(spans[1]).toHaveProperty("parentId", spans[0].spanId);
+
+			expect(spans[2]).toHaveProperty("name", "span2");
+			expect(spans[2]).toHaveProperty("parentId", spans[1].spanId);
+
+			expect(spans[4]).toHaveProperty("name", "span3");
+			expect(spans[4]).toHaveProperty("parentId", spans[0].spanId);
+		});
+
+		it("works with event handlers", async () => {
+			await broker.call("tracing-collector.triggerEvent");
+
+			// Filter out objects from the event exporter
+			const spans = STORE.filter((item) => !item.id);
+
+			// spans = [action, event, custom, custom, event]
+			expect(spans).toHaveLength(5);
+
+			// expect all the spans to be part of the same trace
+			expect(_.uniq(spans.map((s) => s.traceId))).toHaveLength(1);
+
+			// expect correct names and parent ids
+			expect(spans[0]).toHaveProperty(
+				"name",
+				"action 'tracing-collector.triggerEvent'"
+			);
+			expect(spans[0]).toHaveProperty("parentId", null);
+
+			expect(spans[1]).toHaveProperty(
+				"name",
+				"event 'some.event' in 'tracing-collector'"
+			);
+			expect(spans[1]).toEqual(spans[4]);
+			expect(spans[1]).toHaveProperty("parentId", spans[0].spanId);
+
+			expect(spans[2]).toHaveProperty("name", "custom span");
+			expect(spans[2]).toEqual(spans[3]);
+			expect(spans[2]).toHaveProperty("parentId", spans[1].spanId);
+		});
+	});
+});

--- a/test/integration/tracing-datadog.spec.js
+++ b/test/integration/tracing-datadog.spec.js
@@ -200,7 +200,15 @@ supportedScopes.forEach((scope) => {
 			return broker.start();
 		});
 
-		afterAll(() => broker.stop());
+		afterAll(() => {
+			// Some cleanup to avoid affecting other test suites
+			if (["async_hooks", "async_resource"].includes(scope)) {
+				broker.tracer.exporter[0].ddScope._hook.disable();
+			} else if (scope === "async_local_storage") {
+				broker.tracer.exporter[0].ddScope._storage.disable();
+			}
+			return broker.stop();
+		});
 
 		beforeEach(() => {
 			jest.resetAllMocks();

--- a/test/unit/middlewares/tracing.spec.js
+++ b/test/unit/middlewares/tracing.spec.js
@@ -104,6 +104,7 @@ describe("Test TracingMiddleware localAction", () => {
 			action,
 			id: "ctx-id",
 			requestID: "request-id",
+			traceID: "trace-id",
 			parentID: "parent-id",
 			level: 3,
 			service: {
@@ -164,7 +165,7 @@ describe("Test TracingMiddleware localAction", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("action 'posts.find'", {
 				id: "ctx-id",
 				type: "action",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: {
 					fullName: "v1.posts",
@@ -196,6 +197,7 @@ describe("Test TracingMiddleware localAction", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(ctx.finishSpan).toHaveBeenCalledTimes(1);
@@ -244,7 +246,7 @@ describe("Test TracingMiddleware localAction", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("static text", {
 				id: "ctx-id",
 				type: "action",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: null,
 				tags: {
@@ -277,6 +279,7 @@ describe("Test TracingMiddleware localAction", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(ctx.finishSpan).toHaveBeenCalledTimes(1);
@@ -325,7 +328,7 @@ describe("Test TracingMiddleware localAction", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("The posts.find action called", {
 				id: "ctx-id",
 				type: "action",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: null,
 				tags: {
@@ -359,6 +362,7 @@ describe("Test TracingMiddleware localAction", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -397,7 +401,7 @@ describe("Test TracingMiddleware localAction", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("action 'posts.find'", {
 				id: "ctx-id",
 				type: "action",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: null,
 				tags: {
@@ -416,6 +420,7 @@ describe("Test TracingMiddleware localAction", () => {
 					remoteCall: false
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -455,7 +460,7 @@ describe("Test TracingMiddleware localAction", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("action 'posts.find'", {
 				id: "ctx-id",
 				type: "action",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: null,
 				tags: {
@@ -491,6 +496,7 @@ describe("Test TracingMiddleware localAction", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -541,6 +547,7 @@ describe("Test TracingMiddleware localAction", () => {
 			fakeSpan.sampled = false;
 
 			ctx.requestID = null;
+			ctx.traceID = null;
 			ctx.parentID = null;
 
 			tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
@@ -563,7 +570,7 @@ describe("Test TracingMiddleware localAction", () => {
 				expect(action.tracing.tags).toHaveBeenCalledTimes(1);
 				expect(action.tracing.tags).toHaveBeenCalledWith(ctx);
 
-				expect(tracer.getCurrentTraceID).toHaveBeenCalledTimes(1);
+				expect(tracer.getCurrentTraceID).toHaveBeenCalledTimes(2);
 				expect(tracer.getActiveSpanID).toHaveBeenCalledTimes(1);
 
 				expect(ctx.startSpan).toHaveBeenCalledTimes(1);
@@ -606,6 +613,7 @@ describe("Test TracingMiddleware localAction", () => {
 						}
 					},
 					sampled: true,
+					autoActivate: false
 				});
 
 				expect(ctx.tracing).toBe(false);
@@ -667,6 +675,7 @@ describe("Test TracingMiddleware localAction", () => {
 					params: "Moleculer"
 				},
 				sampled: false,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -711,7 +720,6 @@ describe("Test TracingMiddleware localAction", () => {
 				};
 			});
 
-
 			it("should create a span with local custom tags function even if global custom tags are specified", async () => {
 				const brokerOptions = {
 					tracing: {
@@ -735,6 +743,7 @@ describe("Test TracingMiddleware localAction", () => {
 				};
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -786,8 +795,9 @@ describe("Test TracingMiddleware localAction", () => {
 						requestID: "request-id",
 						remoteCall: false
 					},
-					traceID: "request-id",
-					type: "action"
+					traceID: "tracer-trace-id",
+					type: "action",
+					autoActivate: false
 				});
 
 				expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -818,6 +828,7 @@ describe("Test TracingMiddleware localAction", () => {
 				fakeSpan.sampled = false;
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -865,8 +876,9 @@ describe("Test TracingMiddleware localAction", () => {
 						requestID: "request-id",
 						remoteCall: false
 					},
-					traceID: "request-id",
-					type: "action"
+					traceID: "tracer-trace-id",
+					type: "action",
+					autoActivate: false
 
 				});
 				expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -886,6 +898,7 @@ describe("Test TracingMiddleware localAction", () => {
 				fakeSpan.sampled = false;
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -927,8 +940,9 @@ describe("Test TracingMiddleware localAction", () => {
 						requestID: "request-id",
 						remoteCall: false
 					},
-					traceID: "request-id",
-					type: "action"
+					traceID: "tracer-trace-id",
+					type: "action",
+					autoActivate: false
 				});
 
 				expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -955,6 +969,7 @@ describe("Test TracingMiddleware localAction", () => {
 				fakeSpan.sampled = false;
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -999,8 +1014,9 @@ describe("Test TracingMiddleware localAction", () => {
 						requestID: "request-id",
 						remoteCall: false
 					},
-					traceID: "request-id",
-					type: "action"
+					traceID: "tracer-trace-id",
+					type: "action",
+					autoActivate: false
 				});
 
 				expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -1044,6 +1060,7 @@ describe("Test TracingMiddleware localAction", () => {
 				};
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -1083,8 +1100,9 @@ describe("Test TracingMiddleware localAction", () => {
 						requestID: "request-id",
 						remoteCall: false
 					},
-					traceID: "request-id",
-					type: "action"
+					traceID: "tracer-trace-id",
+					type: "action",
+					autoActivate: false
 				});
 
 				expect(fakeSpan.addTags).toHaveBeenCalledTimes(1);
@@ -1209,6 +1227,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			event,
 			id: "ctx-id",
 			requestID: "request-id",
+			traceID: "trace-id",
 			parentID: "parent-id",
 			eventName: "user.created",
 			eventType: "emit",
@@ -1268,7 +1287,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("event 'user.created' in 'v1.posts'", {
 				id: "ctx-id",
 				type: "event",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: {
 					fullName: "v1.posts",
@@ -1298,6 +1317,7 @@ describe("Test TracingMiddleware localEvent", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(ctx.span).toBeUndefined();
@@ -1344,7 +1364,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("static text", {
 				id: "ctx-id",
 				type: "event",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: {
 					fullName: "v1.posts",
@@ -1379,6 +1399,7 @@ describe("Test TracingMiddleware localEvent", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(ctx.span).toBeUndefined();
@@ -1421,7 +1442,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("The user.created triggered", {
 				id: "ctx-id",
 				type: "event",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: {
 					fullName: "v1.posts",
@@ -1457,6 +1478,7 @@ describe("Test TracingMiddleware localEvent", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(0);
@@ -1490,7 +1512,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("event 'user.created' in 'v1.posts'", {
 				id: "ctx-id",
 				type: "event",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: {
 					fullName: "v1.posts",
@@ -1511,6 +1533,7 @@ describe("Test TracingMiddleware localEvent", () => {
 					requestID: "request-id",
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(0);
@@ -1547,7 +1570,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			expect(ctx.startSpan).toHaveBeenCalledWith("event 'user.created' in 'v1.posts'", {
 				id: "ctx-id",
 				type: "event",
-				traceID: "request-id",
+				traceID: "trace-id",
 				parentID: "parent-id",
 				service: {
 					fullName: "v1.posts",
@@ -1586,6 +1609,7 @@ describe("Test TracingMiddleware localEvent", () => {
 					}
 				},
 				sampled: true,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(0);
@@ -1611,6 +1635,7 @@ describe("Test TracingMiddleware localEvent", () => {
 			fakeSpan.sampled = false;
 
 			ctx.requestID = null;
+			ctx.traceID = null;
 			ctx.parentID = null;
 
 			tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
@@ -1633,7 +1658,7 @@ describe("Test TracingMiddleware localEvent", () => {
 				expect(event.tracing.tags).toHaveBeenCalledTimes(1);
 				expect(event.tracing.tags).toHaveBeenCalledWith(ctx);
 
-				expect(tracer.getCurrentTraceID).toHaveBeenCalledTimes(1);
+				expect(tracer.getCurrentTraceID).toHaveBeenCalledTimes(2);
 				expect(tracer.getActiveSpanID).toHaveBeenCalledTimes(1);
 
 				expect(ctx.startSpan).toHaveBeenCalledTimes(1);
@@ -1678,6 +1703,7 @@ describe("Test TracingMiddleware localEvent", () => {
 						}
 					},
 					sampled: true,
+					autoActivate: false
 				});
 
 				expect(ctx.span).toBeUndefined();
@@ -1741,6 +1767,7 @@ describe("Test TracingMiddleware localEvent", () => {
 					params: "Moleculer"
 				},
 				sampled: false,
+				autoActivate: false
 			});
 
 			expect(fakeSpan.addTags).toHaveBeenCalledTimes(0);
@@ -1816,6 +1843,7 @@ describe("Test TracingMiddleware localEvent", () => {
 				};
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -1867,8 +1895,9 @@ describe("Test TracingMiddleware localEvent", () => {
 						remoteCall: false,
 						requestID: "request-id",
 					},
-					traceID: "request-id",
-					type: "event"
+					traceID: "tracer-trace-id",
+					type: "event",
+					autoActivate: false
 				});
 
 				expect(ctx.tracing).toBe(true);
@@ -1899,6 +1928,7 @@ describe("Test TracingMiddleware localEvent", () => {
 				tracer.getActiveSpanID = jest.fn();
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -1947,8 +1977,9 @@ describe("Test TracingMiddleware localEvent", () => {
 						remoteCall: false,
 						requestID: "request-id",
 					},
-					traceID: "request-id",
-					type: "event"
+					traceID: "tracer-trace-id",
+					type: "event",
+					autoActivate: false
 
 				});
 				expect(ctx.tracing).toBe(true);
@@ -1972,6 +2003,7 @@ describe("Test TracingMiddleware localEvent", () => {
 				tracer.getActiveSpanID = jest.fn();
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -2021,8 +2053,9 @@ describe("Test TracingMiddleware localEvent", () => {
 						remoteCall: false,
 						requestID: "request-id",
 					},
-					traceID: "request-id",
-					type: "event"
+					traceID: "tracer-trace-id",
+					type: "event",
+					autoActivate: false
 				});
 				expect(ctx.tracing).toBe(true);
 
@@ -2048,6 +2081,7 @@ describe("Test TracingMiddleware localEvent", () => {
 				tracer.getActiveSpanID = jest.fn();
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -2100,8 +2134,9 @@ describe("Test TracingMiddleware localEvent", () => {
 						remoteCall: false,
 						requestID: "request-id",
 					},
-					traceID: "request-id",
-					type: "event"
+					traceID: "tracer-trace-id",
+					type: "event",
+					autoActivate: false
 				});
 				expect(ctx.tracing).toBe(true);
 
@@ -2135,6 +2170,7 @@ describe("Test TracingMiddleware localEvent", () => {
 				};
 
 				ctx.parentID = null;
+				ctx.traceID = null;
 
 				tracer.getCurrentTraceID = jest.fn(() => "tracer-trace-id");
 				tracer.getActiveSpanID = jest.fn(() => "tracer-span-id");
@@ -2182,8 +2218,9 @@ describe("Test TracingMiddleware localEvent", () => {
 						remoteCall: false,
 						requestID: "request-id",
 					},
-					traceID: "request-id",
-					type: "event"
+					traceID: "tracer-trace-id",
+					type: "event",
+					autoActivate: false
 				});
 				expect(ctx.tracing).toBe(true);
 

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -684,7 +684,7 @@ describe("Test Service class", () => {
 			expect(() => { svc._createMethod("schema", "list"); }).toThrowError("Invalid method definition in 'list' method in 'v2.posts' service!");
 		});
 
-		it("should throw error if action handler is not defined", () => {
+		it("should throw error if method handler is not defined", () => {
 			expect(() => { svc._createMethod({}, "list"); })
 				.toThrowError("Missing method handler on 'list' method in 'v2.posts' service!");
 			expect(() => { svc._createMethod({ handler: null }, "list"); })
@@ -693,7 +693,7 @@ describe("Test Service class", () => {
 				.toThrowError("Missing method handler on 'list' method in 'v2.posts' service!");
 		});
 
-		it("should create action definition from a shorthand handler", () => {
+		it("should create method definition from a shorthand handler", () => {
 			const handler = jest.fn(function(name) {
 				expect(this).toBe(svc);
 				return `Hello ${name}`;
@@ -711,7 +711,7 @@ describe("Test Service class", () => {
 			expect(svc.list("John")).toBe("Hello John");
 		});
 
-		it("should create action definition from a schema", () => {
+		it("should create method definition from a schema", () => {
 			const schema = {
 				uppercase: true,
 				handler: jest.fn(function(name) {


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Support dd-trace's AsyncLocalStorage and AsyncResource scope manager implementations (introduced in [v0.27.0](https://github.com/DataDog/dd-trace-js/releases/tag/v0.27.0) and [v0.28.0](https://github.com/DataDog/dd-trace-js/releases/tag/v0.28.0)) and clean up the AsyncHooks implementation.
- Fix activation of moleculer spans in dd-trace, allowing for propagation to external modules. This also allows for log injection to [connect logs and traces](https://docs.datadoghq.com/tracing/connect_logs_and_traces/).
- Allow moleculer to continue a trace that was started in an external module. For example, this will show the moleculer-web handler as a child span of the node http listener.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

Resolves #690
Resolves  #889

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

- [x] Unit and integration tests added
- [x] Tested an environment with 5 distributed services (each running in separate containers) sending traces to Datadog. The sample screenshots below show cross-service calls, custom spans in an action handler, and modules auto-instrumented by dd-trace (http-client, tcp, dns, fs, redis, postgres).

###### A simple call through moleculer-web to a remote action that makes some HTTP calls and interacts with a postgres database
<img width="1824" alt="Screen Shot 2021-04-18 at 11 39 09 AM" src="https://user-images.githubusercontent.com/1031317/115186978-30496b80-a0a8-11eb-863f-e2efcc463b70.png">

###### A call that includes some nested remote action calls, one of which calls redis and returns an error
<img width="1822" alt="Screen Shot 2021-04-18 at 11 40 06 AM" src="https://user-images.githubusercontent.com/1031317/115187011-3f301e00-a0a8-11eb-9836-a6e91d765478.png">

###### The same call as the previous example, but with a remote service subscribing to an event it emits
<img width="1822" alt="Screen Shot 2021-04-18 at 11 16 12 PM" src="https://user-images.githubusercontent.com/1031317/115187222-90401200-a0a8-11eb-8497-b2b0b266d394.png">

###### The initial call to a lazy-loaded module with a bunch of fs reads needed to require the library
<img width="1820" alt="Screen Shot 2021-04-18 at 11 40 33 AM" src="https://user-images.githubusercontent.com/1031317/115187116-68e94500-a0a8-11eb-8b19-aeea0e705522.png">

###### An action handler with some custom spans via `ctx.startSpan`
<img width="1822" alt="Screen Shot 2021-04-18 at 11 41 49 AM" src="https://user-images.githubusercontent.com/1031317/115187056-4fe09400-a0a8-11eb-94b4-4a83c0bf17ec.png">

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
