### PR TITLE
fix: ActionParamTypes should accept string type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ declare namespace Moleculer {
 		| "url"
 		| "uuid"
 		| boolean
+		| string
 		| ActionParamSchema;
 	type ActionParams = { [key: string]: ActionParamTypes };
 
@@ -746,6 +747,7 @@ declare namespace Moleculer {
 		 * @param timeout The total time this call may take. If this time has passed and the service(s)
 		 * 						    are not available an error will be thrown. (In milliseconds)
 		 * @param interval The time we will wait before once again checking if the service(s) are available (In milliseconds)
+		 * @param logger the broker logger instance
 		 */
 		waitForServices(serviceNames: string | Array<string> | Array<ServiceDependency>, timeout?: number, interval?: number, logger?: LoggerInstance): Promise<WaitForServicesResult>;
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->
```js
export default {
  name: 'test',
  actions: {
    demo: {
      params: {
        a: 'string|max:64'
      }
    }
  }
}
```
Above service config will trigger typescript error
>Type '"string|max:64"' is not comparable to type 'ActionParamTypes'.
because `type ActionParamTypes` missed `string` type (not `"string"`)
### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
