### PR TITLE
add return type void to service started & stopped handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -726,8 +726,8 @@ declare namespace Moleculer {
 
 		events?: ServiceEvents;
 		created?: (() => void) | Array<() => void>;
-		started?: (() => Promise<void>) | Array<() => Promise<void>>;
-		stopped?: (() => Promise<void>) | Array<() => Promise<void>>;
+		started?: (() => Promise<void> | void) | Array<() => Promise<void> | void>;
+		stopped?: (() => Promise<void> | void) | Array<() => Promise<void> | void>;
 
 		[name: string]: any;
 	}

--- a/test/typescript/tsd/ServiceSchema_lifecycles.test-d.ts
+++ b/test/typescript/tsd/ServiceSchema_lifecycles.test-d.ts
@@ -22,9 +22,22 @@ class TestService2 extends Service {
 
 		this.parseServiceSchema({
 			name: "test2",
+			created() {},
+			started() {},
+			stopped() {}
+		});
+	}
+}
+
+class TestService3 extends Service {
+	constructor(broker: ServiceBroker) {
+		super(broker);
+
+		this.parseServiceSchema({
+			name: "test3",
 			created: [() => {}, () => {}],
-			started: [async () => {}, async () => {}],
-			stopped: [async () => {}, async () => {}]
+			started: [async () => {}, () => {}],
+			stopped: [async () => {}, () => {}]
 		});
 	}
 }
@@ -35,3 +48,5 @@ expectType<ServiceSchema>(testService1.schema);
 const testService2 = new TestService2(broker);
 expectType<ServiceSchema>(testService2.schema);
 
+const testService3 = new TestService3(broker);
+expectType<ServiceSchema>(testService3.schema);


### PR DESCRIPTION
## :memo: Description

Fix TypeScript definitions to be able to pass non-async functions (that don't return a promise) as service lifecycle events handlers (for started & stopped events). This is already possible at runtime (passed function is converted to an async function under the hood).

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/1113

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

```
npm run test
npm run test:ts
```

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
