### PR TITLE
add cache keygen to service action

### DIFF
--- a/src/cachers/base.js
+++ b/src/cachers/base.js
@@ -293,14 +293,17 @@ class Cacher {
 	 * Get a cache key by name and params.
 	 * Concatenate the name and the hashed params object
 	 *
-	 * @param {String} name
+	 * @param {String} actionName
 	 * @param {Object} params
 	 * @param {Object} meta
 	 * @param {Array|null} keys
+	 * @param {function?} actionKeygen
 	 * @returns {String}
 	 */
-	getCacheKey(actionName, params, meta, keys) {
-		if (isFunction(this.opts.keygen))
+	getCacheKey(actionName, params, meta, keys, actionKeygen) {
+		if (isFunction(actionKeygen))
+			return actionKeygen.call(this, actionName, params, meta, keys);
+		else if (isFunction(this.opts.keygen))
 			return this.opts.keygen.call(this, actionName, params, meta, keys);
 		else return this.defaultKeygen(actionName, params, meta, keys);
 	}
@@ -343,7 +346,13 @@ class Cacher {
 						return handler(ctx);
 					}
 
-					const cacheKey = this.getCacheKey(action.name, ctx.params, ctx.meta, opts.keys);
+					const cacheKey = this.getCacheKey(
+						action.name,
+						ctx.params,
+						ctx.meta,
+						opts.keys,
+						opts.keygen
+					);
 					// Using lock
 					if (opts.lock.enabled !== false) {
 						let cachePromise;

--- a/test/unit/cachers/base.spec.js
+++ b/test/unit/cachers/base.spec.js
@@ -299,20 +299,25 @@ describe("Test BaseCacher", () => {
 	it("check getCacheKey with custom keygen", () => {
 		let broker = new ServiceBroker({ logger: false });
 		let keygen = jest.fn(() => "custom");
+		let actionKeygen = jest.fn(() => "actionKeygen");
 		let cacher = new Cacher({ keygen });
 
 		cacher.init(broker);
 
-		let res = cacher.getCacheKey("posts.find.model", { limit: 5 }, { user: "bob" }, [
-			"limit",
-			"#user"
-		]);
-		expect(res).toBe("custom");
+		const actionName = "posts.find.model";
+		const params = { limit: 5 };
+		const meta = { user: "bob" };
+		const keys = ["limit", "#user"];
+
+		expect(cacher.getCacheKey(actionName, params, meta, keys)).toBe("custom");
 		expect(keygen).toHaveBeenCalledTimes(1);
-		expect(keygen).toHaveBeenCalledWith("posts.find.model", { limit: 5 }, { user: "bob" }, [
-			"limit",
-			"#user"
-		]);
+		expect(keygen).toHaveBeenCalledWith(actionName, params, meta, keys);
+
+		expect(cacher.getCacheKey(actionName, params, meta, keys, actionKeygen)).toBe(
+			"actionKeygen"
+		);
+		expect(actionKeygen).toHaveBeenCalledTimes(1);
+		expect(actionKeygen).toHaveBeenCalledWith(actionName, params, meta, keys);
 	});
 });
 


### PR DESCRIPTION
allow define `keygen` in `action.cache` that override `cacher.defaultKeygen` and `cacher.keygen`
use case
```js
const serviceSchema = {
  actions: {
    find: {
      cache: {
        keygen(actionName, params, meta, defaultKeys) {
          // add meta.user._id to defaultKeys
          return this.defaultKeygen(actionName, params, meta, ['#user._id'].concat(defaultKeys))
        }
      }
    }
  }
}
```