### PR TITLE
Add safetyTags property to tracer exporters

### DIFF
--- a/dev/issue-777.js
+++ b/dev/issue-777.js
@@ -1,0 +1,108 @@
+"use strict";
+
+/*const tracer = require("dd-trace").init({
+	service: "moleculer", // shows up as Service in Datadog UI
+	url: "http://127.0.0.1:8126",
+	debug: true,
+	samplingPriority: "USER_KEEP"
+});
+
+tracer.use("http");
+tracer.use("ioredis");
+*/
+const ServiceBroker = require("../src/service-broker");
+("use strict");
+
+const { MoleculerError } = require("../src/errors");
+const _ = require("lodash");
+const { inspect } = require("util");
+
+const THROW_ERR = false;
+
+// Create broker
+const broker = new ServiceBroker({
+	nodeID: "node-1",
+	logger: console,
+	logLevel: "info",
+	//transporter: "redis://localhost:6379",
+	//cacher: true, //"redis://localhost:6379",
+
+	tracing: {
+		events: true,
+		stackTrace: true,
+		sampling: {
+			rate: 1
+			//tracesPerSecond: 1
+		},
+		exporter: [
+			/*{
+				type: "Console",
+				options: {
+					width: 100,
+					gaugeWidth: 30,
+					logger: console.info
+				}
+			},*/
+			/*{
+				type: "Datadog",
+				options: {
+					tracer
+				}
+			}*/
+			{
+				type: "Zipkin",
+				options: {
+					safetyTags: true,
+					baseURL: "http://127.0.0.1:9411"
+				}
+			},
+			{
+				type: "Jaeger",
+				options: {
+					safetyTags: true,
+					endpoint: "http://localhost:14268/api/traces"
+				}
+			}
+			/*{
+				type: "Event",
+				options: {
+				}
+			}*/
+			/*{
+				type: "EventLegacy"
+			}*/
+		]
+	}
+});
+
+broker.createService({
+	name: "greeter",
+	actions: {
+		hello: {
+			handler(ctx) {
+				return `Hello!`;
+			}
+		}
+	}
+});
+
+// Start server
+broker.start().then(() => {
+	broker.repl();
+
+	const a = {
+		aa: 5,
+		c: "John"
+	};
+	const b = {
+		bb: 10,
+		a: a
+	};
+
+	a.b = b;
+
+	// Call action
+	setInterval(() => {
+		broker.call("greeter.hello", a).then(console.log).catch(console.error);
+	}, 5000);
+});

--- a/dev/issue-777.js
+++ b/dev/issue-777.js
@@ -52,14 +52,14 @@ const broker = new ServiceBroker({
 			{
 				type: "Zipkin",
 				options: {
-					safetyTags: true,
+					safetyTags: false,
 					baseURL: "http://127.0.0.1:9411"
 				}
 			},
 			{
 				type: "Jaeger",
 				options: {
-					safetyTags: true,
+					safetyTags: false,
 					endpoint: "http://localhost:14268/api/traces"
 				}
 			}
@@ -79,6 +79,9 @@ broker.createService({
 	name: "greeter",
 	actions: {
 		hello: {
+			tracing: {
+				safetyTags: true
+			},
 			handler(ctx) {
 				return `Hello!`;
 			}

--- a/dev/tracing.js
+++ b/dev/tracing.js
@@ -2,8 +2,8 @@
 
 const tracer = require("dd-trace").init({
 	service: "moleculer", // shows up as Service in Datadog UI
-	url: "http://192.168.0.181:8126",
-	debug: true,
+	url: "http://localhost:8126",
+	debug: false,
 	samplingPriority: "USER_KEEP"
 });
 
@@ -48,19 +48,20 @@ const broker = new ServiceBroker({
 				options: {
 					tracer
 				}
-			}
-			/*{
+			},
+			{
 				type: "Zipkin",
 				options: {
-					baseURL: "http://192.168.0.181:9411",
+					baseURL: "http://localhost:9411"
 				}
 			},
 			{
 				type: "Jaeger",
 				options: {
-					host: "192.168.0.181",
+					endpoint: "http://localhost:14268/api/traces"
+					//host: "localhost",
 				}
-			},*/
+			}
 			/*{
 				type: "Event",
 				options: {

--- a/src/middlewares/tracing.js
+++ b/src/middlewares/tracing.js
@@ -7,7 +7,7 @@
 "use strict";
 
 const _ = require("lodash");
-const { isFunction, isPlainObject } = require("../utils");
+const { isFunction, isPlainObject, safetyObject } = require("../utils");
 
 module.exports = function TracingMiddleware(broker) {
 	const tracer = broker.tracer;
@@ -22,7 +22,7 @@ module.exports = function TracingMiddleware(broker) {
 				ctx.requestID = ctx.requestID || tracer.getCurrentTraceID();
 				ctx.parentID = ctx.parentID || tracer.getActiveSpanID();
 
-				const tags = {
+				let tags = {
 					callingLevel: ctx.level,
 					action: ctx.action
 						? {
@@ -67,6 +67,10 @@ module.exports = function TracingMiddleware(broker) {
 						tags.meta = ctx.meta != null ? Object.assign({}, ctx.meta) : ctx.meta;
 					else if (Array.isArray(actionTags.meta))
 						tags.meta = _.pick(ctx.meta, actionTags.meta);
+				}
+
+				if (opts.safetyTags) {
+					tags = safetyObject(tags);
 				}
 
 				let spanName = `action '${ctx.action.name}'`;
@@ -144,7 +148,7 @@ module.exports = function TracingMiddleware(broker) {
 				ctx.requestID = ctx.requestID || tracer.getCurrentTraceID();
 				ctx.parentID = ctx.parentID || tracer.getActiveSpanID();
 
-				const tags = {
+				let tags = {
 					event: {
 						name: event.name,
 						group: event.group
@@ -186,6 +190,10 @@ module.exports = function TracingMiddleware(broker) {
 						tags.meta = ctx.meta != null ? Object.assign({}, ctx.meta) : ctx.meta;
 					else if (Array.isArray(eventTags.meta))
 						tags.meta = _.pick(ctx.meta, eventTags.meta);
+				}
+
+				if (opts.safetyTags) {
+					tags = safetyObject(tags);
 				}
 
 				let spanName = `event '${ctx.eventName}' in '${service.fullName}'`;

--- a/src/tracing/exporters/README.md
+++ b/src/tracing/exporters/README.md
@@ -1,0 +1,21 @@
+# Moleculer Trace Exporters
+
+## Running Jaeger
+
+```bash
+docker run -d --name jaeger -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14250:14250 -p 14268:14268 -p 14269:14269 jaegertracing/all-in-one:latest
+```
+
+**UI:** http://<docker-ip>:16686/
+
+## Running Zipkin
+
+```bash
+docker run -d -p 9411:9411 --name=zipkin openzipkin/zipkin
+```
+
+## Running DataDog Agent
+
+```bash
+docker run -d --name dd-agent --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=123456 -e DD_APM_ENABLED=true -e DD_APM_NON_LOCAL_TRAFFIC=true -p 8126:8126  datadog/agent:latest
+```

--- a/src/tracing/exporters/base.js
+++ b/src/tracing/exporters/base.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
-const { isObject } = require("../../utils");
+const { isObject, safetyObject } = require("../../utils");
 
 /**
  * Abstract Trace Exporter
@@ -15,7 +15,9 @@ class BaseTraceExporter {
 	 * @memberof BaseTraceExporter
 	 */
 	constructor(opts) {
-		this.opts = opts || {};
+		this.opts = _.defaultsDeep(opts, {
+			safetyTags: false
+		});
 		this.Promise = Promise; // default promise before logger is initialized
 	}
 
@@ -86,6 +88,10 @@ class BaseTraceExporter {
 	 */
 	flattenTags(obj, convertToString = false, path = "") {
 		if (!obj) return null;
+
+		if (this.opts.safetyTags) {
+			obj = safetyObject(obj);
+		}
 
 		return Object.keys(obj).reduce((res, k) => {
 			const o = obj[k];

--- a/src/tracing/exporters/datadog.js
+++ b/src/tracing/exporters/datadog.js
@@ -5,10 +5,6 @@ const BaseTraceExporter = require("./base");
 const asyncHooks = require("async_hooks");
 const { isFunction } = require("../../utils");
 
-/*
-	docker run -d --name dd-agent --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=123456 -e DD_APM_ENABLED=true -e DD_APM_NON_LOCAL_TRAFFIC=true -p 8126:8126  datadog/agent:latest
-*/
-
 let DatadogSpanContext;
 let DatadogID;
 

--- a/src/tracing/exporters/jaeger.js
+++ b/src/tracing/exporters/jaeger.js
@@ -17,12 +17,6 @@ let Jaeger, GuaranteedThroughputSampler, RemoteControlledSampler, UDPSender, HTT
  *
  * http://jaeger.readthedocs.io/en/latest/getting_started/#all-in-one-docker-image
  *
- * Running Jaeger in Docker:
- *
- * 		docker run -d --name jaeger -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
- *
- * UI: http://<docker-ip>:16686/
- *
  * @class JaegerTraceExporter
  */
 class JaegerTraceExporter extends BaseTraceExporter {

--- a/src/tracing/exporters/zipkin.js
+++ b/src/tracing/exporters/zipkin.js
@@ -11,10 +11,6 @@ const { isFunction } = require("../../utils");
  * API v2: https://zipkin.io/zipkin-api/#/
  * API v1: https://zipkin.io/pages/data_model.html
  *
- * Running Zipkin in Docker:
- *
- * 	 docker run -d -p 9411:9411 --name=zipkin openzipkin/zipkin
- *
  * @class ZipkinTraceExporter
  */
 class ZipkinTraceExporter extends BaseTraceExporter {

--- a/test/unit/tracing/exporters/base.spec.js
+++ b/test/unit/tracing/exporters/base.spec.js
@@ -8,7 +8,7 @@ describe("Test Base Reporter class", () => {
 		it("should create with default options", () => {
 			const exporter = new BaseExporter();
 
-			expect(exporter.opts).toEqual({});
+			expect(exporter.opts).toEqual({ safetyTags: false });
 		});
 
 		it("should create with custom options", () => {
@@ -18,6 +18,7 @@ describe("Test Base Reporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				some: "thing",
 				a: 5
 			});
@@ -89,6 +90,43 @@ describe("Test Base Reporter class", () => {
 				"myObj.c.e.f": true,
 				"myObj.c.e.g": 100,
 				"myObj.c.h": null
+			});
+		});
+	});
+
+	describe("Test flattenTags method with cyclic tags", () => {
+		const exporter = new BaseExporter({ safetyTags: true });
+
+		const nasty = {
+			evil: true
+		};
+
+		const obj = {
+			a: 5,
+			b: "John",
+			c: {
+				d: "d",
+				e: {
+					f: true,
+					g: 100
+				},
+				h: null,
+				i: undefined
+			},
+			j: nasty
+		};
+
+		nasty.devil = obj; // Cyclic reference
+
+		it("should flattening an object skipping the cyclic properties", () => {
+			expect(exporter.flattenTags(obj)).toEqual({
+				a: 5,
+				b: "John",
+				"c.d": "d",
+				"c.e.f": true,
+				"c.e.g": 100,
+				"c.h": null,
+				"j.evil": true
 			});
 		});
 	});

--- a/test/unit/tracing/exporters/console.spec.js
+++ b/test/unit/tracing/exporters/console.spec.js
@@ -11,6 +11,7 @@ describe("Test Console tracing exporter class", () => {
 			const exporter = new ConsoleTraceExporter();
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				logger: null,
 				colors: true,
 				width: 100,
@@ -28,6 +29,7 @@ describe("Test Console tracing exporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				logger: console,
 				colors: true,
 				width: 120,

--- a/test/unit/tracing/exporters/datadog.spec.js
+++ b/test/unit/tracing/exporters/datadog.spec.js
@@ -49,6 +49,7 @@ describe("Test Datadog tracing exporter class", () => {
 			const exporter = new DatadogTraceExporter();
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				agentUrl: process.env.DD_AGENT_URL || "http://localhost:8126",
 				env: process.env.DD_ENVIRONMENT || null,
 				samplingPriority: "AUTO_KEEP",
@@ -77,6 +78,7 @@ describe("Test Datadog tracing exporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				tracer: fakeDdTracer,
 				agentUrl: "http://datadog-agent:8126",
 				env: "testing",

--- a/test/unit/tracing/exporters/event-legacy.spec.js
+++ b/test/unit/tracing/exporters/event-legacy.spec.js
@@ -11,7 +11,7 @@ describe("Test Event Legacy tracing exporter class", () => {
 		it("should create with default options", () => {
 			const exporter = new EventLegacyTraceExporter();
 
-			expect(exporter.opts).toEqual({});
+			expect(exporter.opts).toEqual({ safetyTags: false });
 		});
 	});
 

--- a/test/unit/tracing/exporters/event.spec.js
+++ b/test/unit/tracing/exporters/event.spec.js
@@ -23,6 +23,7 @@ describe("Test Event tracing exporter class", () => {
 			exporter = new EventTraceExporter();
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				eventName: "$tracing.spans",
 				sendStartSpan: false,
 				sendFinishSpan: true,
@@ -50,6 +51,7 @@ describe("Test Event tracing exporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				eventName: "my-tracing.spans",
 				sendStartSpan: true,
 				sendFinishSpan: true,

--- a/test/unit/tracing/exporters/jaeger.spec.js
+++ b/test/unit/tracing/exporters/jaeger.spec.js
@@ -47,6 +47,7 @@ describe("Test Jaeger tracing exporter class", () => {
 			const exporter = new JaegerTraceExporter();
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				endpoint: null,
 				host: "127.0.0.1",
 				port: 6832,
@@ -80,6 +81,7 @@ describe("Test Jaeger tracing exporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				endpoint: "http://jaeger:9411",
 				host: "127.0.0.1",
 				port: 6832,

--- a/test/unit/tracing/exporters/newrelic.spec.js
+++ b/test/unit/tracing/exporters/newrelic.spec.js
@@ -18,6 +18,7 @@ describe("Test NewRelic tracing exporter class", () => {
 			const exporter = new NewRelicTraceExporter();
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				baseURL: "https://trace-api.newrelic.com",
 				defaultTags: null,
 				insertKey: "",
@@ -46,6 +47,7 @@ describe("Test NewRelic tracing exporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				baseURL: "https://trace-api.newrelic.com",
 				interval: 10,
 				insertKey: "mock-newrelic-insert-key",

--- a/test/unit/tracing/exporters/zipkin.spec.js
+++ b/test/unit/tracing/exporters/zipkin.spec.js
@@ -18,6 +18,7 @@ describe("Test Zipkin tracing exporter class", () => {
 			const exporter = new ZipkinTraceExporter();
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				baseURL: "http://localhost:9411",
 				defaultTags: null,
 				interval: 5,
@@ -52,6 +53,7 @@ describe("Test Zipkin tracing exporter class", () => {
 			});
 
 			expect(exporter.opts).toEqual({
+				safetyTags: false,
 				baseURL: "http://zipkin-server:9411",
 				interval: 10,
 				payloadOptions: {


### PR DESCRIPTION
## :memo: Description

### Option 1
A common problem is that developers or external modules send non-serializable parameters (e.g. http request, socket instance, stream instance...etc) in `ctx.params` or `ctx.meta`. If tracing is enabled, the tracer exporters try to convert these parameters in `flattenTags` methods which is flattening the given object recursively, which causes maximum call stack error.

To avoid it, we added a `safetyTags` option to the exporter options. If it is `true`, the exporters remove the cyclic properties before flattening the tags in the spans. This option is available in all built-in exporters.

>Please note, this enabled option affects the performance, this is the reason why it's not enabled by default.

```js
// moleculer.config.js
{
    tracing: {
        exporter: [{
            type: "Zipkin",
            options: {
                safetyTags: true,
                baseURL: "http://127.0.0.1:9411"
            }
        }]
    }
}
``` 

### Option 2
To avoid that all action span tags will be converted because only just a few are affected by the problem, you can enable this function at action-level as well.

```js
broker.createService({
    name: "greeter",
    actions: {
        hello: {
            tracing: {
                safetyTags: true
            },
            handler(ctx) {
                return `Hello!`;
            }
        }
    }
});
```

### :dart: Relevant issues
Resolves #777, #908

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

