### PR TITLE
add missing maxSafeObjectSize broker option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -879,6 +879,8 @@ declare namespace Moleculer {
 		 * You have to register this manually and stop broker in this case!
 		 */
 		skipProcessEventRegistration?: boolean;
+
+		maxSafeObjectSize?: number;
 	}
 
 	interface NodeHealthStatus {


### PR DESCRIPTION
## :memo: Description

Add  `maxSafeObjectSize` broker option to `index.d.ts` according to https://github.com/moleculerjs/moleculer/blob/7bd4d72d05e79756654638cb449c471a9302717b/src/service-broker.js#L125-L132