### PR TITLE
feat: allow custom cache TTL based on result

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -448,10 +448,15 @@ declare namespace Moleculer {
 	}
 
 	type ActionCacheEnabledFuncType = (ctx: Context<any, any>) => boolean;
+	type ActionCacheTTLCustomFunction<
+		TResult = any,
+		TContext extends Context = Context<any, any, any>,
+		TCacheOptions = ActionCacheOptions
+	> = (result: TResult, cacheKey: string, ctx: TContext, opts: TCacheOptions) => number | null | undefined
 
 	interface ActionCacheOptions<P = Record<string, unknown>, M = unknown> {
 		enabled?: boolean | ActionCacheEnabledFuncType;
-		ttl?: number;
+		ttl?: number | ActionCacheTTLCustomFunction;
 		keys?: string[];
 		keygen?: CacherKeygenFunc<P, M>;
 		lock?: {
@@ -1444,6 +1449,14 @@ declare namespace Moleculer {
 				meta: object,
 				keys: string[] | null
 			): string;
+
+			getCacheTTL<TResult = any, TContext extends Context = Context>(
+				opts: ActionCacheOptions,
+				result: TResult,
+				cacheKey: string,
+				ctx: TContext
+			): number | null | undefined;
+
 			defaultKeygen(
 				actionName: string,
 				params: object | null,

--- a/src/cachers/base.js
+++ b/src/cachers/base.js
@@ -309,6 +309,18 @@ class Cacher {
 	}
 
 	/**
+	 * Get a cache TTL
+	 * @param {Object} opts cache options
+	 * @param {String} cacheKey
+	 * @param {any} result
+	 * @param {Context} ctx
+	 * @returns {number|null}
+	 */
+	getCacheTTL(opts, result, cacheKey, ctx) {
+		return isFunction(opts.ttl) ? opts.ttl.call(this, result, cacheKey, ctx, opts) : opts.ttl;
+	}
+
+	/**
 	 * Register cacher as a middleware
 	 *
 	 * @memberof Cacher
@@ -376,7 +388,12 @@ class Cacher {
 															return this.set(
 																cacheKey,
 																result,
-																opts.ttl
+																this.getCacheTTL(
+																	opts,
+																	result,
+																	cacheKey,
+																	ctx
+																)
 															).then(() => unlock());
 														})
 														.catch((/*err*/) => {
@@ -415,9 +432,11 @@ class Cacher {
 										return handler(ctx)
 											.then(result => {
 												// Save the result to the cache and realse the lock.
-												this.set(cacheKey, result, opts.ttl).then(() =>
-													unlock()
-												);
+												this.set(
+													cacheKey,
+													result,
+													this.getCacheTTL(opts, result, cacheKey, ctx)
+												).then(() => unlock());
 												return result;
 											})
 											.catch(e => {
@@ -440,7 +459,11 @@ class Cacher {
 							// Call the handler
 							return handler(ctx).then(result => {
 								// Save the result to the cache
-								this.set(cacheKey, result, opts.ttl);
+								this.set(
+									cacheKey,
+									result,
+									this.getCacheTTL(opts, result, cacheKey, ctx)
+								);
 
 								return result;
 							});


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### :scroll: Example code
```js
{
  cache: {
    enabled: true,
    ttl(result) {
      return getCacheTTL(result)
    },
  },
}
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

baseCacher
- [x] check getCacheTTL with default `ttl`
- [x] check getCacheTTL with custom ttl function

middleware
- [x] should call the 'cache.set' action with custom TTL as Function

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
