### PR TITLE
feat(validators): add default option for fastest

### DIFF
--- a/src/validators/fastest.js
+++ b/src/validators/fastest.js
@@ -14,6 +14,9 @@ const _ = require("lodash");
 class FastestValidator extends BaseValidator {
 	constructor(opts) {
 		super(opts);
+		this.opts = _.defaultsDeep(opts, {
+			useNewCustomCheckerFunction: true
+		});
 		this.validator = new Validator(this.opts);
 	}
 


### PR DESCRIPTION
add default option `useNewCustomCheckerFunction: true` for fastest, old custom method [deprecated](https://github.com/icebob/fastest-validator/blob/master/CHANGELOG.md#new-custom-function-signature)

#### TODO:

- [ ] adding tests new and old custom methods
- [ ] adding backward compatibility example
- [ ] update docs on site