### PR TITLE
fix for #1169: getPrototypeOf instead of __proto__

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
+    - name: Disable proto
+      if: ${{ matrix.node-version != '10.x' }}
+      run: export NODE_OPTIONS=--disable-proto=delete
+
     - name: Install dependencies
       run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "memleak": "node benchmark/memleak-test.js",
     "proto": "pbjs -t static-module -w commonjs -o src/serializers/proto/packets.proto.js src/serializers/proto/packets.proto",
     "thrift": "thrift -gen js:node -o src\\serializers\\thrift src\\serializers\\thrift\\packets.thrift",
-    "test": "NODE_OPTIONS=--disable-proto=delete jest --coverage --forceExit",
+    "test": "jest --coverage --forceExit",
     "test:unit": "jest --testMatch \"**/unit/**/*.spec.js\" --coverage",
     "test:int": "jest --testMatch \"**/integration/**/*.spec.js\" --coverage",
     "test:e2e": "cd test/e2e && ./start.sh",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "memleak": "node benchmark/memleak-test.js",
     "proto": "pbjs -t static-module -w commonjs -o src/serializers/proto/packets.proto.js src/serializers/proto/packets.proto",
     "thrift": "thrift -gen js:node -o src\\serializers\\thrift src\\serializers\\thrift\\packets.thrift",
-    "test": "jest --coverage --forceExit",
+    "test": "NODE_OPTIONS=--disable-proto=delete jest --coverage --forceExit",
     "test:unit": "jest --testMatch \"**/unit/**/*.spec.js\" --coverage",
     "test:int": "jest --testMatch \"**/integration/**/*.spec.js\" --coverage",
     "test:e2e": "cd test/e2e && ./start.sh",

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -1775,14 +1775,14 @@ class ServiceBroker {
 			return schema;
 		}
 		// Depending how the schema was create the correct constructor name (from base class) will be locate on __proto__.
-		target = utils.getConstructorName(schema.__proto__);
+		target = utils.getConstructorName(Object.getPrototypeOf(schema));
 		if (serviceName === target) {
-			Object.setPrototypeOf(schema.__proto__, this.ServiceFactory);
+			Object.setPrototypeOf(Object.getPrototypeOf(schema), this.ServiceFactory);
 			return schema;
 		}
 		// This is just to handle some idiosyncrasies from Jest.
 		if (schema._isMockFunction) {
-			target = utils.getConstructorName(schema.prototype.__proto__);
+			target = utils.getConstructorName(Object.getPrototypeOf(schema.prototype));
 			if (serviceName === target) {
 				Object.setPrototypeOf(schema, this.ServiceFactory);
 				return schema;


### PR DESCRIPTION
## :memo: Description

This PR basically replaces `__proto__` with `Object.getPrototypeOf`.

### :dart: Relevant issues

This PR is related to issue #1169.

### :gem: Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code

NodeJS flag `--disable-proto` can now be used:
```
node --disable-proto=delete index.js
``` 

## :vertical_traffic_light: How Has This Been Tested?

The whole test plan is executed with `--disable-proto=delete` passed to NodeJS.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
