### PR TITLE
Add MOLECULER_CONFIG env variable

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -136,7 +136,8 @@ class MoleculerRunner {
 	 *
 	 * Try to load a configuration file in order to:
 	 *
-	 * 		- load file which is defined in CLI option with --config
+	 *		- load file defined in MOLECULER_CONFIG env var
+	 * 		- try to load file which is defined in CLI option with --config
 	 * 		- try to load the `moleculer.config.js` file if exist in the cwd
 	 * 		- try to load the `moleculer.config.json` file if exist in the cwd
 	 */

--- a/src/runner.js
+++ b/src/runner.js
@@ -143,7 +143,7 @@ class MoleculerRunner {
 	 */
 	loadConfigFile() {
 		let filePath;
-		// Env vars has priority over the flags
+		// Env vars have priority over the flags
 		if (process.env["MOLECULER_CONFIG"]) {
 			filePath = path.isAbsolute(process.env["MOLECULER_CONFIG"]) ? process.env["MOLECULER_CONFIG"] : path.resolve(process.cwd(), process.env["MOLECULER_CONFIG"]);
 		} else if (this.flags.config) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -142,7 +142,10 @@ class MoleculerRunner {
 	 */
 	loadConfigFile() {
 		let filePath;
-		if (this.flags.config) {
+		// Env vars has priority over the flags
+		if (process.env["MOLECULER_CONFIG"]) {
+			filePath = path.isAbsolute(process.env["MOLECULER_CONFIG"]) ? process.env["MOLECULER_CONFIG"] : path.resolve(process.cwd(), process.env["MOLECULER_CONFIG"]);
+		} else if (this.flags.config) {
 			filePath = path.isAbsolute(this.flags.config) ? this.flags.config : path.resolve(process.cwd(), this.flags.config);
 		}
 		if (!filePath && fs.existsSync(path.resolve(process.cwd(), "moleculer.config.js"))) {


### PR DESCRIPTION
## :memo: Description

Closes https://github.com/moleculerjs/moleculer/issues/921. Add the ability to inform moleculer-runner, via env vars, about the location of `moleculer.config.js` file

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->
https://github.com/moleculerjs/moleculer/issues/921

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```bash
# .env file
MOLECULER_CONFIG=<location-of-the-config-file>
``` 

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
