### PR TITLE
fix TS typings: 'check' optional in RetryPolicyOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -760,7 +760,7 @@ declare namespace Moleculer {
 		delay?: number;
 		maxDelay?: number;
 		factor?: number;
-		check: CheckRetryable;
+		check?: CheckRetryable;
 	}
 
 	interface BrokerRegistryOptions {


### PR DESCRIPTION
## :memo: Description

Update the TS typings file so that the 'check' field of RetryPolicyOptions is optional. I think this part of index.d.ts might have been a typo. When I look through the codebase for usage of RetryPolicyOptions, it looks like this field really is optional, and it's often omitted.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code

Here's a code sample that will FAIL the typescript checker in master branch:

```js

import { ServiceBroker } from 'moleculer';

const broker = new ServiceBroker({
  retryPolicy: {
    enabled: false,
  },
});

``` 

The TSC error looks like:

```
(filename):13:3 - error TS2741: Property 'check' is missing in type '{ enabled: false; }' but required in type 'RetryPolicyOptions'.

    13   retryPolicy: {
      node_modules/moleculer/index.d.ts:763:3
        763  	check: CheckRetryable;
             	~~~~~
        'check' is declared here.
      node_modules/moleculer/index.d.ts:816:3
        816  	retryPolicy?: RetryPolicyOptions;
             	~~~~~~~~~~~
        The expected type comes from property 'retryPolicy' which is declared here on type 'BrokerOptions'
```



## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
