### PR TITLE
feat(types): add middlewares types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { EventEmitter2 } from "eventemitter2";
+import type { Kleur } from "kleur";
 
 declare namespace Moleculer {
 	/**
@@ -1340,21 +1341,23 @@ declare namespace Moleculer {
 			sender: string | null;
 		}
 
+		type packetType = | PACKET_UNKNOWN
+			| PACKET_EVENT
+			| PACKET_DISCONNECT
+			| PACKET_DISCOVER
+			| PACKET_INFO
+			| PACKET_HEARTBEAT
+			| PACKET_REQUEST
+			| PACKET_PING
+			| PACKET_PONG
+			| PACKET_RESPONSE
+			| PACKET_GOSSIP_REQ
+			| PACKET_GOSSIP_RES
+			| PACKET_GOSSIP_HELLO;
+
 		interface Packet {
-			type:
-				| PACKET_UNKNOWN
-				| PACKET_EVENT
-				| PACKET_DISCONNECT
-				| PACKET_DISCOVER
-				| PACKET_INFO
-				| PACKET_HEARTBEAT
-				| PACKET_REQUEST
-				| PACKET_PING
-				| PACKET_PONG
-				| PACKET_RESPONSE
-				| PACKET_GOSSIP_REQ
-				| PACKET_GOSSIP_RES
-				| PACKET_GOSSIP_HELLO;
+			type: packetType
+
 			target?: string;
 			payload: PacketPayload;
 		}
@@ -1663,6 +1666,59 @@ declare namespace Moleculer {
 				plainError: PlainMoleculerError,
 				payload: GenericObject
 			): Error | undefined;
+		}
+	}
+
+	/**
+	 * you can use multiple modifier with a dot
+	 * e.g. `black.bgRed.bold`
+	 */
+	type KleurColor = keyof Kleur | string
+
+	namespace Middlewares {
+		namespace Debugging {
+			type actionLoggerOptions = {
+				logger?: LoggerInstance,
+				logLevel?: LogLevels,
+				logParams?: boolean,
+				logResponse?: boolean,
+				logMeta?: boolean,
+
+				folder?: string | null,
+				extension?: string,
+
+				colors?: {
+					request?: KleurColor,
+					response?: KleurColor,
+					error?: KleurColor
+				},
+				whitelist?: Array<string>
+			}
+			const ActionLogger = (options?: actionLoggerOptions) => Middleware
+			type transitLoggerOptions = {
+				logger?: LoggerInstance,
+				logLevel?: LogLevels,
+				logPacketData?: boolean,
+
+				folder?: string | null,
+				extension?: string,
+
+				colors?: {
+					receive?: KleurColor,
+					send?: KleurColor
+				},
+
+				packetFilter?: Array<Packets.packetType>
+			}
+			const TransitLogger = (options?: transitLoggerOptions) => Middleware
+		}
+		namespace Transmit {
+			type compressionOptions = {
+				method?: "deflate" | "deflateRaw" | "gzip",
+				threshold?: number | string
+			}
+			const Compression = (options?: compressionOptions) => Middleware
+			const Encryption = (password: string, algorithm: string, iv: string | Buffer) => Middleware
 		}
 	}
 


### PR DESCRIPTION
Add typing for the optionals middlewares

PS : I typed the encryption middleware too, but I think it's not a good middleware, not secure (IV not changing), and hard to use (password length need to be a strict length)

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
