### PR TITLE
add support for either-or versions to waitForServices

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -1044,7 +1044,7 @@ class ServiceBroker {
 						};
 					}
 				});
-				const flattenedStatuses = serviceStatuses.flatMap(s => s);
+				const flattenedStatuses = _.flatMap(serviceStatuses, s => s);
 				const names = flattenedStatuses.map(s => s.name);
 				const availableServices = flattenedStatuses.filter(s => s.available);
 

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1800,7 +1800,10 @@ describe("Test broker.getLocalService", () => {
 describe("Test broker.waitForServices", () => {
 	let broker = new ServiceBroker({ logger: false });
 	let res = false;
-	broker.registry.hasService = jest.fn(() => res);
+
+	beforeEach(() => {
+		broker.registry.hasService = jest.fn(() => res);
+	});
 
 	let clock;
 	beforeAll(() => (clock = lolex.install()));
@@ -1978,6 +1981,28 @@ describe("Test broker.waitForServices", () => {
 		clock.tick(450);
 		res = true;
 		clock.tick(150);
+
+		return p;
+	});
+
+	it("should wait for a single service when passed multi-version service", () => {
+		broker.registry.hasService = jest.fn();
+		broker.registry.hasService.mockImplementation(name => name === "v1.posts");
+		let p = broker
+			.waitForServices([{ name: "posts", version: [1, 2] }], 10 * 1000, 50)
+			.catch(protectReject)
+			.then(result => {
+				expect(result).toEqual({
+					services: ["v1.posts", "v2.posts"],
+					statuses: [
+						{ name: "v1.posts", available: true },
+						{ name: "v2.posts", available: false }
+					]
+				});
+				expect(broker.registry.hasService).toHaveBeenCalledTimes(2);
+			});
+
+		clock.tick(500);
 
 		return p;
 	});


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Add support for a dependency formatted as `{ name: 'z', versions: [1, 2] }` - either `v1.z` or `v2.z` will satisfy this.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

#1026 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
