### PR TITLE
Load test

### DIFF
--- a/test/load/documentation.js
+++ b/test/load/documentation.js
@@ -25,4 +25,5 @@ export default function () {
     sleep(1)
 }
 
+// First, you need to download the binary https://github.com/grafana/k6/archive/refs/tags/v0.41.0.zip and move the binary to the folder test
 // To run this test, run on the terminal this command: test/k6 run test/load/documentation.js

--- a/test/load/documentation.js
+++ b/test/load/documentation.js
@@ -24,3 +24,5 @@ export default function () {
     check(res, { 'status was 200': (r) => r.status == 200 })
     sleep(1)
 }
+
+// To run this test, run on the terminal this command: test/k6 run test/load/documentation.js

--- a/test/load/documentation.js
+++ b/test/load/documentation.js
@@ -1,0 +1,26 @@
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js"
+
+export const options = {
+    stages: [
+        { duration: '5m', target: 100 }, // simulate ramp-up of traffic from 1 to 100 users over 5 minutes.
+        { duration: '10m', target: 100 }, // stay at 100 users for 10 minutes
+        { duration: '5m', target: 0 } // ramp-down to 0 users
+    ],
+    thresholds: {
+        'http_req_duration': ['p(99)<1500'] // 99% of requests must complete below 1.5s
+    },
+}
+
+export function handleSummary(data) {
+    return {
+        "test/load/access_documentation.html": htmlReport(data)
+    }
+}
+
+export default function () {
+    const res = http.get("https://moleculer.services/docs/0.14/")
+    check(res, { 'status was 200': (r) => r.status == 200 })
+    sleep(1)
+}


### PR DESCRIPTION
## :memo: Description

I added a load test in the project. For now, i did a small contribution only testing the documentation page, but in the future contributions would try to do load test on the critical functions of the project, to help identify poins of losing performance.

### :dart: Relevant issues


### :gem: Type of change


- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### :scroll: Example code

import http from 'k6/http'
import { check, sleep } from 'k6'
import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js"
​
export const options = {
    stages: [
        { duration: '10s', target: 10 }, // simulate ramp-up of traffic from 1 to 100 users over 5 minutes.
        // { duration: '10m', target: 10 }, // stay at 100 users for 10 minutes
        // { duration: '5m', target: 0 } // ramp-down to 0 users
    ],
    thresholds: {
        'http_req_duration': ['p(99)<1500'] // 99% of requests must complete below 1.5s
    },
}
​
export function handleSummary(data) {
    return {
        "test/load/access_documentation.html": htmlReport(data)
    }
}
​
export default function () {
    const res = http.get("https://moleculer.services/docs/0.14/")
    check(res, { 'status was 200': (r) => r.status == 200 })
    sleep(1)
}

## :vertical_traffic_light: How Has This Been Tested?

1º Download the binary k6 project (https://github.com/grafana/k6/archive/refs/tags/v0.41.0.zip)
2º Move the downloaded binary to the path ../moleculer/test
3º Run in terminal "test/k6 run test/load/documentation.js"

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
