### PR TITLE
add dependencyTimeout broker option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -913,6 +913,7 @@ declare namespace Moleculer {
 		internalMiddlewares?: boolean;
 
 		dependencyInterval?: number;
+		dependencyTimeout?: number;
 
 		hotReload?: boolean | HotReloadOptions;
 

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -110,7 +110,9 @@ const defaultOptions = {
 
 	internalServices: true,
 	internalMiddlewares: true,
+
 	dependencyInterval: 1000,
+	dependencyTimeout: 0,
 
 	hotReload: false,
 
@@ -1001,7 +1003,12 @@ class ServiceBroker {
 	 *
 	 * @memberof ServiceBroker
 	 */
-	waitForServices(serviceNames, timeout, interval, logger = this.logger) {
+	waitForServices(
+		serviceNames,
+		timeout = this.options.dependencyInterval,
+		interval = this.options.dependencyInterval,
+		logger = this.logger
+	) {
 		if (!Array.isArray(serviceNames)) serviceNames = [serviceNames];
 
 		serviceNames = _.uniq(
@@ -1084,7 +1091,7 @@ class ServiceBroker {
 						)
 					);
 
-				setTimeout(check, interval || this.options.dependencyInterval || 1000);
+				setTimeout(check, interval);
 			};
 
 			check();

--- a/src/service.js
+++ b/src/service.js
@@ -285,7 +285,7 @@ class Service {
 				if (this.schema.dependencies)
 					return this.waitForServices(
 						this.schema.dependencies,
-						this.settings.$dependencyTimeout || 0,
+						this.settings.$dependencyTimeout || this.broker.options.dependencyTimeout,
 						this.settings.$dependencyInterval || this.broker.options.dependencyInterval
 					);
 			})


### PR DESCRIPTION
## :memo: Description

Add dependencyTimeout broker option with default 0 (no timeout). Currently there is no way to configure it in broker options, only on a per service level. 0 timeout is currently hard-coded, so there should be no breaking change.

See relevant issue for detailed justification.

### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/1116

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)

### :scroll: Example code
```js
const broker = new ServiceBroker({
  dependencyTimeout: 60_000
});
``` 

## :vertical_traffic_light: How Has This Been Tested?

I've added an additional test case for this option & ran all existing tests except for memory leak tests.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
