### PR TITLE
Use interface instead of type to allow for declaration merging

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -179,12 +179,12 @@ declare namespace Moleculer {
 				meta?: boolean | string[];
 		  };
 
-	type TracingSpanNameOption = string | ((ctx: Context) => string)
+	type TracingSpanNameOption = string | ((ctx: Context) => string);
 
 	interface TracingOptions {
 		enabled?: boolean;
 		tags?: TracingActionTags | TracingEventTags;
-		spanName?: TracingSpanNameOption
+		spanName?: TracingSpanNameOption;
 		safetyTags?: boolean;
 	}
 
@@ -479,7 +479,7 @@ declare namespace Moleculer {
 		basePath?: string;
 	}
 
-	type ActionSchema<S = ServiceSettingSchema> = {
+	interface ActionSchema {
 		name?: string;
 		rest?: RestSchema | string | string[];
 		visibility?: ActionVisibility;
@@ -495,9 +495,9 @@ declare namespace Moleculer {
 		hooks?: ActionHooks;
 
 		[key: string]: any;
-	} & ThisType<Service<S>>;
+	}
 
-	type EventSchema<S = ServiceSettingSchema> = {
+	interface EventSchema {
 		name?: string;
 		group?: string;
 		params?: ActionParams;
@@ -508,7 +508,7 @@ declare namespace Moleculer {
 		context?: boolean;
 
 		[key: string]: any;
-	} & ThisType<Service<S>>;
+	}
 
 	type ServiceActionsSchema<S = ServiceSettingSchema> = {
 		[key: string]: ActionSchema | ActionHandler | boolean;
@@ -638,7 +638,7 @@ declare namespace Moleculer {
 
 	type ServiceEventHandler = (ctx: Context) => void | Promise<void>;
 
-	type ServiceEvent<S = ServiceSettingSchema> = {
+	interface ServiceEvent {
 		name?: string;
 		group?: string;
 		params?: ActionParams;
@@ -646,11 +646,11 @@ declare namespace Moleculer {
 		debounce?: number;
 		throttle?: number;
 		handler?: ServiceEventHandler | ServiceEventLegacyHandler;
-	} & ThisType<Service<S>>;
+	}
 
-	type ServiceEvents = {
+	type ServiceEvents<S = ServiceSettingSchema> = {
 		[key: string]: ServiceEventHandler | ServiceEventLegacyHandler | ServiceEvent;
-	};
+	} & ThisType<Service<S>>;
 
 	type ServiceMethods = { [key: string]: (...args: any[]) => any } & ThisType<Service>;
 
@@ -779,7 +779,7 @@ declare namespace Moleculer {
 		 * @param params The event parameters
 		 * @param opts The event options
 		 */
-		emitLocalEventHandler(eventName: string, params?: any, opts?: any): any
+		emitLocalEventHandler(eventName: string, params?: any, opts?: any): any;
 
 		/**
 		 * Wait for the specified services to become available/registered with this broker.
@@ -790,9 +790,9 @@ declare namespace Moleculer {
 		 * @param interval The time we will wait before once again checking if the service(s) are available (In milliseconds)
 		 */
 		waitForServices(
-		  serviceNames: string | Array<string> | Array<ServiceDependency>,
-		  timeout?: number,
-		  interval?: number,
+			serviceNames: string | Array<string> | Array<ServiceDependency>,
+			timeout?: number,
+			interval?: number
 		): Promise<WaitForServicesResult>;
 
 		[name: string]: any;
@@ -882,10 +882,7 @@ declare namespace Moleculer {
 		 * @param src Source schema property
 		 * @param target Target schema property
 		 */
-		mergeSchemaLifecycleHandlers(
-		  src: GenericObject,
-		  target: GenericObject
-		): GenericObject;
+		mergeSchemaLifecycleHandlers(src: GenericObject, target: GenericObject): GenericObject;
 
 		/**
 		 * Merge unknown properties in schema
@@ -901,7 +898,7 @@ declare namespace Moleculer {
 		 * @param name The name
 		 * @param version The version
 		 */
-		static getVersionedFullName(name: string, version?: string|number): string;
+		static getVersionedFullName(name: string, version?: string | number): string;
 	}
 
 	type CheckRetryable = (err: Errors.MoleculerError | Error) => boolean;
@@ -1088,10 +1085,10 @@ declare namespace Moleculer {
 	type FallbackResponse = string | number | GenericObject;
 	type FallbackResponseHandler = (ctx: Context, err: Errors.MoleculerError) => Promise<any>;
 
-	type ContextParentSpan = {
-		id: string
-		traceID: string
-		sampled: boolean
+	interface ContextParentSpan {
+		id: string;
+		traceID: string;
+		sampled: boolean;
 	}
 
 	interface CallingOptions {
@@ -1448,8 +1445,8 @@ declare namespace Moleculer {
 				meta: object | null,
 				keys: Array<string> | null
 			): string;
-			tryLock(key: string | Array<string>, ttl?: number): Promise<() => Promise<void>>
-			lock(key: string | Array<string>, ttl?: number): Promise<() => Promise<void>>
+			tryLock(key: string | Array<string>, ttl?: number): Promise<() => Promise<void>>;
+			lock(key: string | Array<string>, ttl?: number): Promise<() => Promise<void>>;
 		}
 
 		class Memory extends Base {


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR modifies a few `type` aliases in the declaration file to instead be `interface`s.  As noted in #1164 , an `interface` can be augmented through [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).  This is important for consumers and third party plugins as it allows them to extend the built-in types.  `type` will not allow this merging behavior.

This PR adjusts `ActionSchema`, `EventSchema`, `ServiceEvent`, and `ContextParentSpan` to all be interfaces instead of types.  A few of these types also were intersections with `ThisType<Service<S>>`.  In order to avoid breaking changes, the `ServiceEvents` type was adjusted to have the `ThisType<Service<S>>` instead so the type of `this` will be available in the appropriate contexts for service schemas.  The `ServiceActionsSchema` type already included `ThisType<Service<S>>` so a change there was unnecessary.

A few additional unrelated changes were triggered due to prettier auto-formatting.

This PR supersedes and closes #1164 .

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

I loaded the changed definition in a large repository of services and ran typescript type checking with no errors.  Additionally, I augmented the `ActionSchema` type in a third party library successfully and was able to access the augmented types.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
