### PR TITLE
Resolves #909 - Add Utils typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1590,7 +1590,7 @@ declare namespace Moleculer {
 		function isString(str: unknown): str is string;
 		function isObject(obj: unknown): obj is object;
 		function isPlainObject(obj: unknown): obj is object;
-		function isDate(date: unknown): data is Date;
+		function isDate(date: unknown): date is Date;
 		function flatten<T>(arr: readonly T[] | readonly T[][]): T[];
 		function humanize(millis?: number | null): string;
 		function generateToken(): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1586,7 +1586,7 @@ declare namespace Moleculer {
 	}
 
 	namespace Utils {
-		function isFunction(func: unknown): func is function;
+		function isFunction(func: unknown): boolean;
 		function isString(str: unknown): str is string;
 		function isObject(obj: unknown): obj is object;
 		function isPlainObject(obj: unknown): obj is object;
@@ -1597,8 +1597,8 @@ declare namespace Moleculer {
 		function removeFromArray<T>(arr: T[], item: T): T[];
 		function getNodeID(): string;
 		function getIpList(): string[];
-		function isPromise(promise: unknown): promise is Promise;
-		function polyfillPromise(P: Promise): void;
+		function isPromise<T>(promise: unknown): promise is Promise<T>;
+		function polyfillPromise<T>(P: Promise<T>): void;
 		function clearRequireCache(filename: string): void;
 		function match(text: string, pattern: string): boolean;
 		function deprecate(prop: unknown, msg?: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1586,7 +1586,7 @@ declare namespace Moleculer {
 	}
 
 	namespace Utils {
-		function isFunction(func: unknown): boolean;
+		function isFunction(func: unknown): func is Function;
 		function isString(str: unknown): str is string;
 		function isObject(obj: unknown): obj is object;
 		function isPlainObject(obj: unknown): obj is object;
@@ -1598,7 +1598,7 @@ declare namespace Moleculer {
 		function getNodeID(): string;
 		function getIpList(): string[];
 		function isPromise<T>(promise: unknown): promise is Promise<T>;
-		function polyfillPromise<T>(P: Promise<T>): void;
+		function polyfillPromise(P: typeof Promise): void;
 		function clearRequireCache(filename: string): void;
 		function match(text: string, pattern: string): boolean;
 		function deprecate(prop: unknown, msg?: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1586,24 +1586,24 @@ declare namespace Moleculer {
 	}
 
 	namespace Utils {
-		function isFunction(func: any): boolean;
-		function isString(str: any): boolean;
-		function isObject(obj: any): boolean;
-		function isPlainObject(obj: any): boolean;
-		function isDate(date: any): boolean;
-		function flatten(arr: any[]): any[];
-		function humanize(millis: number): string;
+		function isFunction(func: unknown): func is function;
+		function isString(str: unknown): str is string;
+		function isObject(obj: unknown): obj is object;
+		function isPlainObject(obj: unknown): obj is object;
+		function isDate(date: unknown): data is Date;
+		function flatten<T>(arr: readonly T[] | readonly T[][]): T[];
+		function humanize(millis?: number | null): string;
 		function generateToken(): string;
-		function removeFromArray(arr: any[], item: any): any[];
+		function removeFromArray<T>(arr: T[], item: T): T[];
 		function getNodeID(): string;
-		function getIpList(): any[];
-		function isPromise(promise: any): boolean;
-		// function polyfillPromise(P: Promise): any; // From Utils -> NOT USED & NOT TESTED YET !!!
+		function getIpList(): string[];
+		function isPromise(promise: unknown): promise is Promise;
+		function polyfillPromise(P: Promise): void;
 		function clearRequireCache(filename: string): void;
 		function match(text: string, pattern: string): boolean;
-		function deprecate(prop: any, msg: string): void;
-		function safetyObject(obj: any, options: any): any;
-		function dotSet(obj: any, path: string, value: any): any;
+		function deprecate(prop: unknown, msg?: string): void;
+		function safetyObject(obj: unknown, options?: { maxSafeObjectSize?: number }): any;
+		function dotSet<T extends object>(obj: T, path: string, value: unknown): T;
 		function makeDirs(path: string): void;
 		function parseByteString(value: string): number;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1584,6 +1584,29 @@ declare namespace Moleculer {
 			delimiter(value: string): void;
 		}
 	}
+
+	namespace Utils {
+		function isFunction(func: any): boolean;
+		function isString(str: any): boolean;
+		function isObject(obj: any): boolean;
+		function isPlainObject(obj: any): boolean;
+		function isDate(date: any): boolean;
+		function flatten(arr: any[]): any[];
+		function humanize(millis: number): string;
+		function generateToken(): string;
+		function removeFromArray(arr: any[], item: any): any[];
+		function getNodeID(): string;
+		function getIpList(): any[];
+		function isPromise(promise: any): boolean;
+		// function polyfillPromise(P: Promise): any; // From Utils -> NOT USED & NOT TESTED YET !!!
+		function clearRequireCache(filename: string): void;
+		function match(text: string, pattern: string): boolean;
+		function deprecate(prop: any, msg: string): void;
+		function safetyObject(obj: any, options: any): any;
+		function dotSet(obj: any, path: string, value: any): any;
+		function makeDirs(path: string): void;
+		function parseByteString(value: string): number;
+	}
 }
 
 export = Moleculer;

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,7 +173,6 @@ const utils = {
 	/**
 	 * Polyfill a Promise library with missing Bluebird features.
 	 *
-	 * NOT USED & NOT TESTED YET !!!
 	 *
 	 * @param {PromiseClass} P
 	 */


### PR DESCRIPTION
## :memo: Description

Utils functions in typescript are not possible to import.
Needed to use one of the functions in our typescript project.

### :dart: Relevant issues
#909 

### :gem: Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

### :scroll: Example code

```ts
import { Utils } from 'moleculer';

Utils.match('this.is.a.text',  '**');
``` 

## :vertical_traffic_light: How Has This Been Tested?

This has been tested on a local typescript project. According to the example given above.

## :checkered_flag: Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ x] **New and existing unit tests pass locally with my changes**
- [ x] I have commented my code, particularly in hard-to-understand areas

NOTE: To follow the file standards, no description comments added.
