### PR TITLE
pino child logger bindings + options args fix

### DIFF
--- a/src/loggers/pino.js
+++ b/src/loggers/pino.js
@@ -73,7 +73,7 @@ class PinoLogger extends BaseLogger {
 
 		const logger = isFunction(this.opts.createLogger)
 			? this.opts.createLogger(level, bindings)
-			: this.pino.child({}, { level, ...bindings });
+			: this.pino.child(bindings, { level });
 
 		return (type, args) => logger[type](...args);
 	}

--- a/test/unit/loggers/pino.spec.js
+++ b/test/unit/loggers/pino.spec.js
@@ -95,11 +95,12 @@ describe("Test Pino logger class", () => {
 			expect(logHandler).toBeInstanceOf(Function);
 			expect(logger.pino.child).toHaveBeenCalledTimes(1);
 			expect(logger.pino.child).toHaveBeenCalledWith(
-				{},
 				{
-					level: "info",
 					mod: "my-service",
 					nodeID: "node-1"
+				},
+				{
+					level: "info"
 				}
 			);
 


### PR DESCRIPTION
## :memo: Description

Bug fix for bindings not properly flowing to Pino child logger output.  

### :dart: Relevant issues
#973

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code

N/A

## :vertical_traffic_light: How Has This Been Tested?

- [x] npm test 

Updated pino unit test.  To output using pino logger, replace the ServiceBroker instantiation block with the following snippet in  ./dev/dev.js: 

Before making the proposed change to the Pino logger, bindings are missing from the output.  After making the change, binding show up as expected. 

```
const broker = new ServiceBroker({
	tracing: {
		enabled: true,
		sampling: {
			rate: 1.0
		},
		events: true,
		exporter: {
			type: "Event"
		}
	},
	logger: {
		type: "Pino"
	}
});
```

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
