### PR TITLE
fix(service): removed static on methods for the use of ServiceFactory

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -824,10 +824,7 @@ class ServiceBroker {
 		if (Object.prototype.isPrototypeOf.call(this.ServiceFactory, schema)) {
 			service = new schema(this, schemaMods);
 		} else {
-			let s = schema;
-			if (schemaMods) s = this.ServiceFactory.mergeSchemas(schema, schemaMods);
-
-			service = new this.ServiceFactory(this, s);
+			service = new this.ServiceFactory(this, schema, schemaMods);
 		}
 
 		// If broker has started yet, call the started lifecycle event of service

--- a/src/service.js
+++ b/src/service.js
@@ -145,8 +145,10 @@ class Service {
 						"stopped",
 						"_start",
 						"_stop",
-						"_init"
-					].indexOf(name) !== -1
+						"_init",
+						"applyMixins"
+					].indexOf(name) !== -1 ||
+					name.startsWith("mergeSchema")
 				) {
 					throw new ServiceSchemaError(
 						`Invalid method name '${name}' in '${this.name}' service!`

--- a/src/service.js
+++ b/src/service.js
@@ -44,16 +44,17 @@ class Service {
 	 *
 	 * @param {ServiceBroker} 	broker	broker of service
 	 * @param {Object} 			schema	schema of service
+	 * @param {any=} 			schemaMods	Modified schema
 	 *
 	 * @memberof Service
 	 */
-	constructor(broker, schema) {
+	constructor(broker, schema, schemaMods) {
 		if (!isObject(broker)) throw new ServiceSchemaError("Must set a ServiceBroker instance!");
 
 		this.broker = broker;
 
 		if (broker) this.Promise = broker.Promise;
-
+		if (schemaMods) schema = this.mergeSchemas(schema, schemaMods);
 		if (schema) this.parseServiceSchema(schema);
 	}
 
@@ -71,7 +72,7 @@ class Service {
 		this.originalSchema = _.cloneDeep(schema);
 
 		if (schema.mixins) {
-			schema = Service.applyMixins(schema);
+			schema = this.applyMixins(schema);
 		}
 
 		if (isFunction(schema.merged)) {
@@ -145,7 +146,7 @@ class Service {
 						"_start",
 						"_stop",
 						"_init"
-					].indexOf(name) != -1
+					].indexOf(name) !== -1
 				) {
 					throw new ServiceSchemaError(
 						`Invalid method name '${name}' in '${this.name}' service!`
@@ -554,25 +555,24 @@ class Service {
 	/**
 	 * Apply `mixins` list in schema. Merge the schema with mixins schemas. Returns with the mixed schema
 	 *
-	 * @static
 	 * @param {Schema} schema
 	 * @returns {Schema}
 	 *
 	 * @memberof Service
 	 */
-	static applyMixins(schema) {
+	applyMixins(schema) {
 		if (schema.mixins) {
 			const mixins = Array.isArray(schema.mixins) ? schema.mixins : [schema.mixins];
 			if (mixins.length > 0) {
 				const mixedSchema = Array.from(mixins)
 					.reverse()
 					.reduce((s, mixin) => {
-						if (mixin.mixins) mixin = Service.applyMixins(mixin);
+						if (mixin.mixins) mixin = this.applyMixins(mixin);
 
-						return s ? Service.mergeSchemas(s, mixin) : mixin;
+						return s ? this.mergeSchemas(s, mixin) : mixin;
 					}, null);
 
-				return Service.mergeSchemas(mixedSchema, schema);
+				return this.mergeSchemas(mixedSchema, schema);
 			}
 		}
 
@@ -583,14 +583,13 @@ class Service {
 	/**
 	 * Merge two Service schema
 	 *
-	 * @static
 	 * @param {Object} mixinSchema		Mixin schema
 	 * @param {Object} svcSchema 		Service schema
 	 * @returns {Object} Mixed schema
 	 *
 	 * @memberof Service
 	 */
-	static mergeSchemas(mixinSchema, svcSchema) {
+	mergeSchemas(mixinSchema, svcSchema) {
 		const res = _.cloneDeep(mixinSchema);
 		const mods = _.cloneDeep(svcSchema);
 
@@ -598,39 +597,40 @@ class Service {
 			if (["name", "version"].indexOf(key) !== -1 && mods[key] !== undefined) {
 				// Simple overwrite
 				res[key] = mods[key];
-			} else if (key == "settings") {
+			} else if (key === "settings") {
 				// Merge with defaultsDeep
-				res[key] = Service.mergeSchemaSettings(mods[key], res[key]);
-			} else if (key == "metadata") {
+				res[key] = this.mergeSchemaSettings(mods[key], res[key]);
+			} else if (key === "metadata") {
 				// Merge with defaultsDeep
-				res[key] = Service.mergeSchemaMetadata(mods[key], res[key]);
-			} else if (key == "hooks") {
+				res[key] = this.mergeSchemaMetadata(mods[key], res[key]);
+			} else if (key === "hooks") {
 				// Merge & concat
-				res[key] = Service.mergeSchemaHooks(mods[key], res[key] || {});
-			} else if (key == "actions") {
+				res[key] = this.mergeSchemaHooks(mods[key], res[key] || {});
+			} else if (key === "actions") {
 				// Merge with defaultsDeep
-				res[key] = Service.mergeSchemaActions(mods[key], res[key] || {});
-			} else if (key == "methods") {
+				res[key] = this.mergeSchemaActions(mods[key], res[key] || {});
+			} else if (key === "methods") {
 				// Overwrite
-				res[key] = Service.mergeSchemaMethods(mods[key], res[key]);
-			} else if (key == "events") {
+				res[key] = this.mergeSchemaMethods(mods[key], res[key]);
+			} else if (key === "events") {
 				// Merge & concat by groups
-				res[key] = Service.mergeSchemaEvents(mods[key], res[key] || {});
+				res[key] = this.mergeSchemaEvents(mods[key], res[key] || {});
 			} else if (["merged", "created", "started", "stopped"].indexOf(key) !== -1) {
 				// Concat lifecycle event handlers
-				res[key] = Service.mergeSchemaLifecycleHandlers(mods[key], res[key]);
-			} else if (key == "mixins") {
+				res[key] = this.mergeSchemaLifecycleHandlers(mods[key], res[key]);
+			} else if (key === "mixins") {
 				// Concat mixins
-				res[key] = Service.mergeSchemaUniqArray(mods[key], res[key]);
-			} else if (key == "dependencies") {
+				res[key] = this.mergeSchemaUniqArray(mods[key], res[key]);
+			} else if (key === "dependencies") {
 				// Concat mixins
-				res[key] = Service.mergeSchemaUniqArray(mods[key], res[key]);
+				res[key] = this.mergeSchemaUniqArray(mods[key], res[key]);
 			} else {
 				const customFnName = "mergeSchema" + key.replace(/./, key[0].toUpperCase()); // capitalize first letter
-				if (isFunction(Service[customFnName])) {
-					res[key] = Service[customFnName](mods[key], res[key]);
+				// TODO: add middleware hook
+				if (isFunction(this[customFnName])) {
+					res[key] = this[customFnName](mods[key], res[key]);
 				} else {
-					res[key] = Service.mergeSchemaUnknown(mods[key], res[key]);
+					res[key] = this.mergeSchemaUnknown(mods[key], res[key]);
 				}
 			}
 		});
@@ -641,13 +641,12 @@ class Service {
 	/**
 	 * Merge `settings` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaSettings(src, target) {
+	mergeSchemaSettings(src, target) {
 		if ((target && target.$secureSettings) || (src && src.$secureSettings)) {
 			const srcSS = src && src.$secureSettings ? src.$secureSettings : [];
 			const targetSS = target && target.$secureSettings ? target.$secureSettings : [];
@@ -662,52 +661,48 @@ class Service {
 	/**
 	 * Merge `metadata` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaMetadata(src, target) {
+	mergeSchemaMetadata(src, target) {
 		return _.defaultsDeep(src, target);
 	}
 
 	/**
 	 * Merge `mixins` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaUniqArray(src, target) {
+	mergeSchemaUniqArray(src, target) {
 		return _.uniqWith(_.compact(flatten([src, target])), _.isEqual);
 	}
 
 	/**
 	 * Merge `dependencies` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaDependencies(src, target) {
-		return Service.mergeSchemaUniqArray(src, target);
+	mergeSchemaDependencies(src, target) {
+		return this.mergeSchemaUniqArray(src, target);
 	}
 
 	/**
 	 * Merge `hooks` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaHooks(src, target) {
+	mergeSchemaHooks(src, target) {
 		Object.keys(src).forEach(k => {
 			if (target[k] == null) target[k] = {};
 
@@ -716,7 +711,7 @@ class Service {
 				const resHook = wrapToArray(target[k][k2]);
 
 				target[k][k2] = _.compact(
-					flatten(k == "before" ? [resHook, modHook] : [modHook, resHook])
+					flatten(k === "before" ? [resHook, modHook] : [modHook, resHook])
 				);
 			});
 		});
@@ -727,13 +722,12 @@ class Service {
 	/**
 	 * Merge `actions` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property (real schema)
 	 * @param {Object} target Target schema property (mixin schema)
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaActions(src, target) {
+	mergeSchemaActions(src, target) {
 		Object.keys(src).forEach(k => {
 			if (src[k] === false && target[k]) {
 				delete target[k];
@@ -749,7 +743,7 @@ class Service {
 					const resHook = wrapToArray(targetAction.hooks[k]);
 
 					srcAction.hooks[k] = _.compact(
-						flatten(k == "before" ? [resHook, modHook] : [modHook, resHook])
+						flatten(k === "before" ? [resHook, modHook] : [modHook, resHook])
 					);
 				});
 			}
@@ -763,26 +757,24 @@ class Service {
 	/**
 	 * Merge `methods` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaMethods(src, target) {
+	mergeSchemaMethods(src, target) {
 		return Object.assign(target || {}, src || {});
 	}
 
 	/**
 	 * Merge `events` property in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaEvents(src, target) {
+	mergeSchemaEvents(src, target) {
 		Object.keys(src).forEach(k => {
 			const modEvent = wrapToHander(src[k]);
 			const resEvent = wrapToHander(target[k]);
@@ -790,7 +782,7 @@ class Service {
 			let handler = _.compact(
 				flatten([resEvent ? resEvent.handler : null, modEvent ? modEvent.handler : null])
 			);
-			if (handler.length == 1) handler = handler[0];
+			if (handler.length === 1) handler = handler[0];
 
 			target[k] = _.defaultsDeep(modEvent, resEvent);
 			target[k].handler = handler;
@@ -802,26 +794,24 @@ class Service {
 	/**
 	 * Merge `started`, `stopped`, `created` event handler properties in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaLifecycleHandlers(src, target) {
+	mergeSchemaLifecycleHandlers(src, target) {
 		return _.compact(flatten([target, src]));
 	}
 
 	/**
 	 * Merge unknown properties in schema
 	 *
-	 * @static
 	 * @param {Object} src Source schema property
 	 * @param {Object} target Target schema property
 	 *
 	 * @returns {Object} Merged schema
 	 */
-	static mergeSchemaUnknown(src, target) {
+	mergeSchemaUnknown(src, target) {
 		if (src !== undefined) return src;
 
 		return target;

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -795,7 +795,7 @@ describe("Test broker.stop", () => {
 
 	describe("if stopped throw error", () => {
 		let broker;
-		let schema = {
+		const schema = {
 			name: "test",
 			stopped: jest.fn(() => Promise.reject("Can't stop!"))
 		};
@@ -1073,7 +1073,7 @@ describe("Test isTracingEnabled", () => {
 });
 
 describe("Test broker.getLogger", () => {
-	let broker = new ServiceBroker({ namespace: "test-ns", logger: false });
+	const broker = new ServiceBroker({ namespace: "test-ns", logger: false });
 
 	it("should call loggerFactory with module name", () => {
 		broker.loggerFactory.getLogger = jest.fn();
@@ -1105,7 +1105,7 @@ describe("Test broker.getLogger", () => {
 });
 
 describe("Test broker.fatal", () => {
-	let broker = new ServiceBroker({ logger: false });
+	const broker = new ServiceBroker({ logger: false });
 
 	broker.logger.fatal = jest.fn();
 	broker.logger.debug = jest.fn();
@@ -1136,11 +1136,11 @@ describe("Test broker.fatal", () => {
 });
 
 describe("Test loadServices", () => {
-	let broker = new ServiceBroker({ logger: false });
+	const broker = new ServiceBroker({ logger: false });
 	broker.loadService = jest.fn();
 
 	it("should load 5 services", () => {
-		let count = broker.loadServices("./test/services");
+		const count = broker.loadServices("./test/services");
 		expect(count).toBe(5);
 		expect(broker.loadService).toHaveBeenCalledTimes(5);
 		expect(broker.loadService).toHaveBeenCalledWith("test/services/users.service.js");
@@ -1152,7 +1152,7 @@ describe("Test loadServices", () => {
 
 	it("should load 1 services", () => {
 		broker.loadService.mockClear();
-		let count = broker.loadServices("./test/services", "users.*.js");
+		const count = broker.loadServices("./test/services", "users.*.js");
 		expect(count).toBe(1);
 		expect(broker.loadService).toHaveBeenCalledTimes(1);
 		expect(broker.loadService).toHaveBeenCalledWith("test/services/users.service.js");
@@ -1160,14 +1160,14 @@ describe("Test loadServices", () => {
 
 	it("should load 0 services", () => {
 		broker.loadService.mockClear();
-		let count = broker.loadServices();
+		const count = broker.loadServices();
 		expect(count).toBe(0);
 		expect(broker.loadService).toHaveBeenCalledTimes(0);
 	});
 
 	it("should load selected services", () => {
 		broker.loadService.mockClear();
-		let count = broker.loadServices("./test/services", ["users.service", "math.service"]);
+		const count = broker.loadServices("./test/services", ["users.service", "math.service"]);
 		expect(count).toBe(2);
 		expect(broker.loadService).toHaveBeenCalledTimes(2);
 		expect(broker.loadService).toHaveBeenCalledWith(
@@ -1180,13 +1180,13 @@ describe("Test loadServices", () => {
 });
 
 describe("Test broker.loadService", () => {
-	let broker = new ServiceBroker({ logger: false, hotReload: true });
+	const broker = new ServiceBroker({ logger: false, hotReload: true });
 	broker.createService = jest.fn(svc => svc);
 	broker._restartService = jest.fn();
 
 	it("should load service from schema", () => {
 		// Load schema
-		let service = broker.loadService("./test/services/math.service.js");
+		const service = broker.loadService("./test/services/math.service.js");
 		expect(service).toBeDefined();
 		expect(service.__filename).toBeDefined();
 		expect(broker.createService).toHaveBeenCalledTimes(1);
@@ -1196,7 +1196,7 @@ describe("Test broker.loadService", () => {
 	it("should call function which returns Service instance", () => {
 		broker.createService.mockClear();
 		broker._restartService.mockClear();
-		let service = broker.loadService("./test/services/users.service.js");
+		const service = broker.loadService("./test/services/users.service.js");
 		expect(service).toBeInstanceOf(broker.ServiceFactory);
 		expect(broker.createService).toHaveBeenCalledTimes(0);
 		expect(broker._restartService).toHaveBeenCalledTimes(0);
@@ -1205,7 +1205,7 @@ describe("Test broker.loadService", () => {
 	it("should call function which returns schema", () => {
 		broker.createService.mockClear();
 		broker._restartService.mockClear();
-		let service = broker.loadService("./test/services/posts.service.js");
+		const service = broker.loadService("./test/services/posts.service.js");
 		expect(service).toBeDefined();
 		expect(broker.createService).toHaveBeenCalledTimes(1);
 		expect(broker._restartService).toHaveBeenCalledTimes(0);
@@ -1214,7 +1214,7 @@ describe("Test broker.loadService", () => {
 	it("should load ES6 class", () => {
 		broker.createService.mockClear();
 		broker._restartService.mockClear();
-		let service = broker.loadService("./test/services/greeter.es6.service.js");
+		const service = broker.loadService("./test/services/greeter.es6.service.js");
 		expect(service).toBeDefined();
 		expect(broker.createService).toHaveBeenCalledTimes(0);
 		expect(broker._restartService).toHaveBeenCalledTimes(0);
@@ -1241,7 +1241,7 @@ describe("Test broker.loadService", () => {
 });
 
 describe("Test broker.loadService after broker started", () => {
-	let broker = new ServiceBroker({ logger: false, hotReload: true });
+	const broker = new ServiceBroker({ logger: false, hotReload: true });
 	broker.createService = jest.fn(svc => svc);
 	broker._restartService = jest.fn();
 
@@ -1250,7 +1250,7 @@ describe("Test broker.loadService after broker started", () => {
 
 	it("should load service from schema", () => {
 		// Load schema
-		let service = broker.loadService("./test/services/math.service.js");
+		const service = broker.loadService("./test/services/math.service.js");
 		expect(service).toBeDefined();
 		expect(service.__filename).toBeDefined();
 		expect(broker.createService).toHaveBeenCalledTimes(1);
@@ -1260,7 +1260,7 @@ describe("Test broker.loadService after broker started", () => {
 	it("should call function which returns Service instance", () => {
 		broker.createService.mockClear();
 		broker._restartService.mockClear();
-		let service = broker.loadService("./test/services/users.service.js");
+		const service = broker.loadService("./test/services/users.service.js");
 		expect(service).toBeInstanceOf(broker.ServiceFactory);
 		expect(broker.createService).toHaveBeenCalledTimes(0);
 		expect(broker._restartService).toHaveBeenCalledTimes(1);
@@ -1270,7 +1270,7 @@ describe("Test broker.loadService after broker started", () => {
 	it("should call function which returns schema", () => {
 		broker.createService.mockClear();
 		broker._restartService.mockClear();
-		let service = broker.loadService("./test/services/posts.service.js");
+		const service = broker.loadService("./test/services/posts.service.js");
 		expect(service).toBeDefined();
 		expect(broker.createService).toHaveBeenCalledTimes(1);
 		expect(broker._restartService).toHaveBeenCalledTimes(0);
@@ -1279,7 +1279,7 @@ describe("Test broker.loadService after broker started", () => {
 	it("should load ES6 class", () => {
 		broker.createService.mockClear();
 		broker._restartService.mockClear();
-		let service = broker.loadService("./test/services/greeter.es6.service.js");
+		const service = broker.loadService("./test/services/greeter.es6.service.js");
 		expect(service).toBeDefined();
 		expect(broker.createService).toHaveBeenCalledTimes(0);
 		expect(broker._restartService).toHaveBeenCalledTimes(1);
@@ -1288,41 +1288,55 @@ describe("Test broker.loadService after broker started", () => {
 });
 
 describe("Test broker.createService", () => {
-	let broker = new ServiceBroker({ logger: false });
+	const broker = new ServiceBroker({ logger: false });
 	broker.ServiceFactory = jest.fn((broker, schema) => schema);
-	broker.ServiceFactory.mergeSchemas = jest.fn();
 
 	it("should load math service", () => {
-		let schema = {
+		const schema = {
 			name: "test",
 			actions: {
 				empty() {}
 			}
 		};
 
-		let service = broker.createService(schema);
+		const service = broker.createService(schema);
 		expect(service).toBe(schema);
 		expect(broker.ServiceFactory).toHaveBeenCalledTimes(1);
-		expect(broker.ServiceFactory).toHaveBeenCalledWith(broker, schema);
+		expect(broker.ServiceFactory).toHaveBeenCalledWith(broker, schema, undefined);
+	});
+
+	it("should can't call mergeSchema if not give schema mods param", () => {
+		const broker = new ServiceBroker({ logger: false });
+		broker.ServiceFactory.prototype.mergeSchemas = jest.fn(schema => schema);
+		const schema = {
+			name: "test",
+			actions: {
+				empty() {}
+			}
+		};
+
+		broker.createService(schema);
+		expect(broker.ServiceFactory.prototype.mergeSchemas).toHaveBeenCalledTimes(0);
 	});
 
 	it("should call mergeSchema if give schema mods param", () => {
-		broker.ServiceFactory.mergeSchemas = jest.fn(s1 => s1);
-		let schema = {
+		const broker = new ServiceBroker({ logger: false });
+		broker.ServiceFactory.prototype.mergeSchemas = jest.fn(schema => schema);
+		const schema = {
 			name: "test",
 			actions: {
 				empty() {}
 			}
 		};
 
-		let mods = {
+		const mods = {
 			name: "other",
 			version: 2
 		};
 
 		broker.createService(schema, mods);
-		expect(broker.ServiceFactory.mergeSchemas).toHaveBeenCalledTimes(1);
-		expect(broker.ServiceFactory.mergeSchemas).toHaveBeenCalledWith(schema, mods);
+		expect(broker.ServiceFactory.prototype.mergeSchemas).toHaveBeenCalledTimes(1);
+		expect(broker.ServiceFactory.prototype.mergeSchemas).toHaveBeenCalledWith(schema, mods);
 	});
 
 	it("should load es6 class service", () => {
@@ -1336,7 +1350,7 @@ describe("Test broker.createService", () => {
 });
 
 describe("Test broker.__restartService", () => {
-	let broker = new ServiceBroker({ logger: false });
+	const broker = new ServiceBroker({ logger: false });
 
 	const schema = {
 		name: "test",
@@ -2070,7 +2084,7 @@ describe("Test waitForServices using dependencyInterval from options", () => {
 		jest.spyOn(broker, "createService");
 		jest.spyOn(broker, "waitForServices");
 
-		let services = [
+		[
 			{ name: "users" },
 			{ name: "auth" },
 			{ name: "posts", dependencies: ["users", "auth"] }

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -3,7 +3,6 @@
 const Service = require("../../src/service");
 const Context = require("../../src/context");
 const ServiceBroker = require("../../src/service-broker");
-const { protectReject } = require("./utils");
 
 describe("Test Service class", () => {
 	describe("Test constructor", () => {
@@ -44,7 +43,7 @@ describe("Test Service class", () => {
 
 		jest.spyOn(broker, "callMiddlewareHookSync");
 		jest.spyOn(broker, "getLogger");
-		jest.spyOn(Service, "applyMixins");
+		jest.spyOn(Service.prototype, "applyMixins");
 
 		const svc = new Service(broker);
 
@@ -57,7 +56,7 @@ describe("Test Service class", () => {
 		});
 
 		it("should throw error if name is empty", () => {
-			Service.applyMixins.mockClear();
+			Service.prototype.applyMixins.mockClear();
 			expect(() => {
 				/* eslint-disable-next-line no-console */
 				console.error = jest.fn();
@@ -65,11 +64,11 @@ describe("Test Service class", () => {
 			}).toThrowError(
 				"Service name can't be empty! Maybe it is not a valid Service schema. Maybe is it not a service schema?"
 			);
-			expect(Service.applyMixins).toBeCalledTimes(0);
+			expect(Service.prototype.applyMixins).toBeCalledTimes(0);
 		});
 
 		it("should set common local variables", () => {
-			Service.applyMixins.mockClear();
+			Service.prototype.applyMixins.mockClear();
 
 			const schema = { name: "posts" };
 			svc.parseServiceSchema(schema);
@@ -77,7 +76,7 @@ describe("Test Service class", () => {
 			expect(svc.originalSchema).toEqual({ name: "posts" });
 			expect(svc.originalSchema).not.toBe(schema);
 
-			expect(Service.applyMixins).toBeCalledTimes(0);
+			expect(Service.prototype.applyMixins).toBeCalledTimes(0);
 
 			expect(svc.name).toBe("posts");
 			expect(svc.version).toBeUndefined();
@@ -97,7 +96,7 @@ describe("Test Service class", () => {
 		});
 
 		it("should set common local variables with version", () => {
-			Service.applyMixins.mockClear();
+			Service.prototype.applyMixins.mockClear();
 			broker.getLogger.mockClear();
 			svc._init.mockClear();
 
@@ -107,8 +106,8 @@ describe("Test Service class", () => {
 			expect(svc.originalSchema).toEqual({ name: "posts", version: 3, mixins: [] });
 			expect(svc.originalSchema).not.toBe(schema);
 
-			expect(Service.applyMixins).toBeCalledTimes(1);
-			expect(Service.applyMixins).toBeCalledWith(schema);
+			expect(Service.prototype.applyMixins).toBeCalledTimes(1);
+			expect(Service.prototype.applyMixins).toBeCalledWith(schema);
 
 			expect(svc.name).toBe("posts");
 			expect(svc.version).toBe(3);
@@ -128,7 +127,7 @@ describe("Test Service class", () => {
 		});
 
 		it("should set common local variables with version & noVersionPrefix", () => {
-			Service.applyMixins.mockClear();
+			Service.prototype.applyMixins.mockClear();
 			broker.getLogger.mockClear();
 			svc._init.mockClear();
 
@@ -197,7 +196,7 @@ describe("Test Service class", () => {
 				handler: action.handler || action
 			}));
 			jest.spyOn(broker.middlewares, "wrapHandler").mockImplementation(
-				(type, handler, action) => handler
+				(type, handler) => handler
 			);
 			jest.spyOn(broker.registry, "createPrivateActionEndpoint").mockImplementation(() => ({
 				id: "nodeID"
@@ -1255,22 +1254,22 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static applyMixins", () => {
-		beforeAll(() => jest.spyOn(Service, "mergeSchemas").mockImplementation(s => s));
-		afterAll(() => Service.mergeSchemas.mockRestore());
+	describe("Test applyMixins", () => {
+		beforeAll(() => jest.spyOn(Service.prototype, "mergeSchemas").mockImplementation(s => s));
+		afterAll(() => Service.prototype.mergeSchemas.mockRestore());
 
 		it("should return the schema if no mixins defined", () => {
-			Service.mergeSchemas.mockClear();
+			Service.prototype.mergeSchemas.mockClear();
 			const schema = { name: "posts" };
 
-			const res = Service.applyMixins(schema);
+			const res = Service.prototype.applyMixins(schema);
 
 			expect(res).toBe(schema);
-			expect(Service.mergeSchemas).toBeCalledTimes(0);
+			expect(Service.prototype.mergeSchemas).toBeCalledTimes(0);
 		});
 
 		it("should call mergeSchema once", () => {
-			Service.mergeSchemas.mockClear();
+			Service.prototype.mergeSchemas.mockClear();
 			const mixin1 = {
 				name: "users"
 			};
@@ -1280,17 +1279,17 @@ describe("Test Service class", () => {
 				mixins: mixin1
 			};
 
-			const res = Service.applyMixins(schema);
+			const res = Service.prototype.applyMixins(schema);
 
 			expect(res).toEqual({
 				name: "users"
 			});
-			expect(Service.mergeSchemas).toBeCalledTimes(1);
-			expect(Service.mergeSchemas).toBeCalledWith(mixin1, schema);
+			expect(Service.prototype.mergeSchemas).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemas).toBeCalledWith(mixin1, schema);
 		});
 
 		it("should call mergeSchema twice", () => {
-			Service.mergeSchemas.mockClear();
+			Service.prototype.mergeSchemas.mockClear();
 			const mixin1 = {
 				name: "users"
 			};
@@ -1304,19 +1303,19 @@ describe("Test Service class", () => {
 				mixins: [mixin1, mixin2]
 			};
 
-			const res = Service.applyMixins(schema);
+			const res = Service.prototype.applyMixins(schema);
 
 			expect(res).toEqual({
 				version: 2
 			});
 
-			expect(Service.mergeSchemas).toBeCalledTimes(2);
-			expect(Service.mergeSchemas).toHaveBeenNthCalledWith(1, mixin2, mixin1);
-			expect(Service.mergeSchemas).toHaveBeenNthCalledWith(2, mixin2, schema);
+			expect(Service.prototype.mergeSchemas).toBeCalledTimes(2);
+			expect(Service.prototype.mergeSchemas).toHaveBeenNthCalledWith(1, mixin2, mixin1);
+			expect(Service.prototype.mergeSchemas).toHaveBeenNthCalledWith(2, mixin2, schema);
 		});
 
 		it("should call mergeSchema for multi-level mixins", () => {
-			Service.mergeSchemas.mockClear();
+			Service.prototype.mergeSchemas.mockClear();
 			const mixin2 = {
 				version: 2
 			};
@@ -1331,40 +1330,42 @@ describe("Test Service class", () => {
 				mixins: [mixin1]
 			};
 
-			const res = Service.applyMixins(schema);
+			const res = Service.prototype.applyMixins(schema);
 
 			expect(res).toEqual({
 				version: 2
 			});
 
-			expect(Service.mergeSchemas).toBeCalledTimes(2);
-			expect(Service.mergeSchemas).toHaveBeenNthCalledWith(1, mixin2, mixin1);
-			expect(Service.mergeSchemas).toHaveBeenNthCalledWith(2, mixin2, schema);
+			expect(Service.prototype.mergeSchemas).toBeCalledTimes(2);
+			expect(Service.prototype.mergeSchemas).toHaveBeenNthCalledWith(1, mixin2, mixin1);
+			expect(Service.prototype.mergeSchemas).toHaveBeenNthCalledWith(2, mixin2, schema);
 		});
 	});
 
-	describe("Test static mergeSchemas", () => {
+	describe("Test mergeSchemas", () => {
 		beforeAll(() => {
-			jest.spyOn(Service, "mergeSchemaSettings").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaMetadata").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaHooks").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaActions").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaMethods").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaEvents").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaLifecycleHandlers").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaUniqArray").mockImplementation(s => s);
-			jest.spyOn(Service, "mergeSchemaUnknown").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaSettings").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaMetadata").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaHooks").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaActions").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaMethods").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaEvents").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaLifecycleHandlers").mockImplementation(
+				s => s
+			);
+			jest.spyOn(Service.prototype, "mergeSchemaUniqArray").mockImplementation(s => s);
+			jest.spyOn(Service.prototype, "mergeSchemaUnknown").mockImplementation(s => s);
 		});
 		afterAll(() => {
-			Service.mergeSchemaSettings.mockRestore();
-			Service.mergeSchemaMetadata.mockRestore();
-			Service.mergeSchemaHooks.mockRestore();
-			Service.mergeSchemaActions.mockRestore();
-			Service.mergeSchemaMethods.mockRestore();
-			Service.mergeSchemaEvents.mockRestore();
-			Service.mergeSchemaLifecycleHandlers.mockRestore();
-			Service.mergeSchemaUniqArray.mockRestore();
-			Service.mergeSchemaUnknown.mockRestore();
+			Service.prototype.mergeSchemaSettings.mockRestore();
+			Service.prototype.mergeSchemaMetadata.mockRestore();
+			Service.prototype.mergeSchemaHooks.mockRestore();
+			Service.prototype.mergeSchemaActions.mockRestore();
+			Service.prototype.mergeSchemaMethods.mockRestore();
+			Service.prototype.mergeSchemaEvents.mockRestore();
+			Service.prototype.mergeSchemaLifecycleHandlers.mockRestore();
+			Service.prototype.mergeSchemaUniqArray.mockRestore();
+			Service.prototype.mergeSchemaUnknown.mockRestore();
 		});
 
 		it("should call merge methods", () => {
@@ -1430,66 +1431,79 @@ describe("Test Service class", () => {
 				custom: "123"
 			};
 
-			Service.mergeSchemas({}, mixin);
+			Service.prototype.mergeSchemas({}, mixin);
 
-			expect(Service.mergeSchemaSettings).toBeCalledTimes(1);
-			expect(Service.mergeSchemaSettings).toBeCalledWith(mixin.settings, undefined);
+			expect(Service.prototype.mergeSchemaSettings).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaSettings).toBeCalledWith(mixin.settings, undefined);
 
-			expect(Service.mergeSchemaMetadata).toBeCalledTimes(1);
-			expect(Service.mergeSchemaMetadata).toBeCalledWith(mixin.metadata, undefined);
+			expect(Service.prototype.mergeSchemaMetadata).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaMetadata).toBeCalledWith(mixin.metadata, undefined);
 
-			expect(Service.mergeSchemaHooks).toBeCalledTimes(1);
-			expect(Service.mergeSchemaHooks).toBeCalledWith(mixin.hooks, {});
+			expect(Service.prototype.mergeSchemaHooks).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaHooks).toBeCalledWith(mixin.hooks, {});
 
-			expect(Service.mergeSchemaActions).toBeCalledTimes(1);
-			expect(Service.mergeSchemaActions).toBeCalledWith(mixin.actions, {});
+			expect(Service.prototype.mergeSchemaActions).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaActions).toBeCalledWith(mixin.actions, {});
 
-			expect(Service.mergeSchemaMethods).toBeCalledTimes(1);
-			expect(Service.mergeSchemaMethods).toBeCalledWith(mixin.methods, undefined);
+			expect(Service.prototype.mergeSchemaMethods).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaMethods).toBeCalledWith(mixin.methods, undefined);
 
-			expect(Service.mergeSchemaEvents).toBeCalledTimes(1);
-			expect(Service.mergeSchemaEvents).toBeCalledWith(mixin.events, {});
+			expect(Service.prototype.mergeSchemaEvents).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaEvents).toBeCalledWith(mixin.events, {});
 
-			expect(Service.mergeSchemaLifecycleHandlers).toBeCalledTimes(3);
-			expect(Service.mergeSchemaLifecycleHandlers).toBeCalledWith(mixin.created, undefined);
-			expect(Service.mergeSchemaLifecycleHandlers).toBeCalledWith(mixin.started, undefined);
-			expect(Service.mergeSchemaLifecycleHandlers).toBeCalledWith(mixin.stopped, undefined);
+			expect(Service.prototype.mergeSchemaLifecycleHandlers).toBeCalledTimes(3);
+			expect(Service.prototype.mergeSchemaLifecycleHandlers).toBeCalledWith(
+				mixin.created,
+				undefined
+			);
+			expect(Service.prototype.mergeSchemaLifecycleHandlers).toBeCalledWith(
+				mixin.started,
+				undefined
+			);
+			expect(Service.prototype.mergeSchemaLifecycleHandlers).toBeCalledWith(
+				mixin.stopped,
+				undefined
+			);
 
-			expect(Service.mergeSchemaUniqArray).toBeCalledTimes(2);
-			expect(Service.mergeSchemaUniqArray).toHaveBeenNthCalledWith(
+			expect(Service.prototype.mergeSchemaUniqArray).toBeCalledTimes(2);
+			expect(Service.prototype.mergeSchemaUniqArray).toHaveBeenNthCalledWith(
 				1,
 				mixin.mixins,
 				undefined
 			);
-			expect(Service.mergeSchemaUniqArray).toHaveBeenNthCalledWith(
+			expect(Service.prototype.mergeSchemaUniqArray).toHaveBeenNthCalledWith(
 				2,
 				mixin.dependencies,
 				undefined
 			);
 
-			expect(Service.mergeSchemaUnknown).toBeCalledTimes(1);
-			expect(Service.mergeSchemaUnknown).toHaveBeenNthCalledWith(1, mixin.custom, undefined);
+			expect(Service.prototype.mergeSchemaUnknown).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaUnknown).toHaveBeenNthCalledWith(
+				1,
+				mixin.custom,
+				undefined
+			);
 		});
 
 		it("should call custom merge method", () => {
-			Service.mergeSchemaUnknown.mockClear();
-			Service.mergeSchemaMyProp = jest.fn();
+			Service.prototype.mergeSchemaUnknown.mockClear();
+			Service.prototype.mergeSchemaMyProp = jest.fn();
 
 			const mixin = {
 				myProp: "123"
 			};
 
-			Service.mergeSchemas({}, mixin);
+			Service.prototype.mergeSchemas({}, mixin);
 
-			expect(Service.mergeSchemaMyProp).toBeCalledTimes(1);
-			expect(Service.mergeSchemaMyProp).toBeCalledWith("123", undefined);
-			expect(Service.mergeSchemaUnknown).toBeCalledTimes(0);
+			expect(Service.prototype.mergeSchemaMyProp).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaMyProp).toBeCalledWith("123", undefined);
+			expect(Service.prototype.mergeSchemaUnknown).toBeCalledTimes(0);
 		});
 
 		it("should not overwrite the name & version", () => {
-			Service.mergeSchemaUnknown.mockClear();
+			Service.prototype.mergeSchemaUnknown.mockClear();
 
-			const mixed = Service.mergeSchemas(
+			const mixed = Service.prototype.mergeSchemas(
 				{
 					name: "first",
 					version: 1
@@ -1504,9 +1518,9 @@ describe("Test Service class", () => {
 		});
 
 		it("should overwrite the name & version", () => {
-			Service.mergeSchemaUnknown.mockClear();
+			Service.prototype.mergeSchemaUnknown.mockClear();
 
-			const mixed = Service.mergeSchemas(
+			const mixed = Service.prototype.mergeSchemas(
 				{
 					name: "first",
 					version: 1
@@ -1524,7 +1538,7 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaSettings", () => {
+	describe("Test mergeSchemaSettings", () => {
 		it("should merge values", () => {
 			const src = {
 				a: 5,
@@ -1543,7 +1557,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaSettings(src, prev);
+			const res = Service.prototype.mergeSchemaSettings(src, prev);
 			expect(res).toEqual({
 				a: 5,
 				b: "John",
@@ -1575,7 +1589,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaSettings(src, prev);
+			const res = Service.prototype.mergeSchemaSettings(src, prev);
 			expect(res).toEqual({
 				$secureSettings: ["a", "b", "c"],
 				a: 5,
@@ -1599,7 +1613,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaSettings(src, null);
+			const res = Service.prototype.mergeSchemaSettings(src, null);
 			expect(res).toEqual({
 				$secureSettings: ["a", "b"],
 				a: 5,
@@ -1622,7 +1636,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaSettings(null, src);
+			const res = Service.prototype.mergeSchemaSettings(null, src);
 			expect(res).toEqual({
 				$secureSettings: ["a", "b"],
 				a: 5,
@@ -1635,7 +1649,7 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaMetadata", () => {
+	describe("Test mergeSchemaMetadata", () => {
 		it("should merge values", () => {
 			const src = {
 				a: 5,
@@ -1654,7 +1668,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaMetadata(src, prev);
+			const res = Service.prototype.mergeSchemaMetadata(src, prev);
 			expect(res).toEqual({
 				a: 5,
 				b: "John",
@@ -1667,12 +1681,12 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaUniqArray", () => {
+	describe("Test mergeSchemaUniqArray", () => {
 		it("should merge values", () => {
 			const src = [1, 2, 3, 4, 5];
 			const prev = [2, 4, 6, 8, 10];
 
-			const res = Service.mergeSchemaUniqArray(src, prev);
+			const res = Service.prototype.mergeSchemaUniqArray(src, prev);
 			expect(res).toEqual([1, 2, 3, 4, 5, 6, 8, 10]);
 		});
 
@@ -1680,7 +1694,7 @@ describe("Test Service class", () => {
 			const src = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }];
 			const prev = [{ id: 2 }, { id: 4 }, { id: 6 }, { id: 8 }, { id: 10 }];
 
-			const res = Service.mergeSchemaUniqArray(src, prev);
+			const res = Service.prototype.mergeSchemaUniqArray(src, prev);
 			expect(res).toEqual([
 				{ id: 1 },
 				{ id: 2 },
@@ -1694,22 +1708,22 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaDependencies", () => {
+	describe("Test mergeSchemaDependencies", () => {
 		it("should merge values", () => {
-			jest.spyOn(Service, "mergeSchemaUniqArray");
+			jest.spyOn(Service.prototype, "mergeSchemaUniqArray");
 
 			const src = [1, 2, 3, 4, 5];
 			const prev = [2, 4, 6, 8, 10];
 
-			const res = Service.mergeSchemaDependencies(src, prev);
+			const res = Service.prototype.mergeSchemaDependencies(src, prev);
 			expect(res).toEqual([1, 2, 3, 4, 5, 6, 8, 10]);
 
-			expect(Service.mergeSchemaUniqArray).toBeCalledTimes(1);
-			expect(Service.mergeSchemaUniqArray).toBeCalledWith(src, prev);
+			expect(Service.prototype.mergeSchemaUniqArray).toBeCalledTimes(1);
+			expect(Service.prototype.mergeSchemaUniqArray).toBeCalledWith(src, prev);
 		});
 	});
 
-	describe("Test static mergeSchemaHooks", () => {
+	describe("Test mergeSchemaHooks", () => {
 		it("should merge values", () => {
 			const src = {
 				before: {
@@ -1737,7 +1751,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaHooks(src, prev);
+			const res = Service.prototype.mergeSchemaHooks(src, prev);
 			expect(res).toEqual({
 				before: {
 					all: ["prev-before-all", "src-before-all"],
@@ -1754,7 +1768,7 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaActions", () => {
+	describe("Test mergeSchemaActions", () => {
 		it("should merge actions", () => {
 			const src = {
 				create() {},
@@ -1786,7 +1800,7 @@ describe("Test Service class", () => {
 				remove() {}
 			};
 
-			const res = Service.mergeSchemaActions(src, prev);
+			const res = Service.prototype.mergeSchemaActions(src, prev);
 			expect(res).toEqual({
 				create: {
 					handler: expect.any(Function)
@@ -1852,7 +1866,7 @@ describe("Test Service class", () => {
 				}
 			};
 
-			const res = Service.mergeSchemaActions(src, prev);
+			const res = Service.prototype.mergeSchemaActions(src, prev);
 			expect(res).toEqual({
 				create: {
 					hooks: {
@@ -1887,7 +1901,7 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaMethods", () => {
+	describe("Test mergeSchemaMethods", () => {
 		it("should merge values", () => {
 			const src = {
 				find: "src-find",
@@ -1902,7 +1916,7 @@ describe("Test Service class", () => {
 				remove: "prev-remove"
 			};
 
-			const res = Service.mergeSchemaMethods(src, prev);
+			const res = Service.prototype.mergeSchemaMethods(src, prev);
 			expect(res).toEqual({
 				create: "prev-create",
 				find: "src-find",
@@ -1913,7 +1927,7 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaEvents", () => {
+	describe("Test mergeSchemaEvents", () => {
 		it("should merge actions", () => {
 			const src = {
 				create() {},
@@ -1947,7 +1961,7 @@ describe("Test Service class", () => {
 				remove() {}
 			};
 
-			const res = Service.mergeSchemaEvents(src, prev);
+			const res = Service.prototype.mergeSchemaEvents(src, prev);
 			expect(res).toEqual({
 				create: {
 					handler: expect.any(Function)
@@ -1973,35 +1987,26 @@ describe("Test Service class", () => {
 		});
 	});
 
-	describe("Test static mergeSchemaLifecycleHandlers", () => {
+	describe("Test mergeSchemaLifecycleHandlers", () => {
 		it("should merge values", () => {
-			const src = {
-				created: "src-created",
-				started: "src-started",
-				stopped: "src-stopped"
-			};
-
-			const prev = {
-				created: "prev-created",
-				started: "prev-started",
-				stopped: "prev-stopped"
-			};
-
-			const res = Service.mergeSchemaLifecycleHandlers("src-created", "prev-created");
+			const res = Service.prototype.mergeSchemaLifecycleHandlers(
+				"src-created",
+				"prev-created"
+			);
 			expect(res).toEqual(["prev-created", "src-created"]);
 		});
 	});
 
-	describe("Test static mergeSchemaUnknown", () => {
+	describe("Test mergeSchemaUnknown", () => {
 		it("should merge values", () => {
-			expect(Service.mergeSchemaUnknown("John", "Bob")).toBe("John");
-			expect(Service.mergeSchemaUnknown("John", null)).toBe("John");
-			expect(Service.mergeSchemaUnknown(null, "Bob")).toBeNull();
-			expect(Service.mergeSchemaUnknown(null, null)).toBeNull();
+			expect(Service.prototype.mergeSchemaUnknown("John", "Bob")).toBe("John");
+			expect(Service.prototype.mergeSchemaUnknown("John", null)).toBe("John");
+			expect(Service.prototype.mergeSchemaUnknown(null, "Bob")).toBeNull();
+			expect(Service.prototype.mergeSchemaUnknown(null, null)).toBeNull();
 
-			expect(Service.mergeSchemaUnknown("John", undefined)).toBe("John");
-			expect(Service.mergeSchemaUnknown(undefined, "Bob")).toBe("Bob");
-			expect(Service.mergeSchemaUnknown(undefined, undefined)).toBeUndefined();
+			expect(Service.prototype.mergeSchemaUnknown("John", undefined)).toBe("John");
+			expect(Service.prototype.mergeSchemaUnknown(undefined, "Bob")).toBe("Bob");
+			expect(Service.prototype.mergeSchemaUnknown(undefined, undefined)).toBeUndefined();
 		});
 	});
 

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -148,6 +148,33 @@ describe("Test Service class", () => {
 					}
 				});
 			}).toThrowError("Invalid method name 'actions' in 'posts' service!");
+
+			expect(() => {
+				svc.parseServiceSchema({
+					name: "posts",
+					methods: {
+						applyMixins() {}
+					}
+				});
+			}).toThrowError("Invalid method name 'applyMixins' in 'posts' service!");
+
+			expect(() => {
+				svc.parseServiceSchema({
+					name: "posts",
+					methods: {
+						mergeSchemaSettings() {}
+					}
+				});
+			}).toThrowError("Invalid method name 'mergeSchemaSettings' in 'posts' service!");
+
+			expect(() => {
+				svc.parseServiceSchema({
+					name: "posts",
+					methods: {
+						mergeSchemaUnknown() {}
+					}
+				});
+			}).toThrowError("Invalid method name 'mergeSchemaUnknown' in 'posts' service!");
 		});
 
 		it("should set methods and bind the service instance", () => {


### PR DESCRIPTION
## :memo: Description
To use custom property handlers inside services:
https://github.com/moleculerjs/moleculer/blob/452cbf33b438f3199329e0f4afe59429e4a08124/src/service.js#L630-L631
The problem is that a static method in the `Service` class is always called from that class (original).
Calling the `parseServiceSchema()` method from instance:
https://github.com/moleculerjs/moleculer/blob/452cbf33b438f3199329e0f4afe59429e4a08124/src/service.js#L57
causes the original static method from the `Service` class to be called
https://github.com/moleculerjs/moleculer/blob/452cbf33b438f3199329e0f4afe59429e4a08124/src/service.js#L74
It cannot be overridden via `ServiceFactory` and add custom handlers to combine properties.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

@icebob @AndreMaz It is necessary to document the possibility of using custom handlers. I haven't seen any mention of this in the documentation anywhere.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
