### PR TITLE
Expose cacher & validator middlewares

### DIFF
--- a/dev/cache.js
+++ b/dev/cache.js
@@ -5,9 +5,9 @@ let ServiceBroker = require("../src/service-broker");
 
 // Create broker
 let broker = new ServiceBroker({
-	logLevel: "info",
+	logLevel: "debug",
 	cacher: {
-		type: "Redis",
+		type: "Memory",
 		options: {
 			max: 100,
 			ttl: 3
@@ -41,7 +41,7 @@ broker
 	.then(() => broker.call("greeter.hello", { name: "Moleculer" }, { meta: { $cache: false } }))
 
 	.then(async () => {
-		for (let i = 0; i < 1000; i++) {
+		/*for (let i = 0; i < 1000; i++) {
 			broker.cacher.set(`key-${i}`, i);
 			if (i % 10 == 0) {
 				broker.cacher.get(`key-${100}`);
@@ -50,14 +50,14 @@ broker
 				broker.cacher.get(`key-${400}`);
 				broker.cacher.get(`key-${300}`);
 			}
-		}
+		}*/
 
 		const keys = await broker.cacher.getCacheKeys();
 		broker.logger.info("Length:", keys.length);
 		broker.logger.info("keys:", keys);
 	})
 
-	.delay(5 * 1000)
+	.delay(35 * 1000)
 	.then(async () => {
 		broker.logger.info("=========================================");
 		const keys = await broker.cacher.getCacheKeys();

--- a/dev/mw-order.js
+++ b/dev/mw-order.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const { ServiceBroker, Middlewares } = require("../");
+
+Middlewares.MyMiddleware = {
+	name: "MyMiddleware",
+	localAction(next, action) {
+		return async ctx => {
+			ctx.broker.logger.info("MyMW before");
+			const res = await next(ctx);
+			ctx.broker.logger.info("MyMW after");
+			return res;
+		};
+	}
+};
+
+const broker = new ServiceBroker({
+	nodeID: "mw",
+	cacher: "Memory",
+	internalMiddlewares: false,
+	middlewares: ["Cacher", "ActionHook", "MyMiddleware"]
+});
+
+broker.createService({
+	name: "test",
+	actions: {
+		hello: {
+			cache: true,
+			hooks: {
+				before: ctx => ctx.broker.logger.info("  Hook before"),
+				after: (ctx, res) => {
+					ctx.broker.logger.info("  Hook after");
+					return res;
+				}
+			},
+			handler(ctx) {
+				broker.logger.info("    Call action");
+				return `Hello ${ctx.params.name}`;
+			}
+		}
+	}
+});
+
+broker.start().then(async () => {
+	broker.repl();
+
+	await broker.call("test.hello", { name: "John" });
+	await broker.call("test.hello", { name: "John" });
+	await broker.call("test.hello", { name: "John" });
+});

--- a/dev/mw-order.js
+++ b/dev/mw-order.js
@@ -2,7 +2,7 @@
 
 const { ServiceBroker, Middlewares } = require("../");
 
-Middlewares.MyMiddleware = {
+Middlewares.register("MyMiddleware", {
 	name: "MyMiddleware",
 	localAction(next, action) {
 		return async ctx => {
@@ -12,7 +12,7 @@ Middlewares.MyMiddleware = {
 			return res;
 		};
 	}
-};
+});
 
 const broker = new ServiceBroker({
 	nodeID: "mw",

--- a/src/cachers/base.js
+++ b/src/cachers/base.js
@@ -314,135 +314,142 @@ class Cacher {
 	 * @memberof Cacher
 	 */
 	middleware() {
-		return (handler, action) => {
-			const opts = _.defaultsDeep(
-				{},
-				isObject(action.cache) ? action.cache : { enabled: !!action.cache }
-			);
-			opts.lock = _.defaultsDeep(
-				{},
-				isObject(opts.lock) ? opts.lock : { enabled: !!opts.lock }
-			);
-			if (opts.enabled !== false) {
-				const isEnabledFunction = isFunction(opts.enabled);
+		return {
+			name: "Cacher",
+			localAction: (handler, action) => {
+				const opts = _.defaultsDeep(
+					{},
+					isObject(action.cache) ? action.cache : { enabled: !!action.cache }
+				);
+				opts.lock = _.defaultsDeep(
+					{},
+					isObject(opts.lock) ? opts.lock : { enabled: !!opts.lock }
+				);
+				if (opts.enabled !== false) {
+					const isEnabledFunction = isFunction(opts.enabled);
 
-				return function cacherMiddleware(ctx) {
-					if (isEnabledFunction) {
-						if (!opts.enabled.call(ctx.service, ctx)) {
-							// Cache is disabled. Call the handler only.
+					return function cacherMiddleware(ctx) {
+						if (isEnabledFunction) {
+							if (!opts.enabled.call(ctx.service, ctx)) {
+								// Cache is disabled. Call the handler only.
+								return handler(ctx);
+							}
+						}
+
+						// Disable caching with `ctx.meta.$cache = false`
+						if (ctx.meta["$cache"] === false) return handler(ctx);
+
+						// Cache is enabled but not in healthy state
+						// More info: https://github.com/moleculerjs/moleculer/issues/978
+						if (this.connected === false) {
+							this.logger.debug(
+								"Cacher is enabled but it is not connected at the moment... Calling the handler"
+							);
 							return handler(ctx);
 						}
-					}
 
-					// Disable caching with `ctx.meta.$cache = false`
-					if (ctx.meta["$cache"] === false) return handler(ctx);
-
-					// Cache is enabled but not in healthy state
-					// More info: https://github.com/moleculerjs/moleculer/issues/978
-					if (this.connected === false) {
-						this.logger.debug(
-							"Cacher is enabled but it is not connected at the moment... Calling the handler"
+						const cacheKey = this.getCacheKey(
+							action.name,
+							ctx.params,
+							ctx.meta,
+							opts.keys,
+							opts.keygen
 						);
-						return handler(ctx);
-					}
-
-					const cacheKey = this.getCacheKey(
-						action.name,
-						ctx.params,
-						ctx.meta,
-						opts.keys,
-						opts.keygen
-					);
-					// Using lock
-					if (opts.lock.enabled !== false) {
-						let cachePromise;
-						if (opts.lock.staleTime && this.getWithTTL) {
-							// If enable cache refresh
-							cachePromise = this.getWithTTL(cacheKey).then(({ data, ttl }) => {
-								if (data != null) {
-									if (opts.lock.staleTime && ttl && ttl < opts.lock.staleTime) {
-										// Cache is stale, try to refresh it.
-										this.tryLock(cacheKey, opts.lock.ttl)
-											.then(unlock => {
-												return handler(ctx)
-													.then(result => {
-														// Save the result to the cache and realse the lock.
-														return this.set(
-															cacheKey,
-															result,
-															opts.ttl
-														).then(() => unlock());
-													})
-													.catch((/*err*/) => {
-														return this.del(cacheKey).then(() =>
-															unlock()
-														);
-													});
-											})
-											.catch((/*err*/) => {
-												// The cache is refreshing on somewhere else.
-											});
+						// Using lock
+						if (opts.lock.enabled !== false) {
+							let cachePromise;
+							if (opts.lock.staleTime && this.getWithTTL) {
+								// If enable cache refresh
+								cachePromise = this.getWithTTL(cacheKey).then(({ data, ttl }) => {
+									if (data != null) {
+										if (
+											opts.lock.staleTime &&
+											ttl &&
+											ttl < opts.lock.staleTime
+										) {
+											// Cache is stale, try to refresh it.
+											this.tryLock(cacheKey, opts.lock.ttl)
+												.then(unlock => {
+													return handler(ctx)
+														.then(result => {
+															// Save the result to the cache and realse the lock.
+															return this.set(
+																cacheKey,
+																result,
+																opts.ttl
+															).then(() => unlock());
+														})
+														.catch((/*err*/) => {
+															return this.del(cacheKey).then(() =>
+																unlock()
+															);
+														});
+												})
+												.catch((/*err*/) => {
+													// The cache is refreshing on somewhere else.
+												});
+										}
 									}
-								}
-								return data;
-							});
-						} else {
-							cachePromise = this.get(cacheKey);
-						}
-						return cachePromise.then(data => {
-							if (data != null) {
-								// Found in the cache! Don't call handler, return with the content
-								ctx.cachedResult = true;
-								return data;
+									return data;
+								});
+							} else {
+								cachePromise = this.get(cacheKey);
 							}
-							// Not found in the cache! Acquire a lock
-							return this.lock(cacheKey, opts.lock.ttl).then(unlock => {
-								return this.get(cacheKey).then(content => {
-									if (content != null) {
-										// Cache found. Realse the lock and return the value.
-										ctx.cachedResult = true;
-										return unlock().then(() => {
-											return content;
-										});
-									}
-									// Call the handler
-									return handler(ctx)
-										.then(result => {
-											// Save the result to the cache and realse the lock.
-											this.set(cacheKey, result, opts.ttl).then(() =>
-												unlock()
-											);
-											return result;
-										})
-										.catch(e => {
+							return cachePromise.then(data => {
+								if (data != null) {
+									// Found in the cache! Don't call handler, return with the content
+									ctx.cachedResult = true;
+									return data;
+								}
+								// Not found in the cache! Acquire a lock
+								return this.lock(cacheKey, opts.lock.ttl).then(unlock => {
+									return this.get(cacheKey).then(content => {
+										if (content != null) {
+											// Cache found. Realse the lock and return the value.
+											ctx.cachedResult = true;
 											return unlock().then(() => {
-												return Promise.reject(e);
+												return content;
 											});
-										});
+										}
+										// Call the handler
+										return handler(ctx)
+											.then(result => {
+												// Save the result to the cache and realse the lock.
+												this.set(cacheKey, result, opts.ttl).then(() =>
+													unlock()
+												);
+												return result;
+											})
+											.catch(e => {
+												return unlock().then(() => {
+													return Promise.reject(e);
+												});
+											});
+									});
 								});
 							});
-						});
-					}
-					// Not using lock
-					return this.get(cacheKey).then(content => {
-						if (content != null) {
-							// Found in the cache! Don't call handler, return with the content
-							ctx.cachedResult = true;
-							return content;
 						}
+						// Not using lock
+						return this.get(cacheKey).then(content => {
+							if (content != null) {
+								// Found in the cache! Don't call handler, return with the content
+								ctx.cachedResult = true;
+								return content;
+							}
 
-						// Call the handler
-						return handler(ctx).then(result => {
-							// Save the result to the cache
-							this.set(cacheKey, result, opts.ttl);
+							// Call the handler
+							return handler(ctx).then(result => {
+								// Save the result to the cache
+								this.set(cacheKey, result, opts.ttl);
 
-							return result;
+								return result;
+							});
 						});
-					});
-				}.bind(this);
-			}
+					}.bind(this);
+				}
 
-			return handler;
+				return handler;
+			}
 		};
 	}
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -37,7 +37,7 @@ class MiddlewareHandler {
 
 		if (!isObject(mw))
 			throw new BrokerOptionsError(
-				`Invalid middleware type '${typeof mw}'. Accepted only Object or Function.`,
+				`Invalid middleware type '${typeof mw}'. Accept only Object or Function.`,
 				{ type: typeof mw, value: mw }
 			);
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,7 +36,7 @@ class MiddlewareHandler {
 
 		if (!isObject(mw))
 			throw new BrokerOptionsError(
-				`Invalid middleware type '${typeof mw}'. Accepted only Object of Function.`,
+				`Invalid middleware type '${typeof mw}'. Accepted only Object or Function.`,
 				{ type: typeof mw }
 			);
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -33,11 +33,12 @@ class MiddlewareHandler {
 		}
 
 		if (isFunction(mw)) mw = mw.call(this.broker, this.broker);
+		if (!mw) return;
 
 		if (!isObject(mw))
 			throw new BrokerOptionsError(
 				`Invalid middleware type '${typeof mw}'. Accepted only Object or Function.`,
-				{ type: typeof mw }
+				{ type: typeof mw, value: mw }
 			);
 
 		Object.keys(mw).forEach(key => {

--- a/src/middlewares/cacher.js
+++ b/src/middlewares/cacher.js
@@ -1,0 +1,23 @@
+/*
+ * moleculer
+ * Copyright (c) 2021 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const utils = require("../utils");
+
+module.exports = function CacherMiddleware(broker) {
+	if (broker.cacher) {
+		const mw = broker.cacher.middleware();
+		if (utils.isPlainObject(mw)) return mw;
+
+		return {
+			name: "Cacher",
+			localAction: mw
+		};
+	}
+
+	return null;
+};

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -36,4 +36,8 @@ const Middlewares = {
 	}
 };
 
-module.exports = Middlewares;
+function register(name, value) {
+	Middlewares[name] = value;
+}
+
+module.exports = Object.assign(Middlewares, { register });

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -9,6 +9,7 @@
 const Middlewares = {
 	ActionHook: require("./action-hook"),
 	Cacher: require("./cacher"),
+	Validator: require("./validator"),
 	Bulkhead: require("./bulkhead"),
 	ContextTracker: require("./context-tracker"),
 	CircuitBreaker: require("./circuit-breaker"),

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -8,6 +8,7 @@
 
 const Middlewares = {
 	ActionHook: require("./action-hook"),
+	Cacher: require("./cacher"),
 	Bulkhead: require("./bulkhead"),
 	ContextTracker: require("./context-tracker"),
 	CircuitBreaker: require("./circuit-breaker"),

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -8,20 +8,18 @@
 
 const { isFunction, deprecate } = require("../utils");
 
-module.exports = function CacherMiddleware(broker) {
-	if (broker.cacher) {
-		const mw = broker.cacher.middleware();
+module.exports = function ValidatorMiddleware(broker) {
+	if (broker.validator && isFunction(broker.validator.middleware)) {
+		const mw = broker.validator.middleware(broker);
 		if (isFunction(mw)) {
 			deprecate(
 				"Validator middleware returning a Function is deprecated. Return a middleware object instead."
 			);
-
 			return {
-				name: "Cacher",
+				name: "Validator",
 				localAction: mw
 			};
 		}
-
 		return mw;
 	}
 

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -325,11 +325,7 @@ class ServiceBroker {
 			this.middlewares.add("ActionHook");
 
 			// 1. Validator
-			if (this.validator && utils.isFunction(this.validator.middleware)) {
-				const mw = this.validator.middleware(this);
-				if (utils.isPlainObject(mw)) this.middlewares.add(mw);
-				else this.middlewares.add({ name: "Validator", localAction: mw });
-			}
+			this.middlewares.add("Validator");
 
 			// 2. Bulkhead
 			this.middlewares.add("Bulkhead");

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -316,14 +316,10 @@ class ServiceBroker {
 		// Register user middlewares
 		if (Array.isArray(userMiddlewares) && userMiddlewares.length > 0) {
 			_.compact(userMiddlewares).forEach(mw => this.middlewares.add(mw));
-
-			this.logger.info(`Registered ${this.middlewares.count()} custom middleware(s).`);
 		}
 
 		if (this.options.internalMiddlewares) {
 			// Register internal middlewares
-
-			const prevCount = this.middlewares.count();
 
 			// 0. ActionHook
 			this.middlewares.add("ActionHook");
@@ -339,11 +335,7 @@ class ServiceBroker {
 			this.middlewares.add("Bulkhead");
 
 			// 3. Cacher
-			if (this.cacher && utils.isFunction(this.cacher.middleware)) {
-				const mw = this.cacher.middleware();
-				if (utils.isPlainObject(mw)) this.middlewares.add(mw);
-				else this.middlewares.add({ name: "Cacher", localAction: mw });
-			}
+			this.middlewares.add("Cacher");
 
 			// 4. Context tracker
 			this.middlewares.add("ContextTracker");
@@ -379,11 +371,8 @@ class ServiceBroker {
 				// 14. Hot Reload
 				this.middlewares.add("HotReload");
 			}
-
-			this.logger.info(
-				`Registered ${this.middlewares.count() - prevCount} internal middleware(s).`
-			);
 		}
+		this.logger.info(`Registered ${this.middlewares.count()} middleware(s).`);
 
 		this.createService = this.wrapMethod("createService", this.createService);
 		this.registerLocalService = this.wrapMethod(

--- a/test/unit/cachers/base.spec.js
+++ b/test/unit/cachers/base.spec.js
@@ -345,7 +345,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		expect(typeof cachedHandler).toBe("function");
 
 		return cachedHandler(ctx).then(response => {
@@ -366,7 +366,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 
 		return cachedHandler(ctx).then(response => {
 			expect(response).toBe(resData);
@@ -391,7 +391,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 
 		return cachedHandler(ctx).then(response => {
 			expect(response).toBe(resData);
@@ -417,7 +417,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(action.handler, action);
+		let cachedHandler = cacher.middleware().localAction(action.handler, action);
 		expect(typeof cachedHandler).toBe("function");
 
 		return cachedHandler(ctx).then(() => {
@@ -442,7 +442,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(action.handler, action);
+		let cachedHandler = cacher.middleware().localAction(action.handler, action);
 		expect(typeof cachedHandler).toBe("function");
 
 		return cachedHandler(ctx).then(() => {
@@ -467,7 +467,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(action.handler, action);
+		let cachedHandler = cacher.middleware().localAction(action.handler, action);
 		expect(typeof cachedHandler).toBe("function");
 
 		return cachedHandler(ctx).then(() => {
@@ -502,7 +502,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(action.handler, action);
+		let cachedHandler = cacher.middleware().localAction(action.handler, action);
 		expect(typeof cachedHandler).toBe("function");
 
 		return cachedHandler(ctx).then(() => {
@@ -538,7 +538,7 @@ describe("Test middleware", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(action.handler, action);
+		let cachedHandler = cacher.middleware().localAction(action.handler, action);
 		expect(typeof cachedHandler).toBe("function");
 
 		return cachedHandler(ctx).then(response => {
@@ -579,7 +579,7 @@ describe("Test middleware with lock enabled", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		expect(typeof cachedHandler).toBe("function");
 		let cacheKey = cacher.getCacheKey(mockAction.name, params);
 		return cachedHandler(ctx).then(response => {
@@ -605,7 +605,7 @@ describe("Test middleware with lock enabled", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.getWithTTL).toHaveBeenCalledTimes(0); //Check the cache key and ttl
 
@@ -634,7 +634,7 @@ describe("Test middleware with lock enabled", () => {
 		ctx.setParams(params);
 
 		let cacheKey = cacher.getCacheKey(mockAction.name, params);
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.lock).toHaveBeenCalledTimes(0);
 
@@ -661,7 +661,7 @@ describe("Test middleware with lock enabled", () => {
 		ctx.setParams(params);
 
 		let cacheKey = cacher.getCacheKey(mockAction.name, params);
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.getWithTTL).toHaveBeenCalledTimes(0);
 			expect(broker.cacher.lock).toHaveBeenCalledTimes(0);
@@ -690,7 +690,7 @@ describe("Test middleware with lock enabled", () => {
 		ctx.setParams(params);
 
 		let cacheKey = cacher.getCacheKey(mockAction.name, params);
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.getWithTTL).toHaveBeenCalledTimes(0);
 			expect(broker.cacher.lock).toHaveBeenCalledTimes(0);
@@ -727,7 +727,7 @@ describe("Test middleware with lock enabled", () => {
 		ctx.setParams(params);
 
 		let cacheKey = cacher.getCacheKey(mockAction.name, params);
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 
 		function call() {
 			let ctx = new Context();
@@ -766,7 +766,7 @@ describe("Test middleware with lock enabled", () => {
 		broker.cacher.getWithTTL = jest.fn(() => Promise.resolve({ data: null, ttl: null }));
 		const unlockFn = jest.fn(() => Promise.resolve());
 		broker.cacher.lock = jest.fn(() => Promise.resolve(unlockFn));
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(new Context()).catch(e => {
 			expect(e).toBe(err);
 			expect(unlockFn).toHaveBeenCalledTimes(1);
@@ -792,7 +792,7 @@ describe("Test middleware with lock enabled", () => {
 		broker.cacher.lock = jest.fn(() => Promise.resolve(unlockFn));
 		broker.cacher.tryLock = jest.fn(() => Promise.resolve(unlockFn));
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return new Promise(function (resolve, reject) {
 			cachedHandler(new Context()).then(response => {
 				expect(response).toBe(cachedData);
@@ -825,7 +825,7 @@ describe("Test middleware with lock enabled", () => {
 		broker.cacher.lock = jest.fn(() => Promise.resolve(unlockFn));
 		broker.cacher.tryLock = jest.fn(() => Promise.resolve(unlockFn));
 
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(new Context()).then(response => {
 			expect(response).toBe(cachedData);
 			expect(broker.cacher.get).toHaveBeenCalledTimes(0);
@@ -858,7 +858,7 @@ describe("Test middleware with lock enabled", () => {
 		broker.cacher.lock = jest.fn(() => Promise.resolve(unlockFn));
 		broker.cacher.tryLock = jest.fn(() => Promise.resolve(unlockFn));
 		let cacheKey = cacher.getCacheKey(mockAction.name, params);
-		let cachedHandler = cacher.middleware()(mockAction.handler, mockAction);
+		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 
 		const ctx = new Context();
 		ctx.setParams(params);

--- a/test/unit/middleware.spec.js
+++ b/test/unit/middleware.spec.js
@@ -75,7 +75,7 @@ describe("Test MiddlewareHandler", () => {
 
 		it("should throw error if middleware type is not valid", () => {
 			expect(() => middlewares.add(5)).toThrow(
-				"Invalid middleware type 'number'. Accepted only Object of Function."
+				"Invalid middleware type 'number'. Accept only Object or Function."
 			);
 		});
 	});


### PR DESCRIPTION
## :memo: Description

This PR exposes the Cacher and Validator middleware into separated middlewares. After this, you can redefine and reorder all internal middlewares.

### :dart: Relevant issues
Closing #892
#971

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
{
    internalMiddlewares: false,
    middlewares: [
        "ActionHook",
        // Change the built-in middleware with my custom one
        {
                name: "MyCustomValidatorMW",
                //localAction...
        },
        "Bulkhead",
        "Cacher",
        "ContextTracker",
        "CircuitBreaker",
        "Timeout",
        "Retry",
        "Fallback",
        "ErrorHandler",
        "Tracing",
        "Metrics",
        "Debounce",
        "Throttle",
        "HotReload"
    ]
};
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
