### PR TITLE
fix definition file ThisType Usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,10 @@ declare namespace Moleculer {
 		trace(...args: any[]): void;
 	}
 
-	type ActionHandler<T = any> = ((ctx: Context<any, any>) => Promise<T> | T) & ThisType<Service>;
+	type ActionHandler<T = any, S = ServiceSettingSchema> = (
+		this: Service<S>,
+		ctx: Context<any, any>
+	) => Promise<T> | T;
 	type ActionParamSchema = { [key: string]: any };
 	type ActionParamTypes =
 		| "any"
@@ -595,9 +598,15 @@ declare namespace Moleculer {
 		[name: string]: any;
 	}
 
-	type ServiceEventLegacyHandler = ((payload: any, sender: string, eventName: string, ctx: Context) => void) & ThisType<Service>;
+	type ServiceEventLegacyHandler = (
+		this: Service,
+		payload: any,
+		sender: string,
+		eventName: string,
+		ctx: Context
+	) => void;
 
-	type ServiceEventHandler = ((ctx: Context) => void) & ThisType<Service>;
+	type ServiceEventHandler = (this: Service, ctx: Context) => void;
 
 	interface ServiceEvent {
 		name?: string;
@@ -611,7 +620,12 @@ declare namespace Moleculer {
 
 	type ServiceEvents = { [key: string]: ServiceEventHandler | ServiceEventLegacyHandler | ServiceEvent };
 
-	type ServiceMethods = { [key: string]: ((...args: any[]) => any) } & ThisType<Service>;
+	type ServiceMethods = {
+		[key: string]: <S = ServiceSettingSchema>(
+			this: Service,
+			...args: any[]
+		) => any;
+	};
 
 	type CallMiddlewareHandler = (actionName: string, params: any, opts: CallingOptions) => Promise<any>;
 	type Middleware = {
@@ -624,7 +638,10 @@ declare namespace Moleculer {
 			| ((handler: CallMiddlewareHandler) => CallMiddlewareHandler)
 	}
 
-	type MiddlewareInit = (broker: ServiceBroker) => Middleware & ThisType<ServiceBroker>;
+	type MiddlewareInit = (
+		this: ServiceBroker,
+		broker: ServiceBroker
+	) => Middleware;
 	interface MiddlewareCallHandlerOptions {
 		reverse?: boolean
 	}
@@ -682,7 +699,15 @@ declare namespace Moleculer {
 		[name: string]: any;
 	}
 
-	type ServiceAction = (<T = Promise<any>, P extends GenericObject = GenericObject>(params?: P, opts?: CallingOptions) => T) & ThisType<Service>;
+	type ServiceAction = <
+		T = Promise<any>,
+		P extends GenericObject = GenericObject,
+		S = ServiceSettingSchema
+	>(
+		this: Service<S>,
+		params?: P,
+		opts?: CallingOptions
+	) => T;
 
 	interface ServiceActions {
 		[name: string]: ServiceAction;


### PR DESCRIPTION

## :memo: Description

I think the hardcode in typescript which define
`this` type in function arguments.

It's more intuitive to user.

Reference: https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function

All changes is pass in my local repo. except
`ServiceEventHandler | ServiceEventLegacyHandler`
Becase of typescipt cannot make infer between two function


### :dart: Relevant issues

#949 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
```typescript
this.parseServiceSchema({
  methods: {
    foo(bar) {
      this; // check this
    }
  },
})
```
- [x] Test B
```typescript
this.parseServiceSchema({
  methods: {
    actions(ctx) {
      this; // check this
    }
  },
})
```
- [x] Test C
```typescript
broker.middlewares.add(function () {
  this; // check this
  return {};
});
```
- [x] Test D
```typescript
broker.services[0].actions = {
  foo(params, opts): any {
    this; // check this
  },
};
```

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
