### PR TITLE
Small typo on readme, link was not covering whole word.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Moleculer is a fast, modern and powerful microservices framework for [Node.js](h
 - many fault tolerance features (Circuit Breaker, Bulkhead, Retry, Timeout, Fallback)
 - plugin/middleware system
 - support versioned services
-- support [Stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html)s
+- support [Streams](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html)
 - service mixins
 - built-in caching solution (Memory, MemoryLRU, Redis)
 - pluggable loggers (Console, File, Pino, Bunyan, Winston, Debug, Datadog, Log4js)


### PR DESCRIPTION
## :memo: Description

There were a typo in README.md. Link was not covering the whole word. 
No dependencies required.

### :dart: Relevant issues
None.

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```js
None.
``` 

## :vertical_traffic_light: How Has This Been Tested?

No tests. Just only assumptions.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
