### PR TITLE
Proposal - Allow matching hooks to multiple actions with "|"

### DIFF
--- a/src/middlewares/action-hook.js
+++ b/src/middlewares/action-hook.js
@@ -69,14 +69,16 @@ module.exports = function actionHookMiddleware(broker) {
 
 			// Hooks in service
 			/** @type {Array<String>?} List of hooks names that match the action name */
+
+			const matchHook = hookName => {
+				if (hookName === "*") return false;
+				const patterns = hookName.split("|");
+				return patterns.some(pattern => match(name, pattern));
+			};
+
 			const beforeHookMatches =
 				hooks && hooks.before
-					? Object.keys(hooks.before).filter(hookName => {
-							// Global hook. Skip it
-							if (hookName === "*") return false;
-							const patterns = hookName.split("|");
-							return patterns.some(pattern => match(name, pattern));
-					  })
+					? Object.keys(hooks.before).filter(hookName => matchHook(hookName))
 					: null;
 
 			/** @type {Array<Function>?} List of hooks that match the action name */
@@ -90,13 +92,7 @@ module.exports = function actionHookMiddleware(broker) {
 			/** @type {Array<String>?} List of hooks names that match the action name */
 			const afterHookMatches =
 				hooks && hooks.after
-					? Object.keys(hooks.after).filter(hookName => {
-							// Global hook. Skip it
-							if (hookName === "*") return false;
-
-							const patterns = hookName.split("|");
-							return patterns.some(pattern => match(name, pattern));
-					  })
+					? Object.keys(hooks.after).filter(hookName => matchHook(hookName))
 					: null;
 
 			/** @type {Array<Function>?} List of hooks that match the action name */
@@ -110,13 +106,7 @@ module.exports = function actionHookMiddleware(broker) {
 			/** @type {Array<String>?} List of hooks names that match the action name */
 			const errorHookMatches =
 				hooks && hooks.error
-					? Object.keys(hooks.error).filter(hookName => {
-							// Global hook. Skip it
-							if (hookName === "*") return false;
-
-							const patterns = hookName.split("|");
-							return patterns.some(pattern => match(name, pattern));
-					  })
+					? Object.keys(hooks.error).filter(hookName => matchHook(hookName))
 					: null;
 
 			/** @type {Array<Function>?} List of hooks that match the action name */

--- a/src/middlewares/action-hook.js
+++ b/src/middlewares/action-hook.js
@@ -77,9 +77,7 @@ module.exports = function actionHookMiddleware(broker) {
 			};
 
 			const beforeHookMatches =
-				hooks && hooks.before
-					? Object.keys(hooks.before).filter(hookName => matchHook(hookName))
-					: null;
+				hooks && hooks.before ? Object.keys(hooks.before).filter(matchHook) : null;
 
 			/** @type {Array<Function>?} List of hooks that match the action name */
 			const beforeHook =
@@ -91,9 +89,7 @@ module.exports = function actionHookMiddleware(broker) {
 
 			/** @type {Array<String>?} List of hooks names that match the action name */
 			const afterHookMatches =
-				hooks && hooks.after
-					? Object.keys(hooks.after).filter(hookName => matchHook(hookName))
-					: null;
+				hooks && hooks.after ? Object.keys(hooks.after).filter(matchHook) : null;
 
 			/** @type {Array<Function>?} List of hooks that match the action name */
 			const afterHook =
@@ -105,9 +101,7 @@ module.exports = function actionHookMiddleware(broker) {
 
 			/** @type {Array<String>?} List of hooks names that match the action name */
 			const errorHookMatches =
-				hooks && hooks.error
-					? Object.keys(hooks.error).filter(hookName => matchHook(hookName))
-					: null;
+				hooks && hooks.error ? Object.keys(hooks.error).filter(matchHook) : null;
 
 			/** @type {Array<Function>?} List of hooks that match the action name */
 			const errorHook =

--- a/src/middlewares/action-hook.js
+++ b/src/middlewares/action-hook.js
@@ -74,8 +74,8 @@ module.exports = function actionHookMiddleware(broker) {
 					? Object.keys(hooks.before).filter(hookName => {
 							// Global hook. Skip it
 							if (hookName === "*") return false;
-
-							return match(name, hookName);
+							const patterns = hookName.split("|");
+							return patterns.some(pattern => match(name, pattern));
 					  })
 					: null;
 
@@ -94,7 +94,8 @@ module.exports = function actionHookMiddleware(broker) {
 							// Global hook. Skip it
 							if (hookName === "*") return false;
 
-							return match(name, hookName);
+							const patterns = hookName.split("|");
+							return patterns.some(pattern => match(name, pattern));
 					  })
 					: null;
 
@@ -113,7 +114,8 @@ module.exports = function actionHookMiddleware(broker) {
 							// Global hook. Skip it
 							if (hookName === "*") return false;
 
-							return match(name, hookName);
+							const patterns = hookName.split("|");
+							return patterns.some(pattern => match(name, pattern));
 					  })
 					: null;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -306,7 +306,7 @@ const utils = {
 	 */
 	match(text, pattern) {
 		// Simple patterns
-		if (pattern.indexOf("?") == -1 && pattern.indexOf("|") == -1) {
+		if (pattern.indexOf("?") == -1) {
 			// Exact match (eg. "prefix.event")
 			const firstStarPosition = pattern.indexOf("*");
 			if (firstStarPosition == -1) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -306,7 +306,7 @@ const utils = {
 	 */
 	match(text, pattern) {
 		// Simple patterns
-		if (pattern.indexOf("?") == -1) {
+		if (pattern.indexOf("?") == -1 && pattern.indexOf("|") == -1) {
 			// Exact match (eg. "prefix.event")
 			const firstStarPosition = pattern.indexOf("*");
 			if (firstStarPosition == -1) {

--- a/test/unit/middlewares/action-hook.spec.js
+++ b/test/unit/middlewares/action-hook.spec.js
@@ -190,6 +190,16 @@ describe("Test ActionHookMiddleware", () => {
 						FLOW.push("before-hook-2");
 						ctx.params.third = 3;
 					}
+				],
+				"find|invalid": [
+					function (ctx) {
+						FLOW.push("before-hook-3");
+					}
+				],
+				"invalid1|invalid2": [
+					function (ctx) {
+						FLOW.push("before-hook-4"); //not added
+					}
 				]
 			},
 			after: {
@@ -203,6 +213,14 @@ describe("Test ActionHookMiddleware", () => {
 						return Object.assign(res, { c: 300 });
 					}
 				],
+
+				"invalid|find": [
+					function (ctx, res) {
+						FLOW.push("after-hook-3");
+						return res;
+					}
+				],
+
 				"*": [
 					function (ctx, res) {
 						FLOW.push("after-all-hook-1");
@@ -246,11 +264,13 @@ describe("Test ActionHookMiddleware", () => {
 					"before-all-hook-2",
 					"before-hook-1",
 					"before-hook-2",
+					"before-hook-3",
 					"before-action-hook",
 					"handler-1-2-3",
 					"after-action-hook",
 					"after-hook-1",
 					"after-hook-2",
+					"after-hook-3",
 					"after-all-hook-1",
 					"after-all-hook-2"
 				]);


### PR DESCRIPTION
## :memo: Description

For example, you could write "create|update" to match a hook to both the create and update actions. A single edit to a line of code was required to add this functionality, as a regex matcher is already present in the code. This simply tells the matcher to use the regex matcher if a | is detected in the hook name. This is only breaking if for some reason people used | already in their action names.

### :dart: Relevant issues
No issue that I know of

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality) (only very minor breaking)

## :vertical_traffic_light: How Has This Been Tested?

- [x] Added simple unit tests
- [x] Using the patch via patch-package in my own code and it works.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
