### PR TITLE
Feature/issue 991 ensure error handler throws to the transit layer

### DIFF
--- a/src/middlewares/error-handler.js
+++ b/src/middlewares/error-handler.js
@@ -60,7 +60,7 @@ function wrapEventErrorHandler(handler) {
 					enumerable: false
 				});
 
-				// Call global errorHandler
+				// Call global errorHandler (may choose to resolve error)
 				return ctx.broker.errorHandler(err, {
 					ctx,
 					service: ctx.service,
@@ -68,8 +68,9 @@ function wrapEventErrorHandler(handler) {
 				});
 			})
 			.catch(err => {
-				// No global error Handler, or thrown further, so we handle it because it's an event handler.
+				// No global error Handler, or thrown further, log and re-throw. Pass responsibility to the transit layer.
 				ctx.broker.logger.error(err);
+        throw err;
 			});
 	}.bind(this);
 }

--- a/src/middlewares/error-handler.js
+++ b/src/middlewares/error-handler.js
@@ -70,7 +70,7 @@ function wrapEventErrorHandler(handler) {
 			.catch(err => {
 				// No global error Handler, or thrown further, log and re-throw. Pass responsibility to the transit layer.
 				ctx.broker.logger.error(err);
-        throw err;
+				throw err;
 			});
 	}.bind(this);
 }

--- a/test/unit/middlewares/error-handler.spec.js
+++ b/test/unit/middlewares/error-handler.spec.js
@@ -5,206 +5,232 @@ const Middleware = require("../../../src/middlewares").ErrorHandler;
 const { protectReject } = require("../utils");
 
 describe("Test ErrorHandlerMiddleware", () => {
-	const broker = new ServiceBroker({ nodeID: "server-1", logger: false, transporter: "Fake" });
-	const actionHandler = jest.fn(() => Promise.resolve("Result"));
-	const eventHandler = jest.fn(() => Promise.resolve("Result"));
-	const action = {
-		name: "posts.find",
-		handler: actionHandler,
-		service: {
-			name: "posts",
-			fullName: "posts"
-		}
-	};
+  const broker = new ServiceBroker({ nodeID: "server-1", logger: false, transporter: "Fake" });
+  const actionHandler = jest.fn(() => Promise.resolve("Result"));
+  const eventHandler = jest.fn(() => Promise.resolve("Result"));
+  const action = {
+    name: "posts.find",
+    handler: actionHandler,
+    service: {
+      name: "posts",
+      fullName: "posts"
+    }
+  };
 
-	const event = {
-		name: "post.created",
-		handler: eventHandler,
-		service: {
-			name: "posts",
-			fullName: "posts"
-		}
-	};
+  const event = {
+    name: "post.created",
+    handler: eventHandler,
+    service: {
+      name: "posts",
+      fullName: "posts"
+    }
+  };
 
-	const actionEndpoint = {
-		action,
-		node: {
-			id: broker.nodeID
-		}
-	};
+  const actionEndpoint = {
+    action,
+    node: {
+      id: broker.nodeID
+    }
+  };
 
-	const eventEndpoint = {
-		event,
-		node: {
-			id: broker.nodeID
-		}
-	};
+  const eventEndpoint = {
+    event,
+    node: {
+      id: broker.nodeID
+    }
+  };
 
-	broker.errorHandler = jest.fn(err => Promise.reject(err));
+  broker.errorHandler = jest.fn(err => Promise.reject(err));
 
-	const mw = Middleware(broker);
+  const mw = Middleware(broker);
 
-	it("should register hooks", () => {
-		expect(mw.localAction).toBeInstanceOf(Function);
-		expect(mw.remoteAction).toBeInstanceOf(Function);
-	});
+  it("should register hooks", () => {
+    expect(mw.localAction).toBeInstanceOf(Function);
+    expect(mw.remoteAction).toBeInstanceOf(Function);
+  });
 
-	it("should wrap handler", () => {
-		const newHandler = mw.localAction.call(broker, actionHandler, action);
-		expect(newHandler).not.toBe(actionHandler);
+  it("should wrap handler", () => {
+    const newHandler = mw.localAction.call(broker, actionHandler, action);
+    expect(newHandler).not.toBe(actionHandler);
 
-		const newHandler2 = mw.remoteAction.call(broker, actionHandler, action);
-		expect(newHandler2).not.toBe(actionHandler);
+    const newHandler2 = mw.remoteAction.call(broker, actionHandler, action);
+    expect(newHandler2).not.toBe(actionHandler);
 
-		const newHandler3 = mw.localEvent.call(broker, eventHandler, event);
-		expect(newHandler3).not.toBe(eventHandler);
-	});
+    const newHandler3 = mw.localEvent.call(broker, eventHandler, event);
+    expect(newHandler3).not.toBe(eventHandler);
+  });
 
-	describe("Test with actions", () => {
-		it("should call broker errorHandler", () => {
-			broker.errorHandler.mockClear();
-			const error = new MoleculerError("Something wrong");
-			let handler = jest.fn(() => Promise.reject(error));
+  describe("Test with actions", () => {
+    it("should call broker errorHandler", () => {
+      broker.errorHandler.mockClear();
+      const error = new MoleculerError("Something wrong");
+      let handler = jest.fn(() => Promise.reject(error));
 
-			const newHandler = mw.localAction.call(broker, handler, action);
-			const ctx = Context.create(broker, actionEndpoint);
+      const newHandler = mw.localAction.call(broker, handler, action);
+      const ctx = Context.create(broker, actionEndpoint);
 
-			return newHandler(ctx)
-				.then(protectReject)
-				.catch(err => {
-					expect(err).toBeInstanceOf(MoleculerError);
-					expect(err.name).toBe("MoleculerError");
-					expect(err.message).toBe("Something wrong");
-					expect(err.ctx).toBe(ctx);
+      return newHandler(ctx)
+        .then(protectReject)
+        .catch(err => {
+          expect(err).toBeInstanceOf(MoleculerError);
+          expect(err.name).toBe("MoleculerError");
+          expect(err.message).toBe("Something wrong");
+          expect(err.ctx).toBe(ctx);
 
-					expect(broker.errorHandler).toBeCalledTimes(1);
-					expect(broker.errorHandler).toBeCalledWith(err, {
-						ctx,
-						service: action.service,
-						action
-					});
-				});
-		});
+          expect(broker.errorHandler).toBeCalledTimes(1);
+          expect(broker.errorHandler).toBeCalledWith(err, {
+            ctx,
+            service: action.service,
+            action
+          });
+        });
+    });
 
-		it("should convert if not Error", () => {
-			broker.errorHandler.mockClear();
-			let handler = jest.fn(() => Promise.reject("Something wrong"));
+    it("should convert if not Error", () => {
+      broker.errorHandler.mockClear();
+      let handler = jest.fn(() => Promise.reject("Something wrong"));
 
-			const newHandler = mw.localAction.call(broker, handler, action);
-			const ctx = Context.create(broker, actionEndpoint);
+      const newHandler = mw.localAction.call(broker, handler, action);
+      const ctx = Context.create(broker, actionEndpoint);
 
-			return newHandler(ctx)
-				.then(protectReject)
-				.catch(err => {
-					expect(err).toBeInstanceOf(Error);
-					expect(err).toBeInstanceOf(MoleculerError);
-					expect(err.name).toBe("MoleculerError");
-					expect(err.message).toBe("Something wrong");
-					expect(err.ctx).toBe(ctx);
+      return newHandler(ctx)
+        .then(protectReject)
+        .catch(err => {
+          expect(err).toBeInstanceOf(Error);
+          expect(err).toBeInstanceOf(MoleculerError);
+          expect(err.name).toBe("MoleculerError");
+          expect(err.message).toBe("Something wrong");
+          expect(err.ctx).toBe(ctx);
 
-					expect(broker.errorHandler).toBeCalledTimes(1);
-					expect(broker.errorHandler).toBeCalledWith(err, {
-						ctx,
-						service: action.service,
-						action
-					});
-				});
-		});
+          expect(broker.errorHandler).toBeCalledTimes(1);
+          expect(broker.errorHandler).toBeCalledWith(err, {
+            ctx,
+            service: action.service,
+            action
+          });
+        });
+    });
 
-		it("should remove pending request if remote call", () => {
-			let error = new MoleculerError("Some error");
-			let handler = jest.fn(() => Promise.reject(error));
-			broker.transit.removePendingRequest = jest.fn();
+    it("should remove pending request if remote call", () => {
+      let error = new MoleculerError("Some error");
+      let handler = jest.fn(() => Promise.reject(error));
+      broker.transit.removePendingRequest = jest.fn();
 
-			const newHandler = mw.localAction.call(broker, handler, action);
-			const ctx = Context.create(broker, actionEndpoint);
-			ctx.id = "123456";
-			ctx.nodeID = "server-2";
+      const newHandler = mw.localAction.call(broker, handler, action);
+      const ctx = Context.create(broker, actionEndpoint);
+      ctx.id = "123456";
+      ctx.nodeID = "server-2";
 
-			return newHandler(ctx)
-				.then(protectReject)
-				.catch(err => {
-					expect(err).toBe(error);
-					expect(err.ctx).toBe(ctx);
+      return newHandler(ctx)
+        .then(protectReject)
+        .catch(err => {
+          expect(err).toBe(error);
+          expect(err.ctx).toBe(ctx);
 
-					expect(broker.transit.removePendingRequest).toHaveBeenCalledTimes(1);
-					expect(broker.transit.removePendingRequest).toHaveBeenCalledWith("123456");
-				});
-		});
-	});
+          expect(broker.transit.removePendingRequest).toHaveBeenCalledTimes(1);
+          expect(broker.transit.removePendingRequest).toHaveBeenCalledWith("123456");
+        });
+    });
+  });
 
-	describe("Test with events", () => {
-		it("should call broker errorHandler", () => {
-			broker.errorHandler.mockClear();
-			const error = new MoleculerError("Something wrong");
-			let handler = jest.fn(() => Promise.reject(error));
+  describe("Test with events", () => {
+    it("should call broker errorHandler", () => {
+      broker.errorHandler.mockClear();
+      const error = new MoleculerError("Something wrong");
+      let handler = jest.fn(() => Promise.reject(error));
 
-			const newHandler = mw.localEvent.call(broker, handler, event);
-			const ctx = Context.create(broker, eventEndpoint);
+      const newHandler = mw.localEvent.call(broker, handler, event);
+      const ctx = Context.create(broker, eventEndpoint);
 
-			return newHandler(ctx)
-				.catch(protectReject)
-				.then(() => {
-					expect(error.ctx).toBe(ctx);
-					expect(broker.errorHandler).toBeCalledTimes(1);
-					expect(broker.errorHandler).toBeCalledWith(error, {
-						ctx,
-						service: action.service,
-						event
-					});
-				});
-		});
+      return newHandler(ctx)
+        .then(() => { fail('error should be thrown to the transit message handler') })
+        .catch((err) => {
+          expect(error.ctx).toBe(ctx);
+          expect(broker.errorHandler).toBeCalledTimes(1);
+          expect(broker.errorHandler).toBeCalledWith(err, {
+            ctx,
+            service: action.service,
+            event
+          });
+        });
+    });
 
-		it("should convert if not Error", () => {
-			broker.errorHandler.mockClear();
-			let handler = jest.fn(() => Promise.reject("Something wrong"));
+    it("should convert if not Error", () => {
+      broker.errorHandler.mockClear();
+      let handler = jest.fn(() => Promise.reject("Something wrong"));
 
-			const newHandler = mw.localEvent.call(broker, handler, action);
-			const ctx = Context.create(broker, eventEndpoint);
+      const newHandler = mw.localEvent.call(broker, handler, action);
+      const ctx = Context.create(broker, eventEndpoint);
 
-			return newHandler(ctx)
-				.catch(protectReject)
-				.then(() => {
-					const err = broker.errorHandler.mock.calls[0][0];
+      return newHandler(ctx)
+        .then(() => { fail('error should be thrown to the transit message handler') })
+        .catch((err) => {
+          expect(err).toBeInstanceOf(Error);
+          expect(err).toBeInstanceOf(MoleculerError);
+          expect(err.name).toBe("MoleculerError");
+          expect(err.message).toBe("Something wrong");
+          expect(err.ctx).toBe(ctx);
 
-					expect(err).toBeInstanceOf(Error);
-					expect(err).toBeInstanceOf(MoleculerError);
-					expect(err.name).toBe("MoleculerError");
-					expect(err.message).toBe("Something wrong");
-					expect(err.ctx).toBe(ctx);
+          expect(broker.errorHandler).toBeCalledTimes(1);
+          expect(broker.errorHandler).toBeCalledWith(err, {
+            ctx,
+            service: action.service,
+            event
+          });
+        });
+    });
 
-					expect(broker.errorHandler).toBeCalledTimes(1);
-					expect(broker.errorHandler).toBeCalledWith(err, {
-						ctx,
-						service: action.service,
-						event
-					});
-				});
-		});
+    it("should logging if throw further", () => {
+      broker.errorHandler = jest.fn(err => Promise.reject(err));
+      let error = new MoleculerError("Some error");
+      let handler = jest.fn(() => Promise.reject(error));
 
-		it("should logging if throw further", () => {
-			broker.errorHandler = jest.fn(err => Promise.reject(err));
-			let error = new MoleculerError("Some error");
-			let handler = jest.fn(() => Promise.reject(error));
+      const newHandler = mw.localEvent.call(broker, handler, action);
+      const ctx = Context.create(broker, eventEndpoint);
+      ctx.id = "123456";
+      ctx.nodeID = "server-2";
 
-			const newHandler = mw.localEvent.call(broker, handler, action);
-			const ctx = Context.create(broker, eventEndpoint);
-			ctx.id = "123456";
-			ctx.nodeID = "server-2";
+      jest.spyOn(broker.logger, "error");
 
-			jest.spyOn(broker.logger, "error");
+      return newHandler(ctx)
+        .then(() => { fail('error should be thrown to the transit message handler') })
+        .catch((err) => {
 
-			return newHandler(ctx)
-				.catch(protectReject)
-				.then(() => {
-					const err = broker.errorHandler.mock.calls[0][0];
+          expect(err).toBe(error);
+          expect(err.ctx).toBe(ctx);
 
-					expect(err).toBe(error);
-					expect(err.ctx).toBe(ctx);
+          expect(broker.logger.error).toHaveBeenCalledTimes(1);
+          expect(broker.logger.error).toHaveBeenCalledWith(err);
+        });
+    });
 
-					expect(broker.logger.error).toHaveBeenCalledTimes(1);
-					expect(broker.logger.error).toHaveBeenCalledWith(err);
-				});
-		});
-	});
+    describe('if the error handler resolves the error', () => {
+      beforeEach(() => {
+        broker.errorHandler = jest.fn(() => Promise.resolve(true));
+      });
+
+      it('should return the response from the error handler', () => {
+        let error = new MoleculerError("Some error");
+        let handler = jest.fn(() => Promise.reject(error));
+
+        const newHandler = mw.localEvent.call(broker, handler, action);
+        const ctx = Context.create(broker, eventEndpoint);
+        ctx.id = "123456";
+        ctx.nodeID = "server-2";
+
+
+        return newHandler(ctx)
+          .then((res) => {
+            expect(res).toBe(true);
+            expect(error.ctx).toBe(ctx);
+            expect(broker.errorHandler).toBeCalledTimes(1);
+            expect(broker.errorHandler).toBeCalledWith(error, {
+              ctx,
+              service: action.service,
+              event
+            });
+          })
+      });
+    });
+  });
 });

--- a/test/unit/middlewares/error-handler.spec.js
+++ b/test/unit/middlewares/error-handler.spec.js
@@ -5,232 +5,232 @@ const Middleware = require("../../../src/middlewares").ErrorHandler;
 const { protectReject } = require("../utils");
 
 describe("Test ErrorHandlerMiddleware", () => {
-  const broker = new ServiceBroker({ nodeID: "server-1", logger: false, transporter: "Fake" });
-  const actionHandler = jest.fn(() => Promise.resolve("Result"));
-  const eventHandler = jest.fn(() => Promise.resolve("Result"));
-  const action = {
-    name: "posts.find",
-    handler: actionHandler,
-    service: {
-      name: "posts",
-      fullName: "posts"
-    }
-  };
+	const broker = new ServiceBroker({ nodeID: "server-1", logger: false, transporter: "Fake" });
+	const actionHandler = jest.fn(() => Promise.resolve("Result"));
+	const eventHandler = jest.fn(() => Promise.resolve("Result"));
+	const action = {
+		name: "posts.find",
+		handler: actionHandler,
+		service: {
+			name: "posts",
+			fullName: "posts"
+		}
+	};
 
-  const event = {
-    name: "post.created",
-    handler: eventHandler,
-    service: {
-      name: "posts",
-      fullName: "posts"
-    }
-  };
+	const event = {
+		name: "post.created",
+		handler: eventHandler,
+		service: {
+			name: "posts",
+			fullName: "posts"
+		}
+	};
 
-  const actionEndpoint = {
-    action,
-    node: {
-      id: broker.nodeID
-    }
-  };
+	const actionEndpoint = {
+		action,
+		node: {
+			id: broker.nodeID
+		}
+	};
 
-  const eventEndpoint = {
-    event,
-    node: {
-      id: broker.nodeID
-    }
-  };
+	const eventEndpoint = {
+		event,
+		node: {
+			id: broker.nodeID
+		}
+	};
 
-  broker.errorHandler = jest.fn(err => Promise.reject(err));
+	broker.errorHandler = jest.fn(err => Promise.reject(err));
 
-  const mw = Middleware(broker);
+	const mw = Middleware(broker);
 
-  it("should register hooks", () => {
-    expect(mw.localAction).toBeInstanceOf(Function);
-    expect(mw.remoteAction).toBeInstanceOf(Function);
-  });
+	it("should register hooks", () => {
+		expect(mw.localAction).toBeInstanceOf(Function);
+		expect(mw.remoteAction).toBeInstanceOf(Function);
+	});
 
-  it("should wrap handler", () => {
-    const newHandler = mw.localAction.call(broker, actionHandler, action);
-    expect(newHandler).not.toBe(actionHandler);
+	it("should wrap handler", () => {
+		const newHandler = mw.localAction.call(broker, actionHandler, action);
+		expect(newHandler).not.toBe(actionHandler);
 
-    const newHandler2 = mw.remoteAction.call(broker, actionHandler, action);
-    expect(newHandler2).not.toBe(actionHandler);
+		const newHandler2 = mw.remoteAction.call(broker, actionHandler, action);
+		expect(newHandler2).not.toBe(actionHandler);
 
-    const newHandler3 = mw.localEvent.call(broker, eventHandler, event);
-    expect(newHandler3).not.toBe(eventHandler);
-  });
+		const newHandler3 = mw.localEvent.call(broker, eventHandler, event);
+		expect(newHandler3).not.toBe(eventHandler);
+	});
 
-  describe("Test with actions", () => {
-    it("should call broker errorHandler", () => {
-      broker.errorHandler.mockClear();
-      const error = new MoleculerError("Something wrong");
-      let handler = jest.fn(() => Promise.reject(error));
+	describe("Test with actions", () => {
+		it("should call broker errorHandler", () => {
+			broker.errorHandler.mockClear();
+			const error = new MoleculerError("Something wrong");
+			let handler = jest.fn(() => Promise.reject(error));
 
-      const newHandler = mw.localAction.call(broker, handler, action);
-      const ctx = Context.create(broker, actionEndpoint);
+			const newHandler = mw.localAction.call(broker, handler, action);
+			const ctx = Context.create(broker, actionEndpoint);
 
-      return newHandler(ctx)
-        .then(protectReject)
-        .catch(err => {
-          expect(err).toBeInstanceOf(MoleculerError);
-          expect(err.name).toBe("MoleculerError");
-          expect(err.message).toBe("Something wrong");
-          expect(err.ctx).toBe(ctx);
+			return newHandler(ctx)
+				.then(protectReject)
+				.catch(err => {
+					expect(err).toBeInstanceOf(MoleculerError);
+					expect(err.name).toBe("MoleculerError");
+					expect(err.message).toBe("Something wrong");
+					expect(err.ctx).toBe(ctx);
 
-          expect(broker.errorHandler).toBeCalledTimes(1);
-          expect(broker.errorHandler).toBeCalledWith(err, {
-            ctx,
-            service: action.service,
-            action
-          });
-        });
-    });
+					expect(broker.errorHandler).toBeCalledTimes(1);
+					expect(broker.errorHandler).toBeCalledWith(err, {
+						ctx,
+						service: action.service,
+						action
+					});
+				});
+		});
 
-    it("should convert if not Error", () => {
-      broker.errorHandler.mockClear();
-      let handler = jest.fn(() => Promise.reject("Something wrong"));
+		it("should convert if not Error", () => {
+			broker.errorHandler.mockClear();
+			let handler = jest.fn(() => Promise.reject("Something wrong"));
 
-      const newHandler = mw.localAction.call(broker, handler, action);
-      const ctx = Context.create(broker, actionEndpoint);
+			const newHandler = mw.localAction.call(broker, handler, action);
+			const ctx = Context.create(broker, actionEndpoint);
 
-      return newHandler(ctx)
-        .then(protectReject)
-        .catch(err => {
-          expect(err).toBeInstanceOf(Error);
-          expect(err).toBeInstanceOf(MoleculerError);
-          expect(err.name).toBe("MoleculerError");
-          expect(err.message).toBe("Something wrong");
-          expect(err.ctx).toBe(ctx);
+			return newHandler(ctx)
+				.then(protectReject)
+				.catch(err => {
+					expect(err).toBeInstanceOf(Error);
+					expect(err).toBeInstanceOf(MoleculerError);
+					expect(err.name).toBe("MoleculerError");
+					expect(err.message).toBe("Something wrong");
+					expect(err.ctx).toBe(ctx);
 
-          expect(broker.errorHandler).toBeCalledTimes(1);
-          expect(broker.errorHandler).toBeCalledWith(err, {
-            ctx,
-            service: action.service,
-            action
-          });
-        });
-    });
+					expect(broker.errorHandler).toBeCalledTimes(1);
+					expect(broker.errorHandler).toBeCalledWith(err, {
+						ctx,
+						service: action.service,
+						action
+					});
+				});
+		});
 
-    it("should remove pending request if remote call", () => {
-      let error = new MoleculerError("Some error");
-      let handler = jest.fn(() => Promise.reject(error));
-      broker.transit.removePendingRequest = jest.fn();
+		it("should remove pending request if remote call", () => {
+			let error = new MoleculerError("Some error");
+			let handler = jest.fn(() => Promise.reject(error));
+			broker.transit.removePendingRequest = jest.fn();
 
-      const newHandler = mw.localAction.call(broker, handler, action);
-      const ctx = Context.create(broker, actionEndpoint);
-      ctx.id = "123456";
-      ctx.nodeID = "server-2";
+			const newHandler = mw.localAction.call(broker, handler, action);
+			const ctx = Context.create(broker, actionEndpoint);
+			ctx.id = "123456";
+			ctx.nodeID = "server-2";
 
-      return newHandler(ctx)
-        .then(protectReject)
-        .catch(err => {
-          expect(err).toBe(error);
-          expect(err.ctx).toBe(ctx);
+			return newHandler(ctx)
+				.then(protectReject)
+				.catch(err => {
+					expect(err).toBe(error);
+					expect(err.ctx).toBe(ctx);
 
-          expect(broker.transit.removePendingRequest).toHaveBeenCalledTimes(1);
-          expect(broker.transit.removePendingRequest).toHaveBeenCalledWith("123456");
-        });
-    });
-  });
+					expect(broker.transit.removePendingRequest).toHaveBeenCalledTimes(1);
+					expect(broker.transit.removePendingRequest).toHaveBeenCalledWith("123456");
+				});
+		});
+	});
 
-  describe("Test with events", () => {
-    it("should call broker errorHandler", () => {
-      broker.errorHandler.mockClear();
-      const error = new MoleculerError("Something wrong");
-      let handler = jest.fn(() => Promise.reject(error));
+	describe("Test with events", () => {
+		it("should call broker errorHandler", () => {
+			broker.errorHandler.mockClear();
+			const error = new MoleculerError("Something wrong");
+			let handler = jest.fn(() => Promise.reject(error));
 
-      const newHandler = mw.localEvent.call(broker, handler, event);
-      const ctx = Context.create(broker, eventEndpoint);
+			const newHandler = mw.localEvent.call(broker, handler, event);
+			const ctx = Context.create(broker, eventEndpoint);
 
-      return newHandler(ctx)
-        .then(() => { fail('error should be thrown to the transit message handler') })
-        .catch((err) => {
-          expect(error.ctx).toBe(ctx);
-          expect(broker.errorHandler).toBeCalledTimes(1);
-          expect(broker.errorHandler).toBeCalledWith(err, {
-            ctx,
-            service: action.service,
-            event
-          });
-        });
-    });
+			return newHandler(ctx)
+				.then(() => { fail('error should be thrown to the transit message handler') })
+				.catch((err) => {
+					expect(error.ctx).toBe(ctx);
+					expect(broker.errorHandler).toBeCalledTimes(1);
+					expect(broker.errorHandler).toBeCalledWith(err, {
+						ctx,
+						service: action.service,
+						event
+					});
+				});
+		});
 
-    it("should convert if not Error", () => {
-      broker.errorHandler.mockClear();
-      let handler = jest.fn(() => Promise.reject("Something wrong"));
+		it("should convert if not Error", () => {
+			broker.errorHandler.mockClear();
+			let handler = jest.fn(() => Promise.reject("Something wrong"));
 
-      const newHandler = mw.localEvent.call(broker, handler, action);
-      const ctx = Context.create(broker, eventEndpoint);
+			const newHandler = mw.localEvent.call(broker, handler, action);
+			const ctx = Context.create(broker, eventEndpoint);
 
-      return newHandler(ctx)
-        .then(() => { fail('error should be thrown to the transit message handler') })
-        .catch((err) => {
-          expect(err).toBeInstanceOf(Error);
-          expect(err).toBeInstanceOf(MoleculerError);
-          expect(err.name).toBe("MoleculerError");
-          expect(err.message).toBe("Something wrong");
-          expect(err.ctx).toBe(ctx);
+			return newHandler(ctx)
+				.then(() => { fail('error should be thrown to the transit message handler') })
+				.catch((err) => {
+					expect(err).toBeInstanceOf(Error);
+					expect(err).toBeInstanceOf(MoleculerError);
+					expect(err.name).toBe("MoleculerError");
+					expect(err.message).toBe("Something wrong");
+					expect(err.ctx).toBe(ctx);
 
-          expect(broker.errorHandler).toBeCalledTimes(1);
-          expect(broker.errorHandler).toBeCalledWith(err, {
-            ctx,
-            service: action.service,
-            event
-          });
-        });
-    });
+					expect(broker.errorHandler).toBeCalledTimes(1);
+					expect(broker.errorHandler).toBeCalledWith(err, {
+						ctx,
+						service: action.service,
+						event
+					});
+				});
+		});
 
-    it("should logging if throw further", () => {
-      broker.errorHandler = jest.fn(err => Promise.reject(err));
-      let error = new MoleculerError("Some error");
-      let handler = jest.fn(() => Promise.reject(error));
+		it("should logging if throw further", () => {
+			broker.errorHandler = jest.fn(err => Promise.reject(err));
+			let error = new MoleculerError("Some error");
+			let handler = jest.fn(() => Promise.reject(error));
 
-      const newHandler = mw.localEvent.call(broker, handler, action);
-      const ctx = Context.create(broker, eventEndpoint);
-      ctx.id = "123456";
-      ctx.nodeID = "server-2";
+			const newHandler = mw.localEvent.call(broker, handler, action);
+			const ctx = Context.create(broker, eventEndpoint);
+			ctx.id = "123456";
+			ctx.nodeID = "server-2";
 
-      jest.spyOn(broker.logger, "error");
+			jest.spyOn(broker.logger, "error");
 
-      return newHandler(ctx)
-        .then(() => { fail('error should be thrown to the transit message handler') })
-        .catch((err) => {
+			return newHandler(ctx)
+				.then(() => { fail('error should be thrown to the transit message handler') })
+				.catch((err) => {
 
-          expect(err).toBe(error);
-          expect(err.ctx).toBe(ctx);
+					expect(err).toBe(error);
+					expect(err.ctx).toBe(ctx);
 
-          expect(broker.logger.error).toHaveBeenCalledTimes(1);
-          expect(broker.logger.error).toHaveBeenCalledWith(err);
-        });
-    });
+					expect(broker.logger.error).toHaveBeenCalledTimes(1);
+					expect(broker.logger.error).toHaveBeenCalledWith(err);
+				});
+		});
 
-    describe('if the error handler resolves the error', () => {
-      beforeEach(() => {
-        broker.errorHandler = jest.fn(() => Promise.resolve(true));
-      });
+		describe('if the error handler resolves the error', () => {
+			beforeEach(() => {
+				broker.errorHandler = jest.fn(() => Promise.resolve(true));
+			});
 
-      it('should return the response from the error handler', () => {
-        let error = new MoleculerError("Some error");
-        let handler = jest.fn(() => Promise.reject(error));
+			it('should return the response from the error handler', () => {
+				let error = new MoleculerError("Some error");
+				let handler = jest.fn(() => Promise.reject(error));
 
-        const newHandler = mw.localEvent.call(broker, handler, action);
-        const ctx = Context.create(broker, eventEndpoint);
-        ctx.id = "123456";
-        ctx.nodeID = "server-2";
+				const newHandler = mw.localEvent.call(broker, handler, action);
+				const ctx = Context.create(broker, eventEndpoint);
+				ctx.id = "123456";
+				ctx.nodeID = "server-2";
 
 
-        return newHandler(ctx)
-          .then((res) => {
-            expect(res).toBe(true);
-            expect(error.ctx).toBe(ctx);
-            expect(broker.errorHandler).toBeCalledTimes(1);
-            expect(broker.errorHandler).toBeCalledWith(error, {
-              ctx,
-              service: action.service,
-              event
-            });
-          })
-      });
-    });
-  });
+				return newHandler(ctx)
+					.then((res) => {
+						expect(res).toBe(true);
+						expect(error.ctx).toBe(ctx);
+						expect(broker.errorHandler).toBeCalledTimes(1);
+						expect(broker.errorHandler).toBeCalledWith(error, {
+							ctx,
+							service: action.service,
+							event
+						});
+					})
+			});
+		});
+	});
 });


### PR DESCRIPTION
## :memo: Description
Error-handler should re-throw an event error to ensure the messageHandler can return the correct result to the transporter.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
