### PR TITLE
fix: Add ThisType for remove error in typescript template

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -675,7 +675,7 @@ declare namespace Moleculer {
 		dependencies?: string | ServiceDependency | Array<string | ServiceDependency>;
 		metadata?: any;
 		actions?: ServiceActionsSchema;
-		mixins?: Array<Partial<ServiceSchema>> | Array<Partial<ServiceSchema>, ThisType<Service>>;
+		mixins?: Array<Partial<ServiceSchema>> | Array<Partial<ServiceSchema> & ThisType<Service>>;
 		methods?: ServiceMethods;
 		hooks?: ServiceHooks;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -675,7 +675,7 @@ declare namespace Moleculer {
 		dependencies?: string | ServiceDependency | Array<string | ServiceDependency>;
 		metadata?: any;
 		actions?: ServiceActionsSchema;
-		mixins?: Array<Partial<ServiceSchema>>;
+		mixins?: Array<Partial<ServiceSchema>> | Array<Partial<ServiceSchema>, ThisType<Service>>;
 		methods?: ServiceMethods;
 		hooks?: ServiceHooks;
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```ts


``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

When using some Adapter with typescript support we have to use ThisType in the mixin , that way when injecting in the service mixin, it shows an error , because the mixins type in the ServiceSchema interface, allows only mixins being Array<Partial<ServiceSchema>>.

This restriction limits the implementation of more typescript adapters.

![image](https://user-images.githubusercontent.com/4489558/142565409-06616878-5633-4dcd-b087-ab3ab2eb3676.png)


## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
