### PR TITLE
fixed the issue with setting tracing and metrics options with env variables

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -106,7 +106,7 @@ const defaultOptions = {
 	validator: true,
 
 	metrics: false,
-	tracing: false,
+	tracing: {enabled: false},
 
 	internalServices: true,
 	internalMiddlewares: true,

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -106,7 +106,7 @@ const defaultOptions = {
 	validator: true,
 
 	metrics: false,
-	tracing: {enabled: false},
+	tracing: { enabled: false },
 
 	internalServices: true,
 	internalMiddlewares: true,

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -105,7 +105,7 @@ const defaultOptions = {
 
 	validator: true,
 
-	metrics: false,
+	metrics: { enabled: false },
 	tracing: { enabled: false },
 
 	internalServices: true,

--- a/test/unit/metrics/reporters/console.spec.js
+++ b/test/unit/metrics/reporters/console.spec.js
@@ -180,6 +180,7 @@ describe("Test ConsoleReporter class", () => {
 			logger: false,
 			nodeID: "node-123",
 			metrics: {
+				enabled: true,
 				reporter: {
 					type: "Console",
 					options: {

--- a/test/unit/metrics/reporters/csv.spec.js
+++ b/test/unit/metrics/reporters/csv.spec.js
@@ -243,6 +243,7 @@ describe("Test CSVReporter class", () => {
 				logger: false,
 				nodeID: "node-123",
 				metrics: {
+					enabled: true,
 					reporter: {
 						type: "CSV",
 						options: {

--- a/test/unit/metrics/reporters/event.spec.js
+++ b/test/unit/metrics/reporters/event.spec.js
@@ -187,6 +187,7 @@ describe("Test EventReporter class", () => {
 				logger: false,
 				nodeID: "node-123",
 				metrics: {
+					enabled: true,
 					reporter: {
 						type: "Event",
 						options: {

--- a/test/unit/metrics/reporters/statsd.spec.js
+++ b/test/unit/metrics/reporters/statsd.spec.js
@@ -320,6 +320,7 @@ describe("Test StatsDReporter class", () => {
 		const broker = new ServiceBroker({
 			logger: false,
 			metrics: {
+				enabled: true,
 				reporter: "StatsD"
 			}
 		});

--- a/test/unit/middlewares/tracing.spec.js
+++ b/test/unit/middlewares/tracing.spec.js
@@ -783,6 +783,7 @@ describe("Test TracingMiddleware localAction", () => {
 			it("should create a span with local custom tags function even if global custom tags are specified", async () => {
 				const brokerOptions = {
 					tracing: {
+						enabled: true,
 						tags: {
 							action: jest.fn((ctx, response) => {})
 						}
@@ -791,7 +792,6 @@ describe("Test TracingMiddleware localAction", () => {
 				const broker = new ServiceBroker({
 					nodeID: "server-1",
 					logger: false,
-					tracing: true,
 					...brokerOptions
 				});
 				const tracer = broker.tracer;
@@ -873,6 +873,7 @@ describe("Test TracingMiddleware localAction", () => {
 			it("should create a span with global custom tags function if no local action tags are specified", async () => {
 				const brokerOptions = {
 					tracing: {
+						enabled: true,
 						tags: {
 							action: jest.fn((ctx, response) => ({
 								custom: {
@@ -887,7 +888,6 @@ describe("Test TracingMiddleware localAction", () => {
 				const broker = new ServiceBroker({
 					nodeID: "server-1",
 					logger: false,
-					tracing: true,
 					...brokerOptions
 				});
 				const tracer = broker.tracer;
@@ -1022,6 +1022,7 @@ describe("Test TracingMiddleware localAction", () => {
 			it("should merge global action tags with the default params tag", async () => {
 				const brokerOptions = {
 					tracing: {
+						enabled: true,
 						tags: {
 							action: {
 								meta: true,
@@ -1033,7 +1034,6 @@ describe("Test TracingMiddleware localAction", () => {
 				const broker = new ServiceBroker({
 					nodeID: "server-1",
 					logger: false,
-					tracing: true,
 					...brokerOptions
 				});
 				const tracer = broker.tracer;
@@ -1107,6 +1107,7 @@ describe("Test TracingMiddleware localAction", () => {
 			it("should override global action tags with local tags", async () => {
 				const brokerOptions = {
 					tracing: {
+						enabled: true,
 						tags: {
 							action: {
 								params: false,
@@ -1119,7 +1120,6 @@ describe("Test TracingMiddleware localAction", () => {
 				const broker = new ServiceBroker({
 					nodeID: "server-1",
 					logger: false,
-					tracing: true,
 					...brokerOptions
 				});
 				const tracer = broker.tracer;


### PR DESCRIPTION
## :memo: Description
When using the runner we cannot set tracing options using env variable because defaultOption tracing is a boolean and runner only update the values if property is an object

https://github.com/moleculerjs/moleculer/blob/5d72c97b93896671f47352d11f9006c1080277f9/src/utils.js#L409

So the fix is created by changing the `tracing` and `metrics` property to object with default state as `false`

### :dart: Relevant issues

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```shell
# now can set tracer type as below
MOL_TRACING__EXPORTER=Console 
# can set metrics type as below
MOL_METRICS__REPORTER=StatsD

``` 

## :vertical_traffic_light: How Has This Been Tested?
Created a sample service schema and execueted using moleculer-runner manually.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
