### PR TITLE
Cacher improvements for v0.15

### DIFF
--- a/src/cachers/base.js
+++ b/src/cachers/base.js
@@ -28,7 +28,9 @@ class Cacher {
 		this.opts = _.defaultsDeep(opts, {
 			ttl: null,
 			keygen: null,
-			maxParamsLength: null
+			maxParamsLength: null,
+			/** @type {any}  Return with this if the key is missing in the cache */
+			missingResponse: undefined
 		});
 
 		/** @type {boolean} Flag indicating the connection status */
@@ -417,7 +419,7 @@ class Cacher {
 		}
 
 		return cachePromise.then(data => {
-			if (data != null) {
+			if (data !== this.opts.missingResponse) {
 				// Found in the cache! Don't call handler, return with the content
 				ctx.cachedResult = true;
 				return data;
@@ -460,7 +462,7 @@ class Cacher {
 	 */
 	middlewareWithoutLock(ctx, cacheKey, handler, opts) {
 		return this.get(cacheKey).then(content => {
-			if (content != null) {
+			if (content !== this.opts.missingResponse) {
 				// Found in the cache! Don't call handler, return with the content
 				ctx.cachedResult = true;
 				return content;

--- a/src/cachers/memory-lru.js
+++ b/src/cachers/memory-lru.js
@@ -1,6 +1,6 @@
 /*
  * moleculer
- * Copyright (c) 2018 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * Copyright (c) 2023 MoleculerJS (https://github.com/moleculerjs/moleculer)
  * MIT Licensed
  */
 
@@ -106,7 +106,7 @@ class MemoryLRUCacher extends BaseCacher {
 		} else {
 			timeEnd();
 		}
-		return this.broker.Promise.resolve(null);
+		return this.broker.Promise.resolve(this.opts.missingResponse);
 	}
 
 	/**

--- a/src/cachers/memory-lru.js
+++ b/src/cachers/memory-lru.js
@@ -64,6 +64,7 @@ class MemoryLRUCacher extends BaseCacher {
 			// Clear all entries after transporter connected. Maybe we missed some "cache.clear" events.
 			return this.clean();
 		});
+
 		if (this.opts.lock && this.opts.lock.enabled !== false && this.opts.lock.staleTime) {
 			/* istanbul ignore next */
 			this.logger.warn("setting lock.staleTime with MemoryLRUCacher is not supported.");

--- a/src/cachers/memory.js
+++ b/src/cachers/memory.js
@@ -12,6 +12,7 @@ const BaseCacher = require("./base");
 const { METRIC } = require("../metrics");
 
 const Lock = require("../lock");
+
 /**
  * Cacher factory for memory cache
  *
@@ -159,6 +160,7 @@ class MemoryCacher extends BaseCacher {
 
 	/**
 	 * Clean cache. Remove every key by match
+	 *
 	 * @param {string|Array<string>} match string. Default is "**"
 	 * @returns {Promise}
 	 *

--- a/src/cachers/memory.js
+++ b/src/cachers/memory.js
@@ -1,6 +1,6 @@
 /*
  * moleculer
- * Copyright (c) 2018 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * Copyright (c) 2023 MoleculerJS (https://github.com/moleculerjs/moleculer)
  * MIT Licensed
  */
 
@@ -95,7 +95,7 @@ class MemoryCacher extends BaseCacher {
 				this.metrics.increment(METRIC.MOLECULER_CACHER_EXPIRED_TOTAL);
 				this.cache.delete(key);
 				timeEnd();
-				return this.broker.Promise.resolve(null);
+				return this.broker.Promise.resolve(this.opts.missingResponse);
 			}
 			const res = this.clone ? this.clone(item.data) : item.data;
 			timeEnd();
@@ -104,7 +104,7 @@ class MemoryCacher extends BaseCacher {
 		} else {
 			timeEnd();
 		}
-		return this.broker.Promise.resolve(null);
+		return this.broker.Promise.resolve(this.opts.missingResponse);
 	}
 
 	/**
@@ -194,7 +194,7 @@ class MemoryCacher extends BaseCacher {
 	 */
 	getWithTTL(key) {
 		this.logger.debug(`GET ${key}`);
-		let data = null;
+		let data = this.opts.missingResponse;
 		let ttl = null;
 		if (this.cache.has(key)) {
 			this.logger.debug(`FOUND ${key}`);

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -37,13 +37,13 @@ class RedisCacher extends BaseCacher {
 			pingInterval: null
 		});
 
-		this.pingIntervalHandle = null;
+		this.pingTimer = null;
 	}
 
 	/**
 	 * Initialize cacher. Connect to Redis server
 	 *
-	 * @param {any} broker
+	 * @param {ServiceBroker} broker
 	 *
 	 * @memberof RedisCacher
 	 */
@@ -59,13 +59,14 @@ class RedisCacher extends BaseCacher {
 				true
 			);
 		}
+
 		/**
 		 * ioredis client instance
 		 * @memberof RedisCacher
 		 */
 		if (this.opts.cluster) {
 			if (!this.opts.cluster.nodes || this.opts.cluster.nodes.length === 0) {
-				throw new BrokerOptionsError("No nodes defined for cluster");
+				throw new BrokerOptionsError("There is no 'nodes' configuration for cluster.");
 			}
 
 			this.client = new Redis.Cluster(this.opts.cluster.nodes, this.opts.cluster.options);
@@ -94,28 +95,32 @@ class RedisCacher extends BaseCacher {
 			/* istanbul ignore next */
 			this.logger.error(err);
 		});
-		try {
-			Redlock = require("redlock");
-		} catch (err) {
-			/* istanbul ignore next */
-			this.logger.warn(
-				"The 'redlock' package is missing. If you want to enable cache lock, please install it with 'npm install redlock --save' command."
-			);
+
+		if (this.opts.lock) {
+			try {
+				Redlock = require("redlock");
+			} catch (err) {
+				/* istanbul ignore next */
+				this.logger.warn(
+					"The 'redlock' package is missing. If you want to enable cache lock, please install it with 'npm install redlock --save' command."
+				);
+			}
+
+			if (Redlock) {
+				let redlockClients = (this.opts.redlock ? this.opts.redlock.clients : null) || [
+					this.client
+				];
+
+				// redlock client instance
+				this.redlock = new Redlock(redlockClients, _.omit(this.opts.redlock, ["clients"]));
+
+				// Non-blocking redlock client, used for tryLock()
+				this.redlockNonBlocking = new Redlock(redlockClients, {
+					retryCount: 0
+				});
+			}
 		}
-		if (Redlock) {
-			let redlockClients = (this.opts.redlock ? this.opts.redlock.clients : null) || [
-				this.client
-			];
-			/**
-			 * redlock client instance
-			 * @memberof RedisCacher
-			 */
-			this.redlock = new Redlock(redlockClients, _.omit(this.opts.redlock, ["clients"]));
-			// Non-blocking redlock client, used for tryLock()
-			this.redlockNonBlocking = new Redlock(redlockClients, {
-				retryCount: 0
-			});
-		}
+
 		if (this.opts.monitor) {
 			/* istanbul ignore next */
 			this.client.monitor((err, monitor) => {
@@ -132,7 +137,7 @@ class RedisCacher extends BaseCacher {
 
 		// add interval for ping if set
 		if (this.opts.pingInterval > 0) {
-			this.pingIntervalHandle = setInterval(() => {
+			this.pingTimer = setInterval(() => {
 				this.client
 					.ping()
 					.then(() => {
@@ -163,9 +168,9 @@ class RedisCacher extends BaseCacher {
 	 * @memberof RedisCacher
 	 */
 	close() {
-		if (this.pingIntervalHandle != null) {
-			clearInterval(this.pingIntervalHandle);
-			this.pingIntervalHandle = null;
+		if (this.pingTimer != null) {
+			clearInterval(this.pingTimer);
+			this.pingTimer = null;
 		}
 		return this.client != null ? this.client.quit() : Promise.resolve();
 	}
@@ -253,6 +258,7 @@ class RedisCacher extends BaseCacher {
 
 		deleteTargets = Array.isArray(deleteTargets) ? deleteTargets : [deleteTargets];
 		const keysToDelete = deleteTargets.map(key => this.prefix + key);
+
 		this.logger.debug(`DELETE ${keysToDelete}`);
 		return this.client
 			.del(keysToDelete)
@@ -312,15 +318,17 @@ class RedisCacher extends BaseCacher {
 			.getBuffer(this.prefix + key)
 			.ttl(this.prefix + key)
 			.exec()
-			.then(res => {
-				let [err0, data] = res[0];
-				let [err1, ttl] = res[1];
+			.then(([resBuffer, resTTL]) => {
+				let [err0, data] = resBuffer;
+				const [err1, ttl] = resTTL;
+
 				if (err0) {
 					return this.broker.Promise.reject(err0);
 				}
 				if (err1) {
 					return this.broker.Promise.reject(err1);
 				}
+
 				if (data) {
 					this.logger.debug(`FOUND ${key}`);
 					try {

--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -1,6 +1,6 @@
 /*
  * moleculer
- * Copyright (c) 2020 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * Copyright (c) 2023 MoleculerJS (https://github.com/moleculerjs/moleculer)
  * MIT Licensed
  */
 
@@ -203,7 +203,7 @@ class RedisCacher extends BaseCacher {
 				}
 			}
 			timeEnd();
-			return null;
+			return this.opts.missingResponse;
 		});
 	}
 
@@ -335,7 +335,7 @@ class RedisCacher extends BaseCacher {
 						data = this.serializer.deserialize(data);
 					} catch (err) {
 						this.logger.error("Redis result parse error.", err, data);
-						data = null;
+						data = this.opts.missingResponse;
 					}
 				}
 				return { data, ttl };

--- a/src/serializers/json-extended.js
+++ b/src/serializers/json-extended.js
@@ -62,7 +62,7 @@ class JSONExtSerializer extends BaseSerializer {
 	 * @param {any} value
 	 */
 	reviver(key, value) {
-		if (typeof value === "string" && value.charAt(0) === "[") {
+		if (typeof value === "string" && value.charAt(0) === "[" && value.charAt(1) === "[") {
 			switch (value.slice(0, 6)) {
 				case PREFIX_BIGINT:
 					return BigInt(value.slice(6));

--- a/test/unit/cachers/base.spec.js
+++ b/test/unit/cachers/base.spec.js
@@ -454,7 +454,7 @@ describe("Test middleware", () => {
 	it("should not give back cached data and should call the handler and call the 'cache.set' action with promise", () => {
 		let resData = [1, 3, 5];
 		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
-		broker.cacher.get = jest.fn(() => Promise.resolve(null));
+		broker.cacher.get = jest.fn(() => Promise.resolve(undefined));
 		mockAction.handler = jest.fn(() => Promise.resolve(resData));
 
 		let ctx = new Context();
@@ -478,7 +478,7 @@ describe("Test middleware", () => {
 		let resData = [1];
 		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		broker.cacher.set.mockClear();
-		broker.cacher.get = jest.fn(() => Promise.resolve(null));
+		broker.cacher.get = jest.fn(() => Promise.resolve(undefined));
 		mockAction.handler = jest.fn(() => Promise.resolve(resData));
 		mockAction.cache = { ttl: 8 };
 
@@ -690,8 +690,8 @@ describe("Test middleware with lock enabled", () => {
 	it("should not give back cached data and should call the handler and call the 'cache.set' action with promise", () => {
 		let resData = [1, 3, 5];
 		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
-		broker.cacher.get = jest.fn(() => Promise.resolve(null));
-		broker.cacher.getWithTTL = jest.fn(() => Promise.resolve({ data: null, ttl: null }));
+		broker.cacher.get = jest.fn(() => Promise.resolve(undefined));
+		broker.cacher.getWithTTL = jest.fn(() => Promise.resolve({ data: undefined, ttl: null }));
 		const unlockFn = jest.fn(() => Promise.resolve());
 		broker.cacher.lock = jest.fn(() => Promise.resolve(unlockFn));
 		mockAction.handler = jest.fn(() => Promise.resolve(resData));

--- a/test/unit/cachers/base.spec.js
+++ b/test/unit/cachers/base.spec.js
@@ -84,123 +84,213 @@ describe("Test BaseCacher", () => {
 
 		cacher.init(broker);
 		// Check result
-		let res = cacher.getCacheKey("posts.find.model", { id: 1, name: "Bob" });
-		expect(res).toBe("posts.find.model:id|1|name|Bob");
+		let res = cacher.getCacheKey(
+			{ name: "posts.find.model" },
+			{},
+			{ params: { id: 1, name: "Bob" } }
+		);
+		expect(res).toBe('posts.find.model:id|1|name|"Bob"');
 
 		// Same result, with same params
-		let res2 = cacher.getCacheKey("posts.find.model", { id: 1, name: "Bob" });
+		let res2 = cacher.getCacheKey(
+			{ name: "posts.find.model" },
+			{},
+			{ params: { id: 1, name: "Bob" } }
+		);
 		expect(res2).toEqual(res);
 
 		// Different result, with different params
-		let res3 = cacher.getCacheKey("posts.find.model", { id: 2, name: "Bob" });
+		let res3 = cacher.getCacheKey(
+			{ name: "posts.find.model" },
+			{},
+			{ params: { id: 2, name: "Bob" } }
+		);
 		expect(res3).not.toEqual(res);
-		expect(res3).toBe("posts.find.model:id|2|name|Bob");
+		expect(res3).toBe('posts.find.model:id|2|name|"Bob"');
 
 		res = cacher.getCacheKey();
 		expect(res).toBe(undefined);
 
-		res = cacher.getCacheKey("posts.find");
+		res = cacher.getCacheKey({ name: "posts.find" });
 		expect(res).toBe("posts.find");
 
-		res = cacher.getCacheKey("user", {});
+		res = cacher.getCacheKey({ name: "posts.find" }, {});
+		expect(res).toBe("posts.find");
+
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: {} });
 		expect(res).toBe("user:");
 
-		res = cacher.getCacheKey("user", { a: 5 });
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: 5 } });
 		expect(res).toBe("user:a|5");
 
-		res = cacher.getCacheKey("user", { a: [] });
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: [] } });
 		expect(res).toBe("user:a|[]");
 
-		res = cacher.getCacheKey("user", { a: null });
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: null } });
 		expect(res).toBe("user:a|null");
 
-		res = cacher.getCacheKey("user", { a: 5 }, null, ["a"]);
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: undefined } });
+		expect(res).toBe("user:a|undefined");
+
+		res = cacher.getCacheKey({ name: "user" }, { keys: ["a"] }, { params: { a: 5 } });
 		expect(res).toBe("user:5");
 
-		res = cacher.getCacheKey("user", { a: { id: 5 } }, null, ["a"]);
+		res = cacher.getCacheKey({ name: "user" }, { keys: ["a"] }, { params: { a: { id: 5 } } });
 		expect(res).toBe("user:id|5");
 
-		res = cacher.getCacheKey("user", { a: [1, 3, 5] }, null, ["a"]);
+		res = cacher.getCacheKey({ name: "user" }, { keys: ["a"] }, { params: { a: [1, 3, 5] } });
 		expect(res).toBe("user:[1|3|5]");
 
-		res = cacher.getCacheKey("user", { a: 5, b: 3, c: 5 }, null, ["a"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a"] },
+			{ params: { a: 5, b: 3, c: 5 } }
+		);
 		expect(res).toBe("user:5");
 
-		res = cacher.getCacheKey("user", { a: { b: "John" } }, null, ["a.b"]);
-		expect(res).toBe("user:John");
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a.b"] },
+			{ params: { a: { b: "John" } } }
+		);
+		expect(res).toBe('user:"John"');
 
-		res = cacher.getCacheKey("user", { a: 5, b: 3, c: 5 }, null, ["a", "b", "c"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a", "b", "c"] },
+			{ params: { a: 5, b: 3, c: 5 } }
+		);
 		expect(res).toBe("user:5|3|5");
 
-		res = cacher.getCacheKey("user", { a: 5, c: 5 }, null, ["a", "b", "c"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a", "b", "c"] },
+			{ params: { a: 5, c: 5 } }
+		);
 		expect(res).toBe("user:5|undefined|5");
 
-		res = cacher.getCacheKey("user", { a: "12345" });
-		expect(res).toBe("user:a|12345");
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: "12345" } });
+		expect(res).toBe('user:a|"12345"');
 
-		res = cacher.getCacheKey("user", { a: ["12345"] });
-		expect(res).toBe("user:a|[12345]");
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: ["12345"] } });
+		expect(res).toBe('user:a|["12345"]');
 
 		const d = new Date(1614529868608);
-		res = cacher.getCacheKey("user", { a: d });
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: d } });
 		expect(res).toBe("user:a|1614529868608");
 
-		res = cacher.getCacheKey("user", { a: Symbol("something") });
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: Symbol("something") } });
 		expect(res).toBe("user:a|Symbol(something)");
 
-		res = cacher.getCacheKey("user", { a: 5, b: { id: 3 } }, null, ["a", "c", "b"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a", "c", "b"] },
+			{ params: { a: 5, b: { id: 3 } } }
+		);
 		expect(res).toBe("user:5|undefined|id|3");
 
-		res = cacher.getCacheKey("user", { a: 5, b: { id: 3, other: { status: true } } }, null, [
-			"a",
-			"c",
-			"b.id"
-		]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a", "c", "b.id"] },
+			{ params: { a: 5, b: { id: 3, other: { status: true } } } }
+		);
 		expect(res).toBe("user:5|undefined|3");
 
-		res = cacher.getCacheKey("user", { a: 5, b: { id: 3, other: { status: true } } }, null, [
-			"a",
-			"b.id",
-			"b.other.status"
-		]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a", "b.id", "b.other.status"] },
+			{ params: { a: 5, b: { id: 3, other: { status: true } } } }
+		);
 		expect(res).toBe("user:5|3|true");
 
-		res = cacher.getCacheKey("user", { a: 5, b: { id: 3, other: { status: true } } });
+		res = cacher.getCacheKey({ name: "user" }, null, {
+			params: { a: 5, b: { id: 3, other: { status: true } } }
+		});
 		expect(res).toBe("user:a|5|b|id|3|other|status|true");
 
-		res = cacher.getCacheKey("user", { a: 5, b: 3 }, null, []);
+		res = cacher.getCacheKey({ name: "user" }, { keys: [] }, { params: { a: 5, b: 3 } });
 		expect(res).toBe("user");
 
-		res = cacher.getCacheKey("user", { a: Object.create(null) }, null, ["a"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a"] },
+			{ params: { a: Object.create(null) } }
+		);
 		expect(res).toBe("user:");
 
 		// Test with meta
-		res = cacher.getCacheKey("user", { a: 5 }, { user: "bob" });
+		res = cacher.getCacheKey({ name: "user" }, {}, { params: { a: 5 }, meta: { user: "bob" } });
 		expect(res).toBe("user:a|5");
 
-		res = cacher.getCacheKey("user", { a: 5 }, { user: "bob" }, ["a"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a"] },
+			{ params: { a: 5 }, meta: { user: "bob" } }
+		);
 		expect(res).toBe("user:5");
 
-		res = cacher.getCacheKey("user", { a: 5 }, { user: "bob" }, ["user"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["user"] },
+			{ params: { a: 5 }, meta: { user: "bob" } }
+		);
 		expect(res).toBe("user:undefined");
 
-		res = cacher.getCacheKey("user", { a: 5 }, { user: "bob" }, ["#user"]);
-		expect(res).toBe("user:bob");
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["#user"] },
+			{ params: { a: 5 }, meta: { user: "bob" } }
+		);
+		expect(res).toBe('user:"bob"');
 
-		res = cacher.getCacheKey("user", { a: 5 }, { user: "bob" }, ["a", "#user"]);
-		expect(res).toBe("user:5|bob");
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["a", "#user"] },
+			{ params: { a: 5 }, meta: { user: "bob" } }
+		);
+		expect(res).toBe('user:5|"bob"');
 
-		res = cacher.getCacheKey("user", { a: 5 }, { user: "bob" }, ["#user", "a"]);
-		expect(res).toBe("user:bob|5");
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["#user", "a"] },
+			{ params: { a: 5 }, meta: { user: "bob" } }
+		);
+		expect(res).toBe('user:"bob"|5');
 
-		res = cacher.getCacheKey("user", { a: 5, user: "adam" }, { user: "bob" }, ["#user"]);
-		expect(res).toBe("user:bob");
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["#user"] },
+			{ params: { a: 5, user: "adam" }, meta: { user: "bob" } }
+		);
+		expect(res).toBe('user:"bob"');
 
-		res = cacher.getCacheKey("user", { a: 5 }, null, ["#user"]);
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["#user"] },
+			{ params: { a: 5 }, meta: null }
+		);
 		expect(res).toBe("user:undefined");
 
-		res = cacher.getCacheKey("user", null, { a: { b: { c: "nested" } } }, ["#a.b.c"]);
-		expect(res).toBe("user:nested");
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["#a.b.c"] },
+			{ meta: { a: { b: { c: "nested" } } } }
+		);
+		expect(res).toBe('user:"nested"');
+
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["@user"] },
+			{ params: { a: 5, user: "adam" }, meta: { user: "bob" }, headers: { user: "kevin" } }
+		);
+		expect(res).toBe('user:"kevin"');
+
+		res = cacher.getCacheKey(
+			{ name: "user" },
+			{ keys: ["@a.b.c"] },
+			{ headers: { a: { b: { c: "nested" } } } }
+		);
+		expect(res).toBe('user:"nested"');
 	});
 
 	it("check getCacheKey with hashing", () => {
@@ -251,49 +341,51 @@ describe("Test BaseCacher", () => {
 		};
 
 		cacher.opts.maxParamsLength = 44;
-		res = cacher.getCacheKey("abc.def", bigObj);
-		expect(res).toBe("abc.def:/18CtAt7Z+barI7S7Ef+WTFQ23yVQ4VM8o+riN95sjo=");
+		res = cacher.getCacheKey({ name: "abc.def" }, {}, { params: bigObj });
+		expect(res).toBe("abc.def:NZM9OuUh6/tx+mcELOV3Z3EOaUo6f28bgdL76znnrS8=");
 
 		cacher.opts.maxParamsLength = 94;
-		res = cacher.getCacheKey("abc.def", bigObj);
+		res = cacher.getCacheKey({ name: "abc.def" }, {}, { params: bigObj });
 		expect(res).toBe(
-			"abc.def:A|C0|false|C1|true|C2|true|C3|495f761d77d6294f|C4|/18CtAt7Z+barI7S7Ef+WTFQ23yVQ4VM8o+riN95sjo="
+			'abc.def:A|C0|false|C1|true|C2|true|C3|"495f761d77d6294f"|CNZM9OuUh6/tx+mcELOV3Z3EOaUo6f28bgdL76znnrS8='
 		);
 
 		cacher.opts.maxParamsLength = 485;
-		res = cacher.getCacheKey("abc.def", bigObj);
+		res = cacher.getCacheKey({ name: "abc.def" }, {}, { params: bigObj });
 		expect(res).toBe(
-			"abc.def:A|C0|false|C1|true|C2|true|C3|495f761d77d6294f|C4|true|B|C0|true|C1|false|C2|true|C3|5721c26bfddb7927|C4|false|C|C0|5d9e85c124d5d09e|C1|true|C2|5366|C3|false|C4|false|D|C0|false|C1|true|C2|704473bca1242604|C3|false|C4|6fc56107e69be769|E|C0|true|C1|true|C2|4881|C3|true|C4|1418|F|C0|true|C1|false|C2|false|C3|false|C4|true|G|C0|false|C1|true|C2|false|C3|6547|C4|9565|H|C0|true|C1|1848|C2|232e6552d0b8aa98|C3|1d50627abe5c0463|C4|5251|I|C0|ecd0/18CtAt7Z+barI7S7Ef+WTFQ23yVQ4VM8o+riN95sjo="
+			'abc.def:A|C0|false|C1|true|C2|true|C3|"495f761d77d6294f"|C4|true|B|C0|true|C1|false|C2|true|C3|"5721c26bfddb7927"|C4|false|C|C0|"5d9e85c124d5d09e"|C1|true|C2|5366|C3|false|C4|false|D|C0|false|C1|true|C2|"704473bca1242604"|C3|false|C4|"6fc56107e69be769"|E|C0|true|C1|true|C2|4881|C3|true|C4|1418|F|C0|true|C1|false|C2|false|C3|false|C4|true|G|C0|false|C1|true|C2|false|C3|6547|C4|9565|H|C0|true|C1|1848|C2|"232e6552d0b8aa98"|C3|"1d50627abe5c0463"|C4|NZM9OuUh6/tx+mcELOV3Z3EOaUo6f28bgdL76znnrS8='
 		);
 
 		cacher.opts.maxParamsLength = null;
-		res = cacher.getCacheKey("abc.def", bigObj);
+		res = cacher.getCacheKey({ name: "abc.def" }, {}, { params: bigObj });
 		expect(res).toBe(
-			"abc.def:A|C0|false|C1|true|C2|true|C3|495f761d77d6294f|C4|true|B|C0|true|C1|false|C2|true|C3|5721c26bfddb7927|C4|false|C|C0|5d9e85c124d5d09e|C1|true|C2|5366|C3|false|C4|false|D|C0|false|C1|true|C2|704473bca1242604|C3|false|C4|6fc56107e69be769|E|C0|true|C1|true|C2|4881|C3|true|C4|1418|F|C0|true|C1|false|C2|false|C3|false|C4|true|G|C0|false|C1|true|C2|false|C3|6547|C4|9565|H|C0|true|C1|1848|C2|232e6552d0b8aa98|C3|1d50627abe5c0463|C4|5251|I|C0|ecd0e4eae08e4f|C1|197bcb312fc17f60|C2|4755|C3|true|C4|9552|J|C0|false|C1|1cc45cadbbf240f|C2|4dbb352b21c3c2f3|C3|5065|C4|792b19631c78d4f6|K|C0|13c23a525adf9e1f|C1|true|C2|true|C3|589d3499abbf6765|C4|true|L|C0|false|C1|true|C2|4350|C3|72f6c4f0e9beb03c|C4|434b74b5ff500609|M|C0|9228|C1|5254b36ec238c266|C2|true|C3|27b040089b057684|C4|true|N|C0|35d3c608ef8aac5e|C1|23fbdbd520d5ae7d|C2|false|C3|9061|C4|true|O|C0|true|C1|true|C2|2382f9fe7834e0cc|C3|true|C4|false|P|C0|true|C1|false|C2|38c0d40b91a9d1f6|C3|false|C4|5512|Q|C0|true|C1|true|C2|true|C3|true|C4|true|R|C0|70bd27c06b067734|C1|true|C2|5213493253b98636|C3|8272|C4|1264|S|C0|61044125008e634c|C1|9175|C2|true|C3|225e3d912bfbc338|C4|false|T|C0|38edc77387da030a|C1|false|C2|38d8b9e2525413fc|C3|true|C4|false|U|C0|false|C1|4b3962c3d26bddd0|C2|1e66b069bad46643|C3|3642|C4|9225|V|C0|1c40e44b54486080|C1|5a560d81078bab02|C2|1c131259e1e9aa61|C3|true|C4|9335|W|C0|false|C1|7089b0ad438df2cb|C2|216aec98f513ac08|C3|true|C4|false|X|C0|3b749354aac19f24|C1|9626|C2|true|C3|false|C4|false|Y|C0|298|C1|224075dadd108ef9|C2|3450|C3|2548|C4|true"
+			'abc.def:A|C0|false|C1|true|C2|true|C3|"495f761d77d6294f"|C4|true|B|C0|true|C1|false|C2|true|C3|"5721c26bfddb7927"|C4|false|C|C0|"5d9e85c124d5d09e"|C1|true|C2|5366|C3|false|C4|false|D|C0|false|C1|true|C2|"704473bca1242604"|C3|false|C4|"6fc56107e69be769"|E|C0|true|C1|true|C2|4881|C3|true|C4|1418|F|C0|true|C1|false|C2|false|C3|false|C4|true|G|C0|false|C1|true|C2|false|C3|6547|C4|9565|H|C0|true|C1|1848|C2|"232e6552d0b8aa98"|C3|"1d50627abe5c0463"|C4|5251|I|C0|"ecd0e4eae08e4f"|C1|"197bcb312fc17f60"|C2|4755|C3|true|C4|9552|J|C0|false|C1|"1cc45cadbbf240f"|C2|"4dbb352b21c3c2f3"|C3|5065|C4|"792b19631c78d4f6"|K|C0|"13c23a525adf9e1f"|C1|true|C2|true|C3|"589d3499abbf6765"|C4|true|L|C0|false|C1|true|C2|4350|C3|"72f6c4f0e9beb03c"|C4|"434b74b5ff500609"|M|C0|9228|C1|"5254b36ec238c266"|C2|true|C3|"27b040089b057684"|C4|true|N|C0|"35d3c608ef8aac5e"|C1|"23fbdbd520d5ae7d"|C2|false|C3|9061|C4|true|O|C0|true|C1|true|C2|"2382f9fe7834e0cc"|C3|true|C4|false|P|C0|true|C1|false|C2|"38c0d40b91a9d1f6"|C3|false|C4|5512|Q|C0|true|C1|true|C2|true|C3|true|C4|true|R|C0|"70bd27c06b067734"|C1|true|C2|"5213493253b98636"|C3|8272|C4|1264|S|C0|"61044125008e634c"|C1|9175|C2|true|C3|"225e3d912bfbc338"|C4|false|T|C0|"38edc77387da030a"|C1|false|C2|"38d8b9e2525413fc"|C3|true|C4|false|U|C0|false|C1|"4b3962c3d26bddd0"|C2|"1e66b069bad46643"|C3|3642|C4|9225|V|C0|"1c40e44b54486080"|C1|"5a560d81078bab02"|C2|"1c131259e1e9aa61"|C3|true|C4|9335|W|C0|false|C1|"7089b0ad438df2cb"|C2|"216aec98f513ac08"|C3|true|C4|false|X|C0|"3b749354aac19f24"|C1|9626|C2|true|C3|false|C4|false|Y|C0|298|C1|"224075dadd108ef9"|C2|3450|C3|2548|C4|true'
 		);
 
 		cacher.opts.maxParamsLength = 44;
 		res = cacher.getCacheKey(
-			"users.list",
+			{ name: "users.list" },
+			{ keys: ["token"] },
 			{
-				token: "eyJpZCI6Im9SMU1sS1hCdVVjSGlnM3QiLCJ1c2VybmFtZSI6ImljZWJvYiIsImV4cCI6MTUzNDYyMTk1MCwiaWF0IjoxNTI5NDM3OTUwfQ"
-			},
-			{},
-			["token"]
+				params: {
+					token: "eyJpZCI6Im9SMU1sS1hCdVVjSGlnM3QiLCJ1c2VybmFtZSI6ImljZWJvYiIsImV4cCI6MTUzNDYyMTk1MCwiaWF0IjoxNTI5NDM3OTUwfQ"
+				}
+			}
 		);
-		expect(res).toBe("users.list:YUgoMlSXRyzkAI98NgGKRqakaZdCSJiITaRJWHyaJlU=");
+		expect(res).toBe("users.list:2Svi96M2RiYDODbpezeRkz4mBFYpfvIpVZxZdC0gs6o=");
 
 		cacher.opts.maxParamsLength = 44;
 		res = cacher.getCacheKey(
-			"users.list",
+			{ name: "users.list" },
+			{ keys: ["id", "token"] },
 			{
-				id: 123,
-				token: "eyJpZCI6Im9SMU1sS1hCdVVjSGlnM3QiLCJ1c2VybmFtZSI6ImljZWJvYiIsImV4cCI6MTUzNDYyMTk1MCwiaWF0IjoxNTI5NDM3OTUwfQ"
-			},
-			{},
-			["id", "token"]
+				params: {
+					id: 123,
+					token: "eyJpZCI6Im9SMU1sS1hCdVVjSGlnM3QiLCJ1c2VybmFtZSI6ImljZWJvYiIsImV4cCI6MTUzNDYyMTk1MCwiaWF0IjoxNTI5NDM3OTUwfQ"
+				}
+			}
 		);
-		expect(res).toBe("users.list:jVksjHDWP+LfXPCxdnQC9Sa10+12yis9AhWmSOwCWfY=");
+		expect(res).toBe("users.list:oV1Gcb2R2tSyJLBIYAIskfKvY202E2rscb7XiMbQ2Rs=");
 	});
 
 	it("check getCacheKey with custom keygen", () => {
@@ -304,21 +396,22 @@ describe("Test BaseCacher", () => {
 
 		cacher.init(broker);
 
-		const actionName = "posts.find.model";
-		const params = { limit: 5 };
-		const meta = { user: "bob" };
-		const keys = ["limit", "#user"];
-		const headers = { auth: false };
+		const action = { name: "posts.find.model" };
+		const opts = { keys: ["limit", "#user"] };
+		const ctx = {
+			params: { limit: 5 },
+			meta: { user: "bob" },
+			headers: { auth: false }
+		};
 
-		expect(cacher.getCacheKey(actionName, params, meta, keys, null, headers)).toBe("custom");
+		expect(cacher.getCacheKey(action, opts, ctx)).toBe("custom");
 		expect(keygen).toHaveBeenCalledTimes(1);
-		expect(keygen).toHaveBeenCalledWith(actionName, params, meta, keys, headers);
+		expect(keygen).toHaveBeenCalledWith(action, opts, ctx);
 
-		expect(cacher.getCacheKey(actionName, params, meta, keys, actionKeygen, headers)).toBe(
-			"actionKeygen"
-		);
+		opts.keygen = actionKeygen;
+		expect(cacher.getCacheKey(action, opts, ctx)).toBe("actionKeygen");
 		expect(actionKeygen).toHaveBeenCalledTimes(1);
-		expect(actionKeygen).toHaveBeenCalledWith(actionName, params, meta, keys, headers);
+		expect(actionKeygen).toHaveBeenCalledWith(action, opts, ctx);
 	});
 });
 
@@ -351,7 +444,7 @@ describe("Test middleware", () => {
 
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.get).toHaveBeenCalledTimes(1);
-			expect(broker.cacher.get).toHaveBeenCalledWith("posts.find:id|3|name|Antsa");
+			expect(broker.cacher.get).toHaveBeenCalledWith('posts.find:id|3|name|"Antsa"');
 			expect(mockAction.handler).toHaveBeenCalledTimes(0);
 			expect(broker.cacher.set).toHaveBeenCalledTimes(0);
 			expect(response).toBe(cachedData);
@@ -360,7 +453,7 @@ describe("Test middleware", () => {
 
 	it("should not give back cached data and should call the handler and call the 'cache.set' action with promise", () => {
 		let resData = [1, 3, 5];
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		broker.cacher.get = jest.fn(() => Promise.resolve(null));
 		mockAction.handler = jest.fn(() => Promise.resolve(resData));
 
@@ -383,7 +476,7 @@ describe("Test middleware", () => {
 
 	it("should call the 'cache.set' action with custom TTL", () => {
 		let resData = [1];
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		broker.cacher.set.mockClear();
 		broker.cacher.get = jest.fn(() => Promise.resolve(null));
 		mockAction.handler = jest.fn(() => Promise.resolve(resData));
@@ -582,7 +675,7 @@ describe("Test middleware with lock enabled", () => {
 
 		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		expect(typeof cachedHandler).toBe("function");
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.get).toHaveBeenCalledTimes(1);
 			expect(broker.cacher.get).toHaveBeenCalledWith(cacheKey);
@@ -596,7 +689,7 @@ describe("Test middleware with lock enabled", () => {
 
 	it("should not give back cached data and should call the handler and call the 'cache.set' action with promise", () => {
 		let resData = [1, 3, 5];
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		broker.cacher.get = jest.fn(() => Promise.resolve(null));
 		broker.cacher.getWithTTL = jest.fn(() => Promise.resolve({ data: null, ttl: null }));
 		const unlockFn = jest.fn(() => Promise.resolve());
@@ -634,7 +727,7 @@ describe("Test middleware with lock enabled", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.lock).toHaveBeenCalledTimes(0);
@@ -661,7 +754,7 @@ describe("Test middleware with lock enabled", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.getWithTTL).toHaveBeenCalledTimes(0);
@@ -690,7 +783,7 @@ describe("Test middleware with lock enabled", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 		return cachedHandler(ctx).then(response => {
 			expect(broker.cacher.getWithTTL).toHaveBeenCalledTimes(0);
@@ -727,7 +820,7 @@ describe("Test middleware with lock enabled", () => {
 		let ctx = new Context();
 		ctx.setParams(params);
 
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 
 		function call() {
@@ -858,7 +951,7 @@ describe("Test middleware with lock enabled", () => {
 		const unlockFn = jest.fn(() => Promise.resolve());
 		broker.cacher.lock = jest.fn(() => Promise.resolve(unlockFn));
 		broker.cacher.tryLock = jest.fn(() => Promise.resolve(unlockFn));
-		let cacheKey = cacher.getCacheKey(mockAction.name, params);
+		let cacheKey = cacher.getCacheKey(mockAction, {}, { params });
 		let cachedHandler = cacher.middleware().localAction(mockAction.handler, mockAction);
 
 		const ctx = new Context();

--- a/test/unit/cachers/memory-lru.spec.js
+++ b/test/unit/cachers/memory-lru.spec.js
@@ -81,9 +81,44 @@ describe("Test MemoryLRUCacher set & get", () => {
 		});
 	});
 
-	it("should give null if key not exist", () => {
+	it("should give undefined if key not exist", () => {
 		return cacher.get("123123").then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
+		});
+	});
+});
+
+describe("Test MemoryLRUCacher set & get with missingResponse", () => {
+	let broker = new ServiceBroker({ logger: false });
+	const MISSING = Symbol("MISSING");
+	let cacher = new MemoryLRUCacher({ missingResponse: MISSING });
+	cacher.init(broker);
+
+	let key = "tst123";
+	let data1 = {
+		a: 1,
+		b: false,
+		c: "Test",
+		d: {
+			e: 55
+		}
+	};
+
+	it("should save the data with key", () => {
+		cacher.set(key, data1);
+		expect(cacher.cache.get(key)).toBe(data1);
+	});
+
+	it("should give back the data by key", () => {
+		return cacher.get(key).then(obj => {
+			expect(obj).toBeDefined();
+			expect(obj).toEqual(data1);
+		});
+	});
+
+	it("should give undefined if key not exist", () => {
+		return cacher.get("123123").then(obj => {
+			expect(obj).toBe(MISSING);
 		});
 	});
 });
@@ -245,9 +280,9 @@ describe("Test MemoryLRUCacher delete", () => {
 		expect(cacher.cache.get(key)).toBeUndefined();
 	});
 
-	it("should give null", () => {
+	it("should give undefined", () => {
 		return cacher.get(key).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -295,9 +330,9 @@ describe("Test MemoryLRUCacher clean", () => {
 		cacher.clean("tst*");
 	});
 
-	it("should give null for key1", () => {
+	it("should give undefined for key1", () => {
 		return cacher.get(key1).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -312,9 +347,9 @@ describe("Test MemoryLRUCacher clean", () => {
 		expect(Object.keys(cacher.cache).length).toBe(0);
 	});
 
-	it("should give null for key2 too", () => {
+	it("should give undefined for key2 too", () => {
 		return cacher.get(key1).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -370,11 +405,11 @@ describe("Test MemoryLRUCacher expired method", () => {
 		cacher.set(key2, data2);
 	});
 
-	it("should give null for key1", () => {
+	it("should give undefined for key1", () => {
 		clock.tick(30 * 1000);
 
 		return cacher.get(key1).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -387,7 +422,7 @@ describe("Test MemoryLRUCacher expired method", () => {
 	it("should give back data 2 for key2", () => {
 		clock.tick(65 * 1000);
 		return cacher.get(key2).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 });

--- a/test/unit/cachers/memory.spec.js
+++ b/test/unit/cachers/memory.spec.js
@@ -99,9 +99,51 @@ describe("Test MemoryCacher set & get", () => {
 		});
 	});
 
-	it("should give null if key not exist", () => {
+	it("should give undefined if key not exist", () => {
 		return cacher.get("123123").then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
+		});
+	});
+});
+
+describe("Test MemoryCacher set & get with missingResponse", () => {
+	let broker = new ServiceBroker({ logger: false });
+	const MISSING = Symbol("MISSING");
+	let cacher = new MemoryCacher({ missingResponse: MISSING });
+	cacher.init(broker);
+
+	let key = "tst123";
+	let data1 = {
+		a: 1,
+		b: false,
+		c: "Test",
+		d: {
+			e: 55
+		}
+	};
+
+	afterAll(async () => {
+		await cacher.close();
+		await broker.stop();
+	});
+
+	it("should save the data with key", () => {
+		cacher.set(key, data1);
+		expect(cacher.cache.get(key)).toBeDefined();
+		expect(cacher.cache.get(key).data).toBe(data1);
+		expect(cacher.cache.get(key).expire).toBeNull();
+	});
+
+	it("should give back the data by key", () => {
+		return cacher.get(key).then(obj => {
+			expect(obj).toBeDefined();
+			expect(obj).toEqual(data1);
+		});
+	});
+
+	it("should give 'missingResponse' value if key not exist", () => {
+		return cacher.get("123123").then(obj => {
+			expect(obj).toBe(MISSING);
 		});
 	});
 });
@@ -164,7 +206,7 @@ describe("Test MemoryCacher get() with expire", () => {
 		dateNowSpy.mockImplementationOnce(() => currentTime + 16 * 1000);
 
 		return cacher.get(key).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 });
@@ -321,9 +363,9 @@ describe("Test MemoryCacher delete", () => {
 		expect(cacher.cache.get(key)).toBeUndefined();
 	});
 
-	it("should give null", () => {
+	it("should give undefined", () => {
 		return cacher.get(key).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -376,9 +418,9 @@ describe("Test MemoryCacher clean", () => {
 		cacher.clean("tst*");
 	});
 
-	it("should give null for key1", () => {
+	it("should give undefined for key1", () => {
 		return cacher.get(key1).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -393,9 +435,9 @@ describe("Test MemoryCacher clean", () => {
 		expect(Object.keys(cacher.cache).length).toBe(0);
 	});
 
-	it("should give null for key2 too", () => {
+	it("should give undefined for key2 too", () => {
 		return cacher.get(key1).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 
@@ -456,9 +498,9 @@ describe("Test MemoryCacher expired method", () => {
 		cacher.checkTTL();
 	});
 
-	it("should give null for key1", () => {
+	it("should give undefined for key1", () => {
 		return cacher.get(key1).then(obj => {
-			expect(obj).toBeNull();
+			expect(obj).toBeUndefined();
 		});
 	});
 

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -332,14 +332,14 @@ describe("Test RedisCacher set & get without prefix", () => {
 		});
 	});
 
-	it("should give null if response cannot be deserialized", () => {
+	it("should give undefined if response cannot be deserialized", () => {
 		cacher.client.getBuffer = jest.fn(() => Promise.resolve("{ 'asd' 5}")); // Invalid JSON
 
 		let p = cacher.get(key);
 		expect(cacher.client.getBuffer).toHaveBeenCalledTimes(1);
 		expect(cacher.client.getBuffer).toHaveBeenCalledWith(prefix + key);
 		return p.catch(protectReject).then(d => {
-			expect(d).toBeNull();
+			expect(d).toBeUndefined();
 		});
 	});
 
@@ -633,7 +633,7 @@ describe("Test RedisCacher getWithTTL method", () => {
 		});
 	});
 
-	it("should return null if data cannot be deserialized", () => {
+	it("should return undefined if data cannot be deserialized", () => {
 		mockPipeline.exec = jest.fn(() =>
 			Promise.resolve([
 				[null, "{'some invalid JSON here."],
@@ -641,7 +641,7 @@ describe("Test RedisCacher getWithTTL method", () => {
 			])
 		);
 		return cacher.getWithTTL(key).then(res => {
-			expect(res.data).toBeNull();
+			expect(res.data).toBeUndefined();
 		});
 	});
 });

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -182,7 +182,7 @@ describe("Test RedisCacher cluster", () => {
 		expect(cacher.opts).toEqual(opts);
 		expect(() => {
 			cacher.init(broker);
-		}).toThrowError("No nodes defined for cluster");
+		}).toThrowError("There is no 'nodes' configuration for cluster.");
 	});
 
 	it("should construct serializer based on options", () => {
@@ -714,7 +714,8 @@ describe("Test RedisCacher with opts.lock", () => {
 	it("should create redlock clients", () => {
 		let broker = new ServiceBroker({ logger: false });
 		let cacher = new RedisCacher({
-			ttl: 30
+			ttl: 30,
+			lock: true
 		});
 		cacher.init(broker);
 		expect(cacher.redlock).toBeDefined();


### PR DESCRIPTION
## :memo: Description

### Breaking changes

- [ ] changed the `getCacheKey`, `defaultKeygen` method signatures
- [ ] string values in cache key wrapped into quotes.
- [ ] added `missingResponse` cacher option.

### :dart: Relevant issues
#824 #1024 #965 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update