### PR TITLE
Allow moleculer-runner to resolve configuration files from node_modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,12 @@ module.exports = {
 		"no-process-exit": ["off"],
 		"node/no-unpublished-require": 0
 	},
-	ignorePatterns: ["benchmark/test.js", "test/typescript/hello-world/out/*.js"]
+	ignorePatterns: ["benchmark/test.js", "test/typescript/hello-world/out/*.js"],
+	overrides: {
+		files: ["runner-esm.mjs"],
+		parserOptions: {
+			sourceType: "module",
+			ecmaVersion: "2020" // needed to allow import.meta
+		}
+	}
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,11 +26,13 @@ module.exports = {
 		"node/no-unpublished-require": 0
 	},
 	ignorePatterns: ["benchmark/test.js", "test/typescript/hello-world/out/*.js"],
-	overrides: {
-		files: ["runner-esm.mjs"],
-		parserOptions: {
-			sourceType: "module",
-			ecmaVersion: "2020" // needed to allow import.meta
+	overrides: [
+		{
+			files: ["runner-esm.mjs"],
+			parserOptions: {
+				sourceType: "module",
+				ecmaVersion: "2020" // needed to allow import.meta
+			}
 		}
-	}
+	]
 };

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -201,7 +201,7 @@ export default class MoleculerRunner {
 		for (let idx = 0; idx < paths.length; idx++) {
 			const path = paths[idx];
 			try {
-				return require.resolve(path);
+				return require.resolve(path, { paths: [process.cwd()] });
 			} catch (_) {
 				// ignore
 			}

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -173,6 +173,9 @@ export default class MoleculerRunner {
 		}
 
 		if (filePath == null) {
+			filePath = this.tryConfigPath(path.resolve(process.cwd(), "moleculer.config.mjs"));
+		}
+		if (filePath == null) {
 			filePath = this.tryConfigPath(path.resolve(process.cwd(), "moleculer.config.js"));
 		}
 		if (filePath == null) {

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -7,12 +7,17 @@ import ServiceBroker from "./service-broker.js";
 import utils from "./utils.js";
 import fs from "fs";
 import path from "path";
+import { createRequire } from "module";
 import glob from "glob";
 import _ from "lodash";
 import Args from "args";
 import os from "os";
 import cluster from "cluster";
 import kleur from "kleur";
+
+// import.meta.resolve requires --experimental-import-meta-resolve flag: https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaresolvespecifier-parent
+// createRequire is a workaround to allow require.resolve in esm modules: https://stackoverflow.com/a/62499498
+const require = createRequire(import.meta.url);
 
 const stopSignals = [
 	"SIGHUP",
@@ -149,29 +154,25 @@ export default class MoleculerRunner {
 	async loadConfigFile() {
 		let filePath;
 		// Env vars have priority over the flags
-		if (process.env["MOLECULER_CONFIG"]) {
-			filePath = path.isAbsolute(process.env["MOLECULER_CONFIG"])
-				? process.env["MOLECULER_CONFIG"]
-				: path.resolve(process.cwd(), process.env["MOLECULER_CONFIG"]);
-		} else if (this.flags.config) {
-			filePath = path.isAbsolute(this.flags.config)
-				? this.flags.config
-				: path.resolve(process.cwd(), this.flags.config);
-		}
-		if (!filePath && fs.existsSync(path.resolve(process.cwd(), "moleculer.config.mjs"))) {
-			filePath = path.resolve(process.cwd(), "moleculer.config.mjs");
-		}
-		if (!filePath && fs.existsSync(path.resolve(process.cwd(), "moleculer.config.js"))) {
-			filePath = path.resolve(process.cwd(), "moleculer.config.js");
-		}
-		if (!filePath && fs.existsSync(path.resolve(process.cwd(), "moleculer.config.json"))) {
-			filePath = path.resolve(process.cwd(), "moleculer.config.json");
+		const configPath = process.env["MOLECULER_CONFIG"] || this.flags.config;
+		if (configPath != null) {
+			const paths = path.isAbsolute(configPath)
+				? [configPath]
+				: [path.resolve(process.cwd(), configPath), configPath];
+
+			filePath = this.tryConfigPaths(paths);
+
+			if (filePath == null) {
+				return Promise.reject(new Error(`Config file not found: ${configPath}`));
+			}
+		} else {
+			filePath = this.tryConfigPaths([
+				path.resolve(process.cwd(), "moleculer.config.js"),
+				path.resolve(process.cwd(), "moleculer.config.json")
+			]);
 		}
 
 		if (filePath) {
-			if (!fs.existsSync(filePath))
-				return Promise.reject(new Error(`Config file not found: ${filePath}`));
-
 			const ext = path.extname(filePath);
 			switch (ext) {
 				case ".json":
@@ -189,6 +190,24 @@ export default class MoleculerRunner {
 					return Promise.reject(new Error(`Not supported file extension: ${ext}`));
 			}
 		}
+	}
+
+	/**
+	 * Try to resolve a configuration file at a series of paths
+	 * @param {string[]} paths - Paths to attempt resolution from
+	 * @returns {string | null}
+	 */
+	tryConfigPaths(paths) {
+		for (let idx = 0; idx < paths.length; idx++) {
+			const path = paths[idx];
+			try {
+				return require.resolve(path);
+			} catch (_) {
+				// ignore
+			}
+		}
+
+		return null;
 	}
 
 	normalizeEnvValue(value) {
@@ -376,9 +395,7 @@ export default class MoleculerRunner {
 							return this.broker.logger.warn(
 								kleur
 									.yellow()
-									.bold(
-										`There is no service files in directory: '${svcPath}'`
-									)
+									.bold(`There is no service files in directory: '${svcPath}'`)
 							);
 					} else if (this.isServiceFile(svcPath)) {
 						files = [svcPath.replace(/\\/g, "/")];
@@ -389,9 +406,7 @@ export default class MoleculerRunner {
 						files = glob.sync(p, { cwd: svcDir, absolute: true });
 						if (files.length == 0)
 							this.broker.logger.warn(
-								kleur
-									.yellow()
-									.bold(`There is no matched file for pattern: '${p}'`)
+								kleur.yellow().bold(`There is no matched file for pattern: '${p}'`)
 							);
 					}
 
@@ -402,13 +417,15 @@ export default class MoleculerRunner {
 					}
 				});
 
-			await Promise.all(_.uniq(serviceFiles).map(async f => {
-				const mod = await import(f.startsWith("/") ? f : "/" + f);
-				const content = mod.default;
+			await Promise.all(
+				_.uniq(serviceFiles).map(async f => {
+					const mod = await import(f.startsWith("/") ? f : "/" + f);
+					const content = mod.default;
 
-				const svc = this.broker.createService(content);
-				svc.__filename = f;
-			}));
+					const svc = this.broker.createService(content);
+					svc.__filename = f;
+				})
+			);
 		}
 	}
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -202,7 +202,7 @@ class MoleculerRunner {
 	tryConfigPath(configPath) {
 		let resolveOptions;
 		if (!path.isAbsolute(configPath)) {
-			resolveOptions = { paths: process.cwd() };
+			resolveOptions = { paths: [process.cwd()] };
 		}
 
 		console.log(`Attempting to resolve from from: ${configPath}`);

--- a/src/runner.js
+++ b/src/runner.js
@@ -202,7 +202,7 @@ class MoleculerRunner {
 		for (let idx = 0; idx < paths.length; idx++) {
 			const path = paths[idx];
 			try {
-				return require.resolve(path);
+				return require.resolve(path, { paths: [process.cwd()] });
 			} catch (_) {
 				// ignore
 			}

--- a/src/runner.js
+++ b/src/runner.js
@@ -153,7 +153,7 @@ class MoleculerRunner {
 		// Env vars have priority over the flags
 		const configPath = process.env["MOLECULER_CONFIG"] || this.flags.config;
 
-		console.log(`configured to uss ${configPath}`);
+		console.log(`configured to use ${configPath}`);
 		if (configPath != null) {
 			filePath = this.tryConfigPath(configPath);
 
@@ -201,7 +201,7 @@ class MoleculerRunner {
 	 */
 	tryConfigPath(configPath) {
 		let resolveOptions;
-		if (path.isAbsolute(configPath)) {
+		if (!path.isAbsolute(configPath)) {
 			resolveOptions = { paths: process.cwd() };
 		}
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -153,7 +153,6 @@ class MoleculerRunner {
 		// Env vars have priority over the flags
 		const configPath = process.env["MOLECULER_CONFIG"] || this.flags.config;
 
-		console.log(`configured to use ${configPath}`);
 		if (configPath != null) {
 			if (path.isAbsolute(configPath)) {
 				filePath = this.tryConfigPath(configPath);
@@ -178,7 +177,6 @@ class MoleculerRunner {
 		}
 
 		if (filePath != null) {
-			console.log(`using configuration file from ${filePath}`);
 			const ext = path.extname(filePath);
 			switch (ext) {
 				case ".json":
@@ -199,8 +197,6 @@ class MoleculerRunner {
 				default:
 					return Promise.reject(new Error(`Not supported file extension: ${ext}`));
 			}
-		} else {
-			console.log("not using config file");
 		}
 	}
 
@@ -216,7 +212,6 @@ class MoleculerRunner {
 			resolveOptions = { paths: [process.cwd()] };
 		}
 
-		console.log(`Attempting to resolve config from: ${configPath}`);
 		try {
 			return require.resolve(configPath, resolveOptions);
 		} catch (_) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -152,24 +152,25 @@ class MoleculerRunner {
 		let filePath;
 		// Env vars have priority over the flags
 		const configPath = process.env["MOLECULER_CONFIG"] || this.flags.config;
-		if (configPath != null) {
-			const paths = path.isAbsolute(configPath)
-				? [configPath]
-				: [path.resolve(process.cwd(), configPath), configPath];
 
-			filePath = this.tryConfigPaths(paths);
+		console.log(`configured to uss ${configPath}`);
+		if (configPath != null) {
+			filePath = this.tryConfigPath(configPath);
 
 			if (filePath == null) {
 				return Promise.reject(new Error(`Config file not found: ${configPath}`));
 			}
-		} else {
-			filePath = this.tryConfigPaths([
-				path.resolve(process.cwd(), "moleculer.config.js"),
-				path.resolve(process.cwd(), "moleculer.config.json")
-			]);
+		}
+
+		if (filePath == null) {
+			filePath = this.tryConfigPath("moleculer.config.js");
+		}
+		if (filePath == null) {
+			filePath = this.tryConfigPath("moleculer.config.json");
 		}
 
 		if (filePath != null) {
+			console.log(`using configuration file from ${filePath}`);
 			const ext = path.extname(filePath);
 			switch (ext) {
 				case ".json":
@@ -194,21 +195,22 @@ class MoleculerRunner {
 	}
 
 	/**
-	 * Try to resolve a configuration file at a series of paths
-	 * @param {string[]} paths - Paths to attempt resolution from
+	 * Try to resolve a configuration file at a path
+	 * @param {string} configPath - Path to attempt resolution from
 	 * @returns {string | null}
 	 */
-	tryConfigPaths(paths) {
-		for (let idx = 0; idx < paths.length; idx++) {
-			const path = paths[idx];
-			try {
-				return require.resolve(path, { paths: [process.cwd()] });
-			} catch (_) {
-				// ignore
-			}
+	tryConfigPath(configPath) {
+		let resolveOptions;
+		if (path.isAbsolute(configPath)) {
+			resolveOptions = { paths: process.cwd() };
 		}
 
-		return null;
+		console.log(`Attempting to resolve from from: ${configPath}`);
+		try {
+			return require.resolve(configPath, resolveOptions);
+		} catch (_) {
+			return null;
+		}
 	}
 
 	normalizeEnvValue(value) {


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, `moleculer-runner` will resolve configuration files in the following ways:
1) If configuration options (environment variable or command line) set config to an absolute path, the configuration will be resolved from that absolute path
2) If configuration options (environment variable or command line) set config to a non-absolute path, the configuration will be resolved from a path relative to the current working directory
3) Resolved from a `moleculer.config.js` file in the current working directory
4) Resolved from a `moleculer.config.json` file in the current working directory

The current resolution strategy does not allow for resolution of configurations from `node_modules` because relative paths will only be loaded relative to the current working directory and will not follow the node resolution workflow to look at `node_modules`.  Moleculer users may wish to resolve from `node_modules` for the following reasons:
1) Configuration files are kept in separate external packages
2) Configuration files are kept in a different workspace in a monorepo.  Workspaces in a monorepo are symlinked through `node_modules` with `npm`, `yarn`, or `pnpm` workspaces.

This PR updates `moleculer-runner` so that it will resolve configuration files from `node_modules`.  After this change, the runner will resolve as follows:

**Environment Variable or Command Line Configuration Set**
1) Set to an absolute path then configuration will be resolved from that absolute path
2) Set to a non-absolute path then configuration will first be resolved from a path relative to the current working directory.
3) Set to a non-absolute path and resolution failed relative to the current working directory then resolution will be resolved using regular [node module resolution strategy](https://nodejs.org/api/modules.html#all-together) starting the resolution from the current working directory.

Effectively, item 3 is added to the resolution workflow.  Items 1 and 2 should be consistent with existing behaviors.  If resolution fails then the runner will abort.

**No Environment Variable or Command Line Configuration Set**
4) Resolved from a `moleculer.config.js` file in the current working directory
5) Resolved from a `moleculer.config.json` file in the current working directory

This is identical to the exiting workflow.  If no configuration exists then one will not be used.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

There are no existing unit tests (that I could find) for the runner.  I tested in a local moleculer repository to ensure that the expected configurations were loaded.

1) Confirmed load from specified configuration file which was in the current working directory (`--config=test-config.js` and `--config=test.config.json`)
2) Confirmed load from specified configuration file which was in a subdirectory of the current working directory (`--config=./src/test-config.js` and `--config=./src/test.config.json`
3) Confirmed load for specified configuration file which was in a monorepo workspace (`--config=@scope/moleculer-config/test-config.js`
4) Confirmed load for `moleculer.config.js` from the current working directory with no specified configuration file
5) Confirmed load for `moleculer.config.json` from the current working directory with no specified configuration file

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
