### PR TITLE
Fix #1167 

### DIFF
--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -429,6 +429,8 @@ class AmqpTransporter extends Transporter {
 	 * @memberof AmqpTransporter
 	 */
 	subscribeBalancedRequest(action) {
+		if (!this.channel) return;
+
 		const queue = `${this.prefix}.${PACKET_REQUEST}B.${action}`;
 		return this.channel
 			.assertQueue(queue, this._getQueueOptions(PACKET_REQUEST, true))
@@ -449,6 +451,8 @@ class AmqpTransporter extends Transporter {
 	 * @memberof AmqpTransporter
 	 */
 	subscribeBalancedEvent(event, group) {
+		if (!this.channel) return;
+
 		const queue = `${this.prefix}.${PACKET_EVENT}B.${group}.${event}`;
 		return this.channel
 			.assertQueue(queue, this._getQueueOptions(PACKET_EVENT + "LB", true))


### PR DESCRIPTION
Fixes #1167 

Applies exactly the same logic as the `subscribe(cmd, nodeID)` fn

https://github.com/moleculerjs/moleculer/blob/ef9ccfeef3c3ee1b26d556397643bc1b66463939/src/transporters/amqp.js#L383-L384