### PR TITLE
Fix invalid types of Serializers object

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Moleculer is a fast, modern and powerful microservices framework for [Node.js](h
 - built-in caching solution (Memory, MemoryLRU, Redis)
 - pluggable loggers (Console, File, Pino, Bunyan, Winston, Debug, Datadog, Log4js)
 - pluggable transporters (TCP, NATS, MQTT, Redis, NATS Streaming, Kafka, AMQP 0.9, AMQP 1.0)
-- pluggable serializers (JSON, Avro, MsgPack, Protocol Buffer, Thrift)
+- pluggable serializers (JSON, Avro, MsgPack, Protocol Buffer, Thrift, CBOR, Notepack)
 - pluggable parameter validator
 - multiple services on a node/server
 - master-less architecture, all nodes are equal

--- a/index.d.ts
+++ b/index.d.ts
@@ -1263,14 +1263,14 @@ declare namespace Moleculer {
 	}
 
 	const Serializers: {
-		Base: Serializer,
-		JSON: Serializer,
-		Avro: Serializer,
-		CBOR: Serializer,
-		MsgPack: Serializer,
-		ProtoBuf: Serializer,
-		Thrift: Serializer,
-		Notepack: Serializer,
+		Base: typeof Serializer,
+		JSON: typeof Serializer,
+		Avro: typeof Serializer,
+		CBOR: typeof Serializer,
+		MsgPack: typeof Serializer,
+		ProtoBuf: typeof Serializer,
+		Thrift: typeof Serializer,
+		Notepack: typeof Serializer,
 		resolve: (type: string | GenericObject | Serializer) => Serializer,
 	};
 


### PR DESCRIPTION
## :memo: Description

I've used `typeof Serializer` as value for all built-in serializers in the `Serializers` object. It must be constructor function type. Otherwiser, it's impossible to create objects with `new` or inherit from `Serializers.Base` as described in the [Documentation](https://moleculer.services/docs/0.14/networking.html#Custom-serializer). Also I've added missing pluggable serializers in README.md

[Typescript Playground example](https://www.typescriptlang.org/play#code/JYOwLgpgTgZghgYwgAgMrQG7CQISgewGtpkBvAXwG4AoUSWRFAcQhGmwHkAjAKwgTBkqtcNHhJkOAK4wYJCjWoATfgBs4UFAnUBnHWnZxVwAF7zqyS8gT4QOsFCkD8UABT4ADmB0B+AFzIcCAAngCUNFbIoMBgrlwExFAB6FBYuAnQoQEY+MBKEVY6hsZm7rwBLGxQnLz8YAA0yGDBHhAB9tUgAOZZkjJyUAWWKkXVRqYQcTIB0rLQjc2t7Q6gPRWs7AjcfAI05NTKahpatvYGYyXQOgGkFlY4cEUBixD4MOfA42ZQ9XeWAFKoDgAOWSxQmUGQAHoocgAOoEboAQmo+2obAA7h8vlcAHQPIqucLoiBYlKfS5QHS4wEgomKbSPfQAWWCBIg5JxkIgAA9ICAlPpOZTqeyhNRGXpkKzacDhRDkLz+YLsSKaUDgeKgA)

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: TS Example code
```ts
export class MySerializer extends Serializers.Base { } //TS2507: Type 'Serializer' is not a constructor function type.

``` 