### PR TITLE
Prevent registerInternalServices deprecation warning

### DIFF
--- a/dev/loglevel.js
+++ b/dev/loglevel.js
@@ -120,27 +120,11 @@ const schema = {
 	}
 };
 
-broker.createService(
-	{
-		name: "greeter",
-		version: 2
-	},
-	schema
-);
+broker.createService({ ...schema, name: 'greeter', version: 2 });
 
-broker.createService(
-	{
-		name: "test"
-	},
-	schema
-);
+broker.createService({ ...schema, name: 'test' });
 
-broker.createService(
-	{
-		name: "hello"
-	},
-	schema
-);
+broker.createService({ ...schema, name: 'hello' });
 
 const myLogger = broker.getLogger("my.custom.module");
 

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -964,16 +964,16 @@ class ServiceBroker {
 	 */
 	registerInternalServices(opts) {
 		opts = utils.isObject(opts) ? opts : {};
-		const interalsSchema = require("./internals")(this);
+		const internalsSchema = require("./internals")(this);
 		let definitiveSchema = {};
 		// If it's present any custom definition, define it as the root schema and the default one as a mixin
 		if (opts["$node"]) {
 			definitiveSchema = opts["$node"];
 			if (!definitiveSchema.mixins) definitiveSchema.mixins = [];
-			definitiveSchema.mixins.push(interalsSchema);
+			definitiveSchema.mixins.push(internalsSchema);
 		} else {
 			// Otherwise, just use the default one
-			definitiveSchema = interalsSchema;
+			definitiveSchema = internalsSchema;
 		}
 		this.createService(definitiveSchema);
 	}

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -964,7 +964,18 @@ class ServiceBroker {
 	 */
 	registerInternalServices(opts) {
 		opts = utils.isObject(opts) ? opts : {};
-		this.createService(require("./internals")(this), opts["$node"]);
+		const interalsSchema = require("./internals")(this);
+		let definitiveSchema = {};
+		// If it's present any custom definition, define it as the root schema and the default one as a mixin
+		if (opts["$node"]) {
+			definitiveSchema = opts["$node"];
+			if (!definitiveSchema.mixins) definitiveSchema.mixins = [];
+			definitiveSchema.mixins.push(interalsSchema);
+		// Otherwise, just use the default one
+		} else {
+			definitiveSchema = interalsSchema;
+		}
+		this.createService(definitiveSchema);
 	}
 
 	/**

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -971,8 +971,8 @@ class ServiceBroker {
 			definitiveSchema = opts["$node"];
 			if (!definitiveSchema.mixins) definitiveSchema.mixins = [];
 			definitiveSchema.mixins.push(interalsSchema);
-		// Otherwise, just use the default one
 		} else {
+			// Otherwise, just use the default one
 			definitiveSchema = interalsSchema;
 		}
 		this.createService(definitiveSchema);

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1715,21 +1715,18 @@ describe("Test broker.registerInternalServices", () => {
 		broker.registerInternalServices();
 
 		expect(broker.createService).toHaveBeenCalledTimes(1);
-		expect(broker.createService).toHaveBeenCalledWith(
-			{
-				name: "$node",
-				actions: {
-					list: expect.any(Object),
-					services: expect.any(Object),
-					actions: expect.any(Object),
-					events: expect.any(Object),
-					health: expect.any(Object),
-					options: expect.any(Object),
-					metrics: expect.any(Object)
-				}
-			},
-			undefined
-		);
+		expect(broker.createService).toHaveBeenCalledWith({
+			name: "$node",
+			actions: {
+				list: expect.any(Object),
+				services: expect.any(Object),
+				actions: expect.any(Object),
+				events: expect.any(Object),
+				health: expect.any(Object),
+				options: expect.any(Object),
+				metrics: expect.any(Object)
+			}
+		});
 	});
 
 	it("should register internal action with mixins", () => {
@@ -1748,25 +1745,25 @@ describe("Test broker.registerInternalServices", () => {
 		});
 
 		expect(broker.createService).toHaveBeenCalledTimes(1);
-		expect(broker.createService).toHaveBeenCalledWith(
-			{
-				name: "$node",
-				actions: {
-					list: expect.any(Object),
-					services: expect.any(Object),
-					actions: expect.any(Object),
-					events: expect.any(Object),
-					health: expect.any(Object),
-					options: expect.any(Object),
-					metrics: expect.any(Object)
-				}
+		expect(broker.createService).toHaveBeenCalledWith({
+			metadata: {
+				a: 5
 			},
-			{
-				metadata: {
-					a: 5
+			mixins: [
+				{
+					name: "$node",
+					actions: {
+						list: expect.any(Object),
+						services: expect.any(Object),
+						actions: expect.any(Object),
+						events: expect.any(Object),
+						health: expect.any(Object),
+						options: expect.any(Object),
+						metrics: expect.any(Object)
+					}
 				}
-			}
-		);
+			]
+		});
 	});
 });
 


### PR DESCRIPTION
## :memo: Description

Prevent deprecation warning when running starting up using custom internal services properties

### :dart: Relevant issues

#1162 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Running tests by declaring custom $node properties
- Running and fixing tests/unit/service-broker.spec.js

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
