### PR TITLE
Update NATS transporter messages to debug

### DIFF
--- a/src/transporters/nats.js
+++ b/src/transporters/nats.js
@@ -152,7 +152,7 @@ class NatsTransporter extends Transporter {
 
 				(async () => {
 					for await (const s of this.client.status()) {
-						this.logger.info(`NATS client ${s.type}: ${s.data}`);
+						this.logger.debug(`NATS client ${s.type}: ${s.data}`);
 					}
 				})().then();
 


### PR DESCRIPTION
Changes NATS transporter client messages to `debug` instead of `info`.

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/962#issue-941955430

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

`npm run test` has been run successfully.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code