### PR TITLE
Deprecated method substr replaced with substring

### DIFF
--- a/benchmark/suites/serializers.js
+++ b/benchmark/suites/serializers.js
@@ -17,7 +17,7 @@ let dataFiles = ["10", "1k", "50k", "100k", "buf-10240", "buf-102400"];
 function runTest(dataName) {
 	let payload = !dataName.startsWith("buf-")
 		? JSON.parse(getDataFile(dataName + ".json"))
-		: crypto.randomBytes(parseInt(dataName.substr(4)));
+		: crypto.randomBytes(parseInt(dataName.substring(4)));
 
 	const broker = new ServiceBroker({ logger: false });
 

--- a/dev/buffer.js
+++ b/dev/buffer.js
@@ -78,7 +78,7 @@ function inspect(x) {
 		rv = x.constructor.name;
 	}
 	if (typeof x === "object") {
-		rv += ". Keys: " + Object.keys(x).join(", ").substr(0, 80);
+		rv += ". Keys: " + Object.keys(x).join(", ").substring(0, 80);
 	}
 	return rv;
 }

--- a/src/loggers/file.js
+++ b/src/loggers/file.js
@@ -111,7 +111,7 @@ class FileLogger extends FormattedLogger {
 				return this.render(format, {
 					...row,
 					timestamp,
-					time: timestamp.substr(11),
+					time: timestamp.substring(11),
 
 					level: this.padLevels[row.level],
 					mod: row && row.mod ? row.mod.toUpperCase() : ""
@@ -126,7 +126,7 @@ class FileLogger extends FormattedLogger {
 	getFilename() {
 		const now = new Date();
 		//const date = `${now.getFullYear()}-${_.padStart(now.getMonth() + 1, 2, "0")}-${_.padStart(now.getDate(), 2, "0")}`;
-		const date = now.toISOString().substr(0, 10);
+		const date = now.toISOString().substring(0, 10);
 
 		return path.join(
 			this.logFolder,

--- a/src/loggers/formatted.js
+++ b/src/loggers/formatted.js
@@ -182,7 +182,7 @@ class FormattedLogger extends BaseLogger {
 			const prefixLen = 23 + bindings.mod.length;
 			this.maxPrefixLength = Math.max(prefixLen, this.maxPrefixLength);
 			return (type, args) => [
-				kleur.grey(`[${new Date().toISOString().substr(11)}]`),
+				kleur.grey(`[${new Date().toISOString().substring(11)}]`),
 				this.levelColorStr[type],
 				modColorName + this.padLeft(prefixLen) + kleur.grey(":"),
 				...printArgs(args)
@@ -205,7 +205,7 @@ class FormattedLogger extends BaseLogger {
 				return [
 					this.render(formatter, {
 						timestamp: kleur.grey(timestamp),
-						time: kleur.grey(timestamp.substr(11)),
+						time: kleur.grey(timestamp.substring(11)),
 
 						level: this.levelColorStr[type],
 						nodeID: kleur.grey(bindings.nodeID),

--- a/src/runner.js
+++ b/src/runner.js
@@ -224,7 +224,7 @@ class MoleculerRunner {
 				.filter(key => key.startsWith(moleculerPrefix))
 				.map(key => ({
 					key,
-					withoutPrefix: key.substr(moleculerPrefix.length)
+					withoutPrefix: key.substring(moleculerPrefix.length)
 				}))
 				.forEach(variable => {
 					const dotted = variable.withoutPrefix


### PR DESCRIPTION
## :memo: Description

Deprecated method ```substr``` ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)) replaced with ```substring```

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **New and existing unit tests pass locally with my changes**
