### PR TITLE
RedisCacher pingInterval Option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1232,6 +1232,7 @@ declare namespace Moleculer {
 		redis?: GenericObject;
 		redlock?: GenericObject;
 		monitor?: boolean;
+		pingInterval?: number;
 	}
 
 	namespace Cachers {

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -118,9 +118,13 @@ class RedisCacher extends BaseCacher {
 		// add interval for ping if set
 		if (typeof this.opts.pingInterval === "number") {
 			setInterval(() => {
-				this.client.ping().catch((err) => {
-					this.logger.error("Failed to send PING to Redis Server", err);
-				});
+				this.client.ping()
+					.then(() => {
+						this.logger.debug("Sent PING to Redis Server");
+					})
+					.catch((err) => {
+						this.logger.error("Failed to send PING to Redis Server", err);
+					});
 			}, this.opts.pingInterval);
 		}
 

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -37,6 +37,8 @@ class RedisCacher extends BaseCacher {
 			prefix: null,
 			pingInterval: null,
 		});
+
+		this.pingIntervalHandle = null;
 	}
 
 	/**
@@ -117,7 +119,7 @@ class RedisCacher extends BaseCacher {
 
 		// add interval for ping if set
 		if (typeof this.opts.pingInterval === "number") {
-			setInterval(() => {
+			this.pingIntervalHandle = setInterval(() => {
 				this.client.ping()
 					.then(() => {
 						this.logger.debug("Sent PING to Redis Server");
@@ -137,6 +139,10 @@ class RedisCacher extends BaseCacher {
 	 * @memberof RedisCacher
 	 */
 	close() {
+		if (this.pingIntervalHandle != null) {
+			clearInterval(this.pingIntervalHandle);
+			this.pingIntervalHandle = null;
+		}
 		return this.client != null ? this.client.quit() : Promise.resolve();
 	}
 

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -118,7 +118,7 @@ class RedisCacher extends BaseCacher {
 		this.serializer.init(this.broker);
 
 		// add interval for ping if set
-		if (typeof this.opts.pingInterval === "number") {
+		if (this.opts.pingInterval > 0) {
 			this.pingIntervalHandle = setInterval(() => {
 				this.client.ping()
 					.then(() => {
@@ -127,7 +127,7 @@ class RedisCacher extends BaseCacher {
 					.catch((err) => {
 						this.logger.error("Failed to send PING to Redis Server", err);
 					});
-			}, this.opts.pingInterval);
+			}, Number(this.opts.pingInterval));
 		}
 
 		this.logger.debug("Redis Cacher created. Prefix: " + this.prefix);

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -34,7 +34,8 @@ class RedisCacher extends BaseCacher {
 		super(opts);
 
 		this.opts = _.defaultsDeep(this.opts, {
-			prefix: null
+			prefix: null,
+			pingInterval: null,
 		});
 	}
 
@@ -113,6 +114,15 @@ class RedisCacher extends BaseCacher {
 		// create an instance of serializer (default to JSON)
 		this.serializer = Serializers.resolve(this.opts.serializer);
 		this.serializer.init(this.broker);
+
+		// add interval for ping if set
+		if (typeof this.opts.pingInterval === "number") {
+			setInterval(() => {
+				this.client.ping().catch((err) => {
+					this.logger.error("Failed to send PING to Redis Server", err);
+				});
+			}, this.opts.pingInterval);
+		}
 
 		this.logger.debug("Redis Cacher created. Prefix: " + this.prefix);
 	}

--- a/test/unit/cachers/index.spec.js
+++ b/test/unit/cachers/index.spec.js
@@ -52,14 +52,14 @@ describe("Test Cacher resolver with valid instances", () => {
 		let options = { ttl: 100 };
 		cacher = Cachers.resolve({ type: "Redis", options });
 		expect(cacher).toBeInstanceOf(Cachers.Redis);
-		expect(cacher.opts).toEqual({ prefix: null, keygen: null, maxParamsLength: null, ttl: 100 });
+		expect(cacher.opts).toEqual({ prefix: null, keygen: null, maxParamsLength: null, ttl: 100, pingInterval: null });
 	});
 
 	it("should resolve RedisCacher from obj with Redis type", () => {
 		let options = { ttl: 80, redis: { db: 3 } };
 		cacher = Cachers.resolve({ type: "redis", options });
 		expect(cacher).toBeInstanceOf(Cachers.Redis);
-		expect(cacher.opts).toEqual({ prefix: null, keygen: null, maxParamsLength: null, ttl: 80, redis: { db: 3 } });
+		expect(cacher.opts).toEqual({ prefix: null, keygen: null, maxParamsLength: null, ttl: 80, pingInterval: null, redis: { db: 3 } });
 	});
 
 	it("should resolve RedisCacher from connection string", () => {

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -161,7 +161,7 @@ describe("Test RedisCacher cluster", () => {
 		expect(cacher.serializer).toBeInstanceOf(Serializers.Notepack);
 	});
 
-	it("should ping based on interval", () => {
+	it("should ping based on numeric interval", () => {
 		jest.useFakeTimers();
 		let broker = new ServiceBroker({ logger: false });
 
@@ -181,6 +181,56 @@ describe("Test RedisCacher cluster", () => {
 		expect(cacher.client.ping).toHaveBeenCalledTimes(2);
 		jest.advanceTimersByTime(25);
 		expect(cacher.client.ping).toHaveBeenCalledTimes(3);
+
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	});
+
+	it("should ping based on numeric string interval", () => {
+		jest.useFakeTimers();
+		let broker = new ServiceBroker({ logger: false });
+
+		let opts = {
+			type: "Redis",
+			pingInterval: "25",
+		};
+
+		let cacher = new RedisCacher(opts);
+		expect(cacher).toBeDefined();
+		cacher.init(broker);
+		cacher.client.ping = jest.fn().mockResolvedValue(undefined);
+
+		jest.advanceTimersByTime(25);
+		expect(cacher.client.ping).toHaveBeenCalledTimes(1);
+		jest.advanceTimersByTime(25);
+		expect(cacher.client.ping).toHaveBeenCalledTimes(2);
+		jest.advanceTimersByTime(25);
+		expect(cacher.client.ping).toHaveBeenCalledTimes(3);
+
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	});
+
+	it("should not ping with malformed pingInterval", () => {
+		jest.useFakeTimers();
+		let broker = new ServiceBroker({ logger: false });
+
+		let opts = {
+			type: "Redis",
+			pingInterval: "foo",
+		};
+
+		let cacher = new RedisCacher(opts);
+		expect(cacher).toBeDefined();
+		cacher.init(broker);
+		cacher.client.ping = jest.fn().mockResolvedValue(undefined);
+
+		jest.advanceTimersByTime(25);
+		expect(cacher.client.ping).toHaveBeenCalledTimes(0);
+		jest.advanceTimersByTime(25);
+		expect(cacher.client.ping).toHaveBeenCalledTimes(0);
+		jest.advanceTimersByTime(25);
+		expect(cacher.client.ping).toHaveBeenCalledTimes(0);
 
 		jest.clearAllTimers();
 		jest.useRealTimers();


### PR DESCRIPTION
## :memo: Description

This PR adds a new option `pingInterval` to the `RedisCacher`.  If this option is set, it will send a PING command to the Redis server every `pingInterval` milliseconds.  The intention is for this to keep traffic active on the connection to avoid idle timeouts introduced by services like Azure Cache for Redis.  

### :dart: Relevant issues
<!-- Please add relevant opened issues -->
N/A

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update


## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested in production environment as well as new unit tests.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
