### PR TITLE
Fix merge schemas

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -16,7 +16,7 @@ const { isObject, isFunction, flatten, functionArguments, deprecate } = require(
  * @param {Function|Object} o
  * @returns {Object}
  */
-function wrapToHander(o) {
+function wrapToHandler(o) {
 	return isFunction(o) ? { handler: o } : o;
 }
 
@@ -742,8 +742,8 @@ class Service {
 				return;
 			}
 
-			const srcAction = wrapToHander(src[k]);
-			const targetAction = wrapToHander(target[k]);
+			const srcAction = wrapToHandler(src[k]);
+			const targetAction = wrapToHandler(target[k]);
 
 			if (srcAction && srcAction.hooks && targetAction && targetAction.hooks) {
 				Object.keys(srcAction.hooks).forEach(k => {
@@ -784,8 +784,8 @@ class Service {
 	 */
 	mergeSchemaEvents(src, target) {
 		Object.keys(src).forEach(k => {
-			const modEvent = wrapToHander(src[k]);
-			const resEvent = wrapToHander(target[k]);
+			const modEvent = wrapToHandler(src[k]);
+			const resEvent = wrapToHandler(target[k]);
 
 			let handler = _.compact(
 				flatten([resEvent ? resEvent.handler : null, modEvent ? modEvent.handler : null])

--- a/src/service.js
+++ b/src/service.js
@@ -599,10 +599,12 @@ class Service {
 	 */
 	mergeSchemas(mixinSchema, svcSchema) {
 		const res = _.cloneDeep(mixinSchema);
+		if (!svcSchema) return res;
 		const mods = _.cloneDeep(svcSchema);
+		if (!mixinSchema) return mods;
 
 		Object.keys(mods).forEach(key => {
-			if (["name", "version"].indexOf(key) !== -1 && mods[key] !== undefined) {
+			if ((key === "name" || key === "version") && mods[key] !== undefined) {
 				// Simple overwrite
 				res[key] = mods[key];
 			} else if (key === "settings") {

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -1395,6 +1395,18 @@ describe("Test Service class", () => {
 			Service.prototype.mergeSchemaUnknown.mockRestore();
 		});
 
+		it("should not throw if input null/undefined", () => {
+			const schema = {
+				name: "schema"
+			};
+			const mods = {
+				name: "mods"
+			};
+			expect(Service.prototype.mergeSchemas(schema, null)).toEqual(schema);
+			expect(Service.prototype.mergeSchemas(null, mods)).toEqual(mods);
+			expect(Service.prototype.mergeSchemas(schema, mods)).toEqual(mods);
+		});
+
 		it("should call merge methods", () => {
 			const mixin2 = {};
 


### PR DESCRIPTION
if `mixinSchema` is null, `res[key]` will throw error
if `svcSchema` is null, `Object.keys(mods)` will throw error
