### PR TITLE
Introduces exclusions from tracing

### DIFF
--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -318,9 +318,8 @@ class Tracer {
 	 */
 	spanFinished(span) {
 		if (span.sampled) {
-			if (this.opts.exclude && this.opts.exclude.length != 0 && this.opts.exclude.indexOf(span.tags.action.name) != -1) return;
-			if (this.opts.excludeByRest && this.opts.excludeByRest.length != 0 && this.opts.excludeByRest.indexOf(span.name) != -1) return;
-			
+			if (this.opts.exclude && this.opts.exclude.length !== 0 && this.opts.exclude.indexOf(span.tags.action.name) !== -1) return;
+			if (this.opts.excludeByRest && this.opts.excludeByRest.length !== 0 && this.opts.excludeByRest.indexOf(span.name) !== -1) return;
 			this.invokeExporter("spanFinished", [span]);
 		}
 	}

--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -317,9 +317,12 @@ class Tracer {
 	 * @memberof Tracer
 	 */
 	spanFinished(span) {
-		//this.removeCurrentSpan(span);
-
-		if (span.sampled) this.invokeExporter("spanFinished", [span]);
+		if (span.sampled) {
+			if (this.opts.exclude && this.opts.exclude.length != 0 && this.opts.exclude.indexOf(span.tags.action.name) != -1) return;
+			if (this.opts.excludeByRest && this.opts.excludeByRest.length != 0 && this.opts.excludeByRest.indexOf(span.name) != -1) return;
+			
+			this.invokeExporter("spanFinished", [span]);
+		}
 	}
 }
 


### PR DESCRIPTION
## :memo: Description

Introduces support for excluding actions from tracing.
In the tracing configuration object, two arrays can be added:

exclude : ["service.action","service1.action1"] - will exclude by service and action name
excludeByRest : ["GET /service/action"] - Useful to exclude REST actions from tracing within API Gateway

This will apply gobally, to any exporters configured
### :dart: Relevant issues
#720 

### :gem: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
    tracing: {
        enabled: true,
        exclude : ["service.action"],
        excludeByRest : ["GET /service/action"],
        // Available built-in exporters: "Console", "Datadog", "Event", "EventLegacy", "Jaeger", "Zipkin"
        exporter: {
            type: "Console", // Console exporter is only for development!
            options: {
                // Custom logger
                logger: null,
                // Using colors
                colors: true,
                // Width of row
                width: 100,
                // Gauge width in the row
                gaugeWidth: 40
            }
        }
    },

``` 

## :vertical_traffic_light: How Has This Been Tested?

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
