### PR TITLE
fix(typescript) updated check retryable error param type to moleculer error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -804,7 +804,7 @@ declare namespace Moleculer {
 		static mergeSchemaUnknown(src: GenericObject, target: GenericObject): GenericObject;
 	}
 
-	type CheckRetryable = (err: Error) => boolean;
+	type CheckRetryable = (err: Errors.MoleculerError) => boolean;
 
 	interface BrokerCircuitBreakerOptions {
 		enabled?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -804,7 +804,7 @@ declare namespace Moleculer {
 		static mergeSchemaUnknown(src: GenericObject, target: GenericObject): GenericObject;
 	}
 
-	type CheckRetryable = (err: Errors.MoleculerError) => boolean;
+	type CheckRetryable = (err: Errors.MoleculerError | Error) => boolean;
 
 	interface BrokerCircuitBreakerOptions {
 		enabled?: boolean;


### PR DESCRIPTION
## :memo: Description

Updated the CheckRetryable error param type to follow the real object structure and also what is described in the documentation:

```
...
check: err => err && !!err.retryable
...
```

The `retryable` property is only available in the `Errors.MoleculerError` type.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
