### PR TITLE
 Keep custom error classes for calls between services

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -844,6 +844,7 @@ declare namespace Moleculer {
 		cacher?: boolean | Cacher | string | GenericObject;
 		serializer?: Serializer | string | GenericObject;
 		validator?: boolean | BaseValidator | ValidatorNames | ValidatorOptions;
+		errorRegenerator?: Errors.Regenerator;
 
 		metrics?: boolean | MetricRegistryOptions;
 		tracing?: boolean | TracerOptions;
@@ -1034,6 +1035,7 @@ declare namespace Moleculer {
 		cacher?: Cacher;
 		serializer?: Serializer;
 		validator?: BaseValidator;
+		errorRegenerator?: Errors.Regenerator;
 
 		tracer: Tracer;
 
@@ -1434,6 +1436,8 @@ declare namespace Moleculer {
 
 		interface PlainMoleculerError extends MoleculerError {
 			nodeID?: string;
+
+			[key: string]: any;
 		}
 
 		class Regenerator {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1431,6 +1431,17 @@ declare namespace Moleculer {
 		class InvalidPacketDataError extends MoleculerError {
 			constructor(data: any);
 		}
+
+		interface PlainMoleculerError extends MoleculerError {
+			nodeID?: string;
+		}
+
+		class Regenerator {
+			init(broker: ServiceBroker): void;
+			restore(plainError: PlainMoleculerError, payload: GenericObject): Error;
+			extractPlainError(err: Error): PlainMoleculerError;
+			restoreCustomError(plainError: PlainMoleculerError, payload: GenericObject): Error | undefined;
+		}
 	}
 
 	interface TransitRequest {

--- a/src/errors.js
+++ b/src/errors.js
@@ -497,11 +497,30 @@ function recreateError(err) {
 	}
 }
 
+/**
+ * Error Regenerator
+ * @class Regenerator
+ */
 class Regenerator {
+	/**
+	 * Init Regenerator
+	 * @param {ServiceBroker} broker
+	 *
+	 * @memberof Regenerator
+	 */
 	init(broker) {
 		this.broker = broker;
 	}
 
+	/**
+	 * Restore Error object
+	 *
+	 * @param {Object} plainError
+	 * @param {Object} payload
+	 * @return {Error}
+	 *
+	 * @memberof Regenerator
+	 */
 	restore(plainError, payload) {
 		let err = this.restoreCustomError(plainError, payload);
 		if (!err) {
@@ -516,7 +535,16 @@ class Regenerator {
 		return err;
 	}
 
-	extractPlainError(err, payload) {
+	/**
+	 * Extract plain error object from Error object
+	 *
+	 * @param {MoleculerError & { nodeID?: string }} err
+	 * @param {Object} payload
+	 * @return {Object} plain error
+	 *
+	 * @memberof Regenerator
+	 */
+	extractPlainError(err) {
 		return {
 			name: err.name,
 			message: err.message,
@@ -529,7 +557,16 @@ class Regenerator {
 		};
 	}
 
-	restoreCustomError(plainError, payload) {
+	/**
+	 * Hook to restore a custom error in a child class
+	 *
+	 * @param {Object} plainError
+	 * @param {Object} payload
+	 * @return {Error | undefined}
+	 *
+	 * @memberof Regenerator
+	 */
+	restoreCustomError() {
 		return undefined;
 	}
 
@@ -553,6 +590,12 @@ class Regenerator {
 	}
 }
 
+/**
+ * Resolve regenerator option
+ *
+ * @param {Regenerator} opt
+ * @return {Regenerator}
+ */
 function resolveRegenerator(opt) {
 	if (opt instanceof Regenerator) {
 		return opt;

--- a/src/errors.js
+++ b/src/errors.js
@@ -503,7 +503,8 @@ function recreateError(err) {
  */
 class Regenerator {
 	/**
-	 * Init Regenerator
+	 * Initializes Regenerator
+	 *
 	 * @param {ServiceBroker} broker
 	 *
 	 * @memberof Regenerator
@@ -513,7 +514,7 @@ class Regenerator {
 	}
 
 	/**
-	 * Restore Error object
+	 * Restores an Error object
 	 *
 	 * @param {Object} plainError
 	 * @param {Object} payload
@@ -529,16 +530,16 @@ class Regenerator {
 		if (!err) {
 			err = this._createDefaultError(plainError);
 		}
-		this._restoreMoleculerErrorFields(plainError, err, payload);
+		this._restoreExternalFields(plainError, err, payload);
 		this._restoreStack(plainError, err);
 
 		return err;
 	}
 
 	/**
-	 * Extract plain error object from Error object
+	 * Extracts a plain error object from Error object
 	 *
-	 * @param {MoleculerError & { nodeID?: string }} err
+	 * @param {Error} err
 	 * @param {Object} payload
 	 * @return {Object} plain error
 	 *
@@ -571,7 +572,7 @@ class Regenerator {
 	}
 
 	/**
-	 * Create a default error if not found
+	 * Creates a default error if not found
 	 *
 	 * @param {Object} plainError
 	 * @return {Error}
@@ -590,7 +591,7 @@ class Regenerator {
 	}
 
 	/**
-	 * Restore common Moleculer error fields
+	 * Restores external error fields
 	 *
 	 * @param {Object} plainError
 	 * @param {Object} err
@@ -599,13 +600,13 @@ class Regenerator {
 	 *
 	 * @memberof Regenerator
 	 */
-	_restoreMoleculerErrorFields(plainError, err, payload) {
+	_restoreExternalFields(plainError, err, payload) {
 		err.retryable = plainError.retryable;
 		err.nodeID = plainError.nodeID || payload.sender;
 	}
 
 	/**
-	 * Restore error stack
+	 * Restores an error stack
 	 *
 	 * @param {Object} plainError
 	 * @param {Object} err
@@ -619,7 +620,7 @@ class Regenerator {
 }
 
 /**
- * Resolve regenerator option
+ * Resolves a regenerator option
  *
  * @param {Regenerator} opt
  * @return {Regenerator}

--- a/src/errors.js
+++ b/src/errors.js
@@ -570,6 +570,15 @@ class Regenerator {
 		return undefined;
 	}
 
+	/**
+	 * Create a default error if not found
+	 *
+	 * @param {Object} plainError
+	 * @return {Error}
+	 * @private
+	 *
+	 * @memberof Regenerator
+	 */
 	_createDefaultError(plainError) {
 		const err = new Error(plainError.message);
 		err.name = plainError.name;
@@ -580,11 +589,30 @@ class Regenerator {
 		return err;
 	}
 
+	/**
+	 * Restore common Moleculer error fields
+	 *
+	 * @param {Object} plainError
+	 * @param {Object} err
+	 * @param {Object} payload
+	 * @private
+	 *
+	 * @memberof Regenerator
+	 */
 	_restoreMoleculerErrorFields(plainError, err, payload) {
 		err.retryable = plainError.retryable;
 		err.nodeID = plainError.nodeID || payload.sender;
 	}
 
+	/**
+	 * Restore error stack
+	 *
+	 * @param {Object} plainError
+	 * @param {Object} err
+	 * @private
+	 *
+	 * @memberof Regenerator
+	 */
 	_restoreStack(plainError, err) {
 		if (plainError.stack) err.stack = plainError.stack;
 	}

--- a/src/errors.js
+++ b/src/errors.js
@@ -502,21 +502,21 @@ class Regenerator {
 		this.broker = broker;
 	}
 
-	restore(plainError, sender) {
-		let err = this.restoreCustomError(plainError);
+	restore(plainError, payload) {
+		let err = this.restoreCustomError(plainError, payload);
 		if (!err) {
 			err = recreateError(plainError);
 		}
 		if (!err) {
 			err = this._createDefaultError(plainError);
 		}
-		this._restoreMoleculerErrorFields(plainError, err, sender);
+		this._restoreMoleculerErrorFields(plainError, err, payload);
 		this._restoreStack(plainError, err);
 
 		return err;
 	}
 
-	extractPlainError(err) {
+	extractPlainError(err, payload) {
 		return {
 			name: err.name,
 			message: err.message,
@@ -529,7 +529,7 @@ class Regenerator {
 		};
 	}
 
-	restoreCustomError(plainError) {
+	restoreCustomError(plainError, payload) {
 		return undefined;
 	}
 
@@ -543,9 +543,9 @@ class Regenerator {
 		return err;
 	}
 
-	_restoreMoleculerErrorFields(plainError, err, sender) {
+	_restoreMoleculerErrorFields(plainError, err, payload) {
 		err.retryable = plainError.retryable;
-		err.nodeID = plainError.nodeID || sender;
+		err.nodeID = plainError.nodeID || payload.sender;
 	}
 
 	_restoreStack(plainError, err) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -553,6 +553,14 @@ class Regenerator {
 	}
 }
 
+function resolveRegenerator(opt) {
+	if (opt instanceof Regenerator) {
+		return opt;
+	}
+
+	return new Regenerator();
+}
+
 module.exports = {
 	ExtendableError,
 
@@ -581,5 +589,6 @@ module.exports = {
 	BrokerDisconnectedError,
 
 	recreateError,
+	resolveRegenerator,
 	Regenerator
 };

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -23,6 +23,7 @@ const Validators = require("./validators");
 const Cachers = require("./cachers");
 const Transporters = require("./transporters");
 const Serializers = require("./serializers");
+const Errors = require("./errors");
 const H = require("./health");
 const MiddlewareHandler = require("./middleware");
 const cpuUsage = require("./cpu-usage");
@@ -42,7 +43,7 @@ const defaultOptions = {
 
 	transporter: null, //"TCP",
 
-	recreateError: null,
+	errorsRegenerator: null,
 
 	requestTimeout: 0 * 1000,
 	retryPolicy: {
@@ -226,6 +227,10 @@ class ServiceBroker {
 			// Serializer
 			this.serializer = Serializers.resolve(this.options.serializer);
 			this.serializer.init(this);
+
+			// Errors regenerator TODO: create resolve method
+			this.errorsRegenerator = this.options.errorsRegenerator || new Errors.Regenerator();
+			this.errorsRegenerator.init(this);
 
 			const serializerName = this.getConstructorName(this.serializer);
 			this.logger.info(`Serializer: ${serializerName}`);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -228,8 +228,8 @@ class ServiceBroker {
 			this.serializer = Serializers.resolve(this.options.serializer);
 			this.serializer.init(this);
 
-			// Errors regenerator TODO: create resolve method
-			this.errorsRegenerator = this.options.errorsRegenerator || new Errors.Regenerator();
+			// Errors regenerator
+			this.errorsRegenerator = Errors.resolveRegenerator(this.options.errorsRegenerator);
 			this.errorsRegenerator.init(this);
 
 			const serializerName = this.getConstructorName(this.serializer);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -43,7 +43,7 @@ const defaultOptions = {
 
 	transporter: null, //"TCP",
 
-	errorsRegenerator: null,
+	errorRegenerator: null,
 
 	requestTimeout: 0 * 1000,
 	retryPolicy: {
@@ -228,9 +228,9 @@ class ServiceBroker {
 			this.serializer = Serializers.resolve(this.options.serializer);
 			this.serializer.init(this);
 
-			// Errors regenerator
-			this.errorsRegenerator = Errors.resolveRegenerator(this.options.errorsRegenerator);
-			this.errorsRegenerator.init(this);
+			// Error regenerator
+			this.errorRegenerator = Errors.resolveRegenerator(this.options.errorRegenerator);
+			this.errorRegenerator.init(this);
 
 			const serializerName = this.getConstructorName(this.serializer);
 			this.logger.info(`Serializer: ${serializerName}`);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -42,6 +42,8 @@ const defaultOptions = {
 
 	transporter: null, //"TCP",
 
+	recreateError: null,
+
 	requestTimeout: 0 * 1000,
 	retryPolicy: {
 		enabled: false,

--- a/src/transit.js
+++ b/src/transit.js
@@ -38,6 +38,7 @@ class Transit {
 		this.tx = transporter;
 		this.opts = opts;
 		this.discoverer = broker.registry.discoverer;
+		this.customRecreateError = broker.options.recreateError;
 
 		this.pendingRequests = new Map();
 		this.pendingReqStreams = new Map();
@@ -610,6 +611,7 @@ class Transit {
 	 */
 	_createErrFromPayload(error, sender) {
 		let err = E.recreateError(error);
+		if (!err && this.customRecreateError) err = this.customRecreateError(error);
 		if (!err) {
 			err = new Error(error.message);
 			err.name = error.name;

--- a/src/transit.js
+++ b/src/transit.js
@@ -38,7 +38,7 @@ class Transit {
 		this.tx = transporter;
 		this.opts = opts;
 		this.discoverer = broker.registry.discoverer;
-		this.errorsRegenerator = broker.errorsRegenerator;
+		this.errorRegenerator = broker.errorRegenerator;
 
 		this.pendingRequests = new Map();
 		this.pendingReqStreams = new Map();
@@ -610,7 +610,7 @@ class Transit {
 	 * @param {Object} payload
 	 */
 	_createErrFromPayload(error, payload) {
-		return this.errorsRegenerator.restore(error, payload);
+		return this.errorRegenerator.restore(error, payload);
 	}
 
 	/**
@@ -1019,7 +1019,7 @@ class Transit {
 	 * @memberof Transit
 	 */
 	_createPayloadErrorField(err, payload) {
-		return this.errorsRegenerator.extractPlainError(err, payload);
+		return this.errorRegenerator.extractPlainError(err, payload);
 	}
 
 	/**

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -583,8 +583,9 @@ describe("Test Errors.recreateError", () => {
 
 describe("Test Errors.Regenerator", () => {
 	describe("Initialization", () => {
-		it("check constructor", () => {
+		it("should create an instance", () => {
 			let regenerator = new errors.Regenerator();
+
 			expect(regenerator).toBeDefined();
 			expect(regenerator.init).toBeDefined();
 			expect(regenerator.restore).toBeDefined();
@@ -592,11 +593,12 @@ describe("Test Errors.Regenerator", () => {
 			expect(regenerator.restoreCustomError).toBeDefined();
 		});
 
-		it("check init", () => {
+		it("should initialize an instance", () => {
 			let broker = new ServiceBroker({ logger: false });
 			let regenerator = new errors.Regenerator();
 
 			regenerator.init(broker);
+
 			expect(regenerator.broker).toBe(broker);
 		});
 	});
@@ -627,7 +629,7 @@ describe("Test Errors.Regenerator", () => {
 			expect(regenerator.restoreCustomError).toHaveBeenCalledWith(plainError, payload);
 		});
 
-		it("should restore built-in error", () => {
+		it("should restore a built-in error", () => {
 			let plainError = {
 				name: "ServiceNotFoundError",
 				code: 404,
@@ -652,7 +654,7 @@ describe("Test Errors.Regenerator", () => {
 			expect(err.stack).toBe("error stack");
 		});
 
-		it("should pick nodeID from payload.sender when nodeID is absent in plain error", () => {
+		it("should pick nodeID from payload.sender when nodeID is absent in a plain error", () => {
 			let plainError = {
 				name: "ServiceNotFoundError",
 				code: 404,
@@ -676,7 +678,7 @@ describe("Test Errors.Regenerator", () => {
 			expect(err.stack).toBe("error stack");
 		});
 
-		it("should restore unknown error", () => {
+		it("should restore an unknown error", () => {
 			let plainError = {
 				name: "UnknownError",
 				code: 456,
@@ -802,7 +804,7 @@ describe("Test Errors.Regenerator", () => {
 			});
 		});
 
-		it("should select nodeID from broker when input error doesn't have nodeID", () => {
+		it("should select nodeID from a broker when input error doesn't have nodeID", () => {
 			const err = new errors.MoleculerRetryableError("Msg", 456, "TYPE", { a: 5 });
 			err.stack = "custom stack";
 

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -821,3 +821,30 @@ describe("Test Errors.Regenerator", () => {
 		});
 	});
 });
+
+describe("Test Errors.resolveRegenerator", () => {
+	it("should resolve to a custom regenerator when option is an instance of Errors.Regenerator", () => {
+		class CustomRegenerator extends errors.Regenerator {}
+
+		const result = errors.resolveRegenerator(CustomRegenerator);
+
+		expect(result).toBeInstanceOf(CustomRegenerator);
+	});
+
+	it("should resolve to Errors.Regenerator when option isn't an instance of Errors.Regenerator", () => {
+		class CustomRegenerator {}
+
+		const result = errors.resolveRegenerator(CustomRegenerator);
+
+		expect(result).toBeInstanceOf(errors.Regenerator);
+	});
+
+	it.each([-1, 0, 1, "", "custom", {}, null, undefined, [], true, false, () => {}])(
+		"should resolve to Errors.Regenerator when option is '%p'",
+		option => {
+			const result = errors.resolveRegenerator(option);
+
+			expect(result).toBeInstanceOf(errors.Regenerator);
+		}
+	);
+});

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -826,7 +826,7 @@ describe("Test Errors.resolveRegenerator", () => {
 	it("should resolve to a custom regenerator when option is an instance of Errors.Regenerator", () => {
 		class CustomRegenerator extends errors.Regenerator {}
 
-		const result = errors.resolveRegenerator(CustomRegenerator);
+		const result = errors.resolveRegenerator(new CustomRegenerator());
 
 		expect(result).toBeInstanceOf(CustomRegenerator);
 	});
@@ -834,7 +834,7 @@ describe("Test Errors.resolveRegenerator", () => {
 	it("should resolve to Errors.Regenerator when option isn't an instance of Errors.Regenerator", () => {
 		class CustomRegenerator {}
 
-		const result = errors.resolveRegenerator(CustomRegenerator);
+		const result = errors.resolveRegenerator(new CustomRegenerator());
 
 		expect(result).toBeInstanceOf(errors.Regenerator);
 	});

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 let errors = require("../../src/errors");
+const ServiceBroker = require("../../src/service-broker");
 
 describe("Test Errors", () => {
 	it("test MoleculerError", () => {
@@ -577,5 +578,26 @@ describe("Test Errors.recreateError", () => {
 			data: { a: 5 }
 		});
 		expect(err).toBeUndefined();
+	});
+});
+
+describe("Test Errors.Regenerator", () => {
+	describe("Initialization", () => {
+		it("check constructor", () => {
+			let regenerator = new errors.Regenerator();
+			expect(regenerator).toBeDefined();
+			expect(regenerator.init).toBeDefined();
+			expect(regenerator.restore).toBeDefined();
+			expect(regenerator.extractPlainError).toBeDefined();
+			expect(regenerator.restoreCustomError).toBeDefined();
+		});
+
+		it("check init", () => {
+			let broker = new ServiceBroker({ logger: false });
+			let regenerator = new errors.Regenerator();
+
+			regenerator.init(broker);
+			expect(regenerator.broker).toBe(broker);
+		});
 	});
 });

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -71,7 +71,8 @@ const {
 	MoleculerError,
 	MoleculerServerError,
 	ServiceNotFoundError,
-	ServiceNotAvailableError
+	ServiceNotAvailableError,
+	Regenerator
 } = require("../../src/errors");
 
 jest.spyOn(Registry.prototype, "init");
@@ -124,6 +125,7 @@ describe("Test ServiceBroker constructor", () => {
 		expect(broker.cacher).toBeNull();
 		expect(broker.serializer).toBeInstanceOf(Serializers.JSON);
 		expect(broker.validator).toBeInstanceOf(Validators.Fastest);
+		expect(broker.errorRegenerator).toBeInstanceOf(Regenerator);
 		expect(broker.transit).toBeUndefined();
 
 		expect(broker.getLocalService("$node")).toBeDefined();
@@ -323,6 +325,20 @@ describe("Test ServiceBroker constructor", () => {
 		expect(broker.cacher).toBe(cacher);
 		expect(cacher.init).toHaveBeenCalledTimes(1);
 		expect(cacher.init).toHaveBeenCalledWith(broker);
+	});
+
+	it("should create errorRegenerator and call init", () => {
+		let errorRegenerator = new Regenerator();
+		errorRegenerator.init = jest.fn();
+		broker = new ServiceBroker({
+			logger: false,
+			errorRegenerator
+		});
+
+		expect(broker).toBeDefined();
+		expect(broker.errorRegenerator).toBe(errorRegenerator);
+		expect(errorRegenerator.init).toHaveBeenCalledTimes(1);
+		expect(errorRegenerator.init).toHaveBeenCalledWith(broker);
 	});
 
 	it("should set serializer and call init", () => {

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -205,7 +205,7 @@ describe("Test ServiceBroker constructor", () => {
 				}
 			},
 			logLevel: null,
-			recreateError: null,
+			errorsRegenerator: null,
 			cacher: null,
 			serializer: null,
 			transporter: null,

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -205,7 +205,7 @@ describe("Test ServiceBroker constructor", () => {
 				}
 			},
 			logLevel: null,
-			errorsRegenerator: null,
+			errorRegenerator: null,
 			cacher: null,
 			serializer: null,
 			transporter: null,

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -205,6 +205,7 @@ describe("Test ServiceBroker constructor", () => {
 				}
 			},
 			logLevel: null,
+			recreateError: null,
 			cacher: null,
 			serializer: null,
 			transporter: null,

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -1129,7 +1129,7 @@ describe("Test Transit._createErrFromPayload", () => {
 				retryable: true,
 				stack: "error stack"
 			},
-			"node-999"
+			{ sender: "node-999" }
 		);
 
 		expect(err).toBeInstanceOf(E.MoleculerError);

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -1173,7 +1173,7 @@ describe("Test Transit._createErrFromPayload", () => {
 				this.data = data;
 			}
 		}
-		class MyErrorsRegenerator extends E.Regenerator {
+		class MyErrorRegenerator extends E.Regenerator {
 			restoreCustomError(plainError) {
 				if (plainError.name === "MyCustomError") {
 					return new MyCustomError(
@@ -1189,7 +1189,7 @@ describe("Test Transit._createErrFromPayload", () => {
 		const broker = new ServiceBroker({
 			logger: false,
 			nodeID: "node1",
-			errorsRegenerator: new MyErrorsRegenerator(),
+			errorRegenerator: new MyErrorRegenerator(),
 			transporter: new FakeTransporter()
 		});
 		const transit = broker.transit;

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -1173,17 +1173,23 @@ describe("Test Transit._createErrFromPayload", () => {
 				this.data = data;
 			}
 		}
-
-		const customRecreateError = function (err) {
-			switch (err.name) {
-				case "MyCustomError":
-					return new MyCustomError(err.name, err.code, err.type, err.data);
+		class MyErrorsRegenerator extends E.Regenerator {
+			restoreCustomError(plainError) {
+				if (plainError.name === "MyCustomError") {
+					return new MyCustomError(
+						plainError.name,
+						plainError.code,
+						plainError.type,
+						plainError.data
+					);
+				}
 			}
-		};
+		}
+
 		const broker = new ServiceBroker({
 			logger: false,
 			nodeID: "node1",
-			recreateError: customRecreateError,
+			errorsRegenerator: new MyErrorsRegenerator(),
 			transporter: new FakeTransporter()
 		});
 		const transit = broker.transit;


### PR DESCRIPTION
## :memo: Description
I'm working on implementing a solution to preserve custom error classes between services (see Relevant issues). I've decided to add `recreateError` option to `ServiceBroker` options and call this function after the built-in one.

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/861

### :gem:  Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: Example code
```js
const customRecreateError = function (err) {
			switch (err.name) {
				case "MyCustomError":
					return new MyCustomError(err.name, err.code, err.type, err.data);
			}
		};
		const broker = new ServiceBroker({
			logger: false,
			nodeID: "node1",
			recreateError: customRecreateError,
			transporter: new FakeTransporter()
		});
``` 
