### PR TITLE
Improves StartedStoppedHandler definition to return Promise with void[]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -721,7 +721,7 @@ declare namespace Moleculer {
 		version?: string | number;
 	}
 
-	type StartedStoppedHandler = () => Promise<void> | void;
+	type StartedStoppedHandler = () => Promise<void[]> | Promise<void> | void;
 	interface ServiceSchema<S = ServiceSettingSchema> {
 		name: string;
 		version?: string | number;


### PR DESCRIPTION
When using TypeScript, the `started`, `created` and `stopped` methods in services (and for extension, middleware) are supposed to be able to return any kind of `Promise`, but the current type definition breaks in case a `Promise.all` is returned. This PR fixes it by adding a `Promise<void[]>` return type.

- [x] Bug fix (non-breaking change which fixes an issue)


## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Applied the change to `index.d.ts` and then checked type definition in a middleware (extending `ServiceSchema`). Linter did not return any error while testing `created() {return Promise.all(promises)}`.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
