### PR TITLE
Adding typing for settled in CallingOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -956,7 +956,7 @@ declare namespace Moleculer {
 		requestID?: string;
 		tracking?: boolean;
 		paramsCloning?: boolean;
-		caller
+		caller?: string;
 	}
 
 	interface MCallCallingOptions extends CallingOptions{

--- a/index.d.ts
+++ b/index.d.ts
@@ -956,8 +956,7 @@ declare namespace Moleculer {
 		requestID?: string;
 		tracking?: boolean;
 		paramsCloning?: boolean;
-		caller?: string;
-		settled?: boolean;
+		caller
 	}
 
 	interface MCallCallingOptions extends CallingOptions{

--- a/index.d.ts
+++ b/index.d.ts
@@ -957,6 +957,7 @@ declare namespace Moleculer {
 		tracking?: boolean;
 		paramsCloning?: boolean;
 		caller?: string;
+		settled?: boolean;
 	}
 
 	interface CallDefinition<P extends GenericObject = GenericObject> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -960,6 +960,10 @@ declare namespace Moleculer {
 		settled?: boolean;
 	}
 
+	interface MCallCallingOptions extends CallingOptions{
+		settled?: boolean;
+	}
+
 	interface CallDefinition<P extends GenericObject = GenericObject> {
 		action: string;
 		params: P;
@@ -1086,7 +1090,7 @@ declare namespace Moleculer {
 		call<T>(actionName: string): Promise<T>;
 		call<T, P>(actionName: string, params: P, opts?: CallingOptions): Promise<T>;
 
-		mcall<T>(def: Array<MCallDefinition> | { [name: string]: MCallDefinition }, opts?: CallingOptions): Promise<Array<T> | T>;
+		mcall<T>(def: Array<MCallDefinition> | { [name: string]: MCallDefinition }, opts?: MCallCallingOptions): Promise<Array<T> | T>;
 
 		emit<D>(eventName: string, data: D, opts: GenericObject): Promise<void>;
 		emit<D>(eventName: string, data: D, groups: Array<string>): Promise<void>;


### PR DESCRIPTION
## :memo: Description

Following our exchange on discord, here is a small fix to add typing for the `settled` params in `mcall`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change

Updating Types


## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Edit index file
- Compile

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
