### PR TITLE
[ts] mark args as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -642,7 +642,7 @@ declare namespace Moleculer {
 		callHandlers(method: string, args: any[], opts: MiddlewareCallHandlerOptions): Promise<void>;
 		callSyncHandlers(method: string, args: any[], opts: MiddlewareCallHandlerOptions): void;
 		count(): number;
-		wrapMethod(method: string, handler: ActionHandler, bindTo: any, opts: MiddlewareCallHandlerOptions): typeof handler;
+		wrapMethod(method: string, handler: ActionHandler, bindTo?: any, opts?: MiddlewareCallHandlerOptions): typeof handler;
 	}
 
 	interface ServiceHooksBefore {
@@ -1049,7 +1049,7 @@ declare namespace Moleculer {
 
 		errorHandler(err: Error, info: GenericObject): void;
 
-		wrapMethod(method: string, handler: ActionHandler, bindTo: any, opts: MiddlewareCallHandlerOptions): typeof handler;
+		wrapMethod(method: string, handler: ActionHandler, bindTo?: any, opts?: MiddlewareCallHandlerOptions): typeof handler;
 		callMiddlewareHookSync(name: string, args: any[], opts: MiddlewareCallHandlerOptions): Promise<void>;
 		callMiddlewareHook(name: string, args: any[], opts: MiddlewareCallHandlerOptions): void;
 
@@ -1262,8 +1262,8 @@ declare namespace Moleculer {
 	class Serializer {
 		constructor(opts?: any);
 		init(broker: ServiceBroker): void;
-		serialize(obj: GenericObject, type: string): Buffer;
-		deserialize(buf: Buffer, type: string): GenericObject;
+		serialize(obj: GenericObject, type?: string): Buffer;
+		deserialize(buf: Buffer, type?: string): GenericObject;
 	}
 
 	const Serializers: {


### PR DESCRIPTION
This PR is an effort to solve some of the TS-related issues that were found in [`types`](https://github.com/moleculerjs/moleculer-channels/tree/types) branch of [moleculer-channels](https://github.com/moleculerjs/moleculer-channels)


There are still some missing types for the `this.broker.Promise`. @0x0a0d can you help me out on this?
![aaa](https://user-images.githubusercontent.com/9802754/141481617-6ecfd088-a05c-42d6-955c-bf61decbcff8.jpg)
