### PR TITLE
Fix info packet send on stop

### DIFF
--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -443,7 +443,7 @@ class Registry {
 	 *
 	 * @memberof Registry
 	 */
-	regenerateLocalRawInfo(incSeq) {
+	regenerateLocalRawInfo(incSeq, isStopping) {
 		let node = this.nodes.localNode;
 		if (incSeq) node.seq++;
 
@@ -457,8 +457,12 @@ class Registry {
 			"seq",
 			"metadata"
 		]);
-		if (this.broker.started || incSeq) rawInfo.services = this.services.getLocalNodeServices();
-		else rawInfo.services = [];
+
+		if (!isStopping && (this.broker.started || incSeq)) {
+			rawInfo.services = this.services.getLocalNodeServices();
+		} else {
+			rawInfo.services = [];
+		}
 
 		// Make to be safety
 		node.rawInfo = utils.safetyObject(rawInfo, this.broker.options);

--- a/test/integration/circuit-breaker.spec.js
+++ b/test/integration/circuit-breaker.spec.js
@@ -58,11 +58,10 @@ describe("Test circuit breaker", () => {
 			.then(() => (clock = lolex.install({ shouldClearNativeTimers: true })));
 	});
 
-	afterAll(() => {
-		return master1
-			.stop()
-			.then(() => slave1.stop())
-			.then(() => clock.uninstall());
+	afterAll(async () => {
+		await clock.uninstall();
+
+		await master1.stop().then(() => slave1.stop());
 	});
 
 	it("should call 'happy' x5 without problem", () => {

--- a/test/unit/cachers/memory-lru.spec.js
+++ b/test/unit/cachers/memory-lru.spec.js
@@ -89,6 +89,7 @@ describe("Test MemoryLRUCacher set & get", () => {
 });
 
 describe("Test MemoryLRUCacher set & get with default cloning enabled", () => {
+	let clock = lolex.install({ shouldClearNativeTimers: true });
 	let broker = new ServiceBroker({ logger: false });
 	let cacher = new MemoryLRUCacher({ clone: true });
 	cacher.init(broker);
@@ -104,6 +105,8 @@ describe("Test MemoryLRUCacher set & get with default cloning enabled", () => {
 	};
 
 	afterAll(async () => {
+		await clock.uninstall();
+
 		await cacher.close();
 		await broker.stop();
 	});
@@ -176,6 +179,7 @@ describe("Test MemoryLRUCacher set & get with default cloning disabled", () => {
 });
 
 describe("Test MemoryLRUCacher set & get with custom cloning", () => {
+	let clock;
 	const clone = jest.fn(data => JSON.parse(JSON.stringify(data)));
 	let broker = new ServiceBroker({ logger: false });
 	let cacher = new MemoryLRUCacher({ clone });
@@ -191,7 +195,13 @@ describe("Test MemoryLRUCacher set & get with custom cloning", () => {
 		}
 	};
 
+	beforeAll(async () => {
+		clock = lolex.install({ shouldClearNativeTimers: true });
+	});
+
 	afterAll(async () => {
+		await clock.uninstall();
+
 		await cacher.close();
 		await broker.stop();
 	});
@@ -329,7 +339,7 @@ describe("Test MemoryLRUCacher clean", () => {
 });
 
 describe("Test MemoryLRUCacher expired method", () => {
-	let clock = lolex.install({ shouldClearNativeTimers: true });
+	let clock;
 
 	let broker = new ServiceBroker({ logger: false });
 	let cacher = new MemoryLRUCacher({
@@ -349,6 +359,9 @@ describe("Test MemoryLRUCacher expired method", () => {
 	};
 	let data2 = "Data2";
 
+	beforeAll(async () => {
+		clock = lolex.install({ shouldClearNativeTimers: true });
+	});
 	afterAll(() => clock.uninstall());
 
 	it("should save the data with key", () => {

--- a/test/unit/registry/registry.spec.js
+++ b/test/unit/registry/registry.spec.js
@@ -19,6 +19,7 @@ describe("Test Registry constructor", () => {
 
 		expect(registry.opts).toEqual({
 			preferLocal: true,
+			stopDelay: 100,
 			strategy: "RoundRobin"
 		});
 		expect(registry.StrategyFactory).toBe(Strategies.RoundRobin);
@@ -42,6 +43,7 @@ describe("Test Registry constructor", () => {
 
 		expect(registry.opts).toEqual({
 			preferLocal: false,
+			stopDelay: 100,
 			strategy: "Random"
 		});
 		expect(registry.StrategyFactory).toBe(Strategies.Random);
@@ -58,6 +60,7 @@ describe("Test Registry constructor", () => {
 
 		expect(registry.opts).toEqual({
 			preferLocal: true,
+			stopDelay: 100,
 			discoverer: "Redis",
 			strategy: "RoundRobin"
 		});

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -233,7 +233,8 @@ describe("Test ServiceBroker constructor", () => {
 			disableBalancer: true,
 			registry: {
 				strategy: Strategies.Random,
-				preferLocal: false
+				preferLocal: false,
+				stopDelay: 100
 			},
 
 			circuitBreaker: {
@@ -761,7 +762,7 @@ describe("Test broker.stop", () => {
 
 			return broker.stop().then(() => {
 				expect(broker.registry.regenerateLocalRawInfo).toBeCalledTimes(1);
-				expect(broker.registry.regenerateLocalRawInfo).toBeCalledWith(true);
+				expect(broker.registry.regenerateLocalRawInfo).toBeCalledWith(true, true);
 				expect(broker.registry.discoverer.sendLocalNodeInfo).toBeCalledTimes(1);
 
 				expect(optStopped).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## :memo: Description

Use case is basic redeploy moleculer app with consistent event flow.
On redeploy we have large amount of ServiceIsNotAvailable errors.

Minimal reproduction repository:
https://github.com/Ubitso/moleculer-sd-issue

### :dart: Relevant issues
No

### :gem: Type of change

I've changed stop function in `service-broker`. Error was in regenerateLocalRawInfo in 'registry.js'. During broker stop process broker should send info packet with empty array of services. But it does send packet with current available services.
So we should properly send info packet, and then after delay set `broker.stopping = true`, otherwise remote services will send requests to registred services when it's locked by 'broker.stopping = true'

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: Example code
I've tried to reproduce using test but i cant get same errors. I think it happens only if services is in separate processes.
Please look at my test, if possible to reproduce in one process please give me advice to how achieve that.
```js

describe("Test proper broker stop", () => {
	const broker = new ServiceBroker({
		transporter: "Redis",
		registry: {
			strategy: "RoundRobin",
			preferLocal: false,
			discoverer: {
				type: 'Local'
			}
		},

		tracking: {
			enabled: false
		}
	});

	jest.setTimeout(30000)

	it("Should not throw service is not available error", async () => {
		const errors = []

		broker.createService({
			name: "consumer",

			started() {
				const ctx = this.broker.ContextFactory.create(
					this.broker,
					null,
					{},
					{ caller: this.fullName }
				);

				let i = 0
				const interval = setInterval(async () => {
					if (i < 1000000000) {
						try {
							console.log('find called')
							await ctx.call("producer.find", {});
						} catch (err) {
							console.error(err)
							errors.push(err)
						}
					} else {
						console.warn('clean interval')
						clearInterval(interval)
					}
				}, 1);
			}
		});

		broker.createService({
			name: "producer",

			started() {},

			actions: {
				async find() {

					return new Promise((resolve) => {
						setTimeout(() => {
							return resolve({
								data: "some result"
							});
						}, 1);
					});
				},
			}
		});

		await broker.start();

		await broker.Promise.delay(2000)

		const brokerStopPromise = broker.stop();
		console.log('Broker stop called')

		await brokerStopPromise

		console.log(errors)
	});
});
``` 

## :vertical_traffic_light: How Has This Been Tested?

I tested on my reproduction repo on versions 0.14.19 also on 0.14.21.
Also I fixed current test with fake timers because it starts to fail after my changes.

No

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
