### PR TITLE
Next stream

### DIFF
--- a/dev/.eslintrc.js
+++ b/dev/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
 		"no-var": ["warn"],
 		"no-console": ["off"],
 		"no-unused-vars": ["off"],
-		"security/detect-possible-timing-attacks": ["off"]
+		"security/detect-possible-timing-attacks": ["off"],
+		"security/detect-non-literal-fs-filename": ["off"]
 	}
 };

--- a/dev/duplex-streaming.js
+++ b/dev/duplex-streaming.js
@@ -32,13 +32,15 @@ broker2.createService({
 	name: "aes",
 	actions: {
 		encrypt(ctx) {
+			console.log("encrypt params:", ctx.params);
 			const encrypt = crypto.createCipheriv("aes-256-ctr", pass, iv);
-			return ctx.params.pipe(encrypt);
+			return ctx.stream.pipe(encrypt);
 		},
 
 		decrypt(ctx) {
+			console.log("decrypt params:", ctx.params);
 			const decrypt = crypto.createDecipheriv("aes-256-ctr", pass, iv);
-			return ctx.params.pipe(decrypt);
+			return ctx.stream.pipe(decrypt);
 		}
 	}
 });
@@ -69,8 +71,8 @@ function callAES() {
 	const stream = fs.createReadStream(fileName);
 
 	broker1
-		.call("aes.encrypt", stream)
-		.then(stream => broker1.call("aes.decrypt", stream))
+		.call("aes.encrypt", { a: 5 }, { stream })
+		.then(stream => broker1.call("aes.decrypt", { b: "John" }, { stream }))
 		.then(stream => {
 			const s = fs.createWriteStream(fileName2);
 			stream.pipe(s);

--- a/dev/issue-1100-receiver.js
+++ b/dev/issue-1100-receiver.js
@@ -30,20 +30,15 @@ broker.createService({
 			async handler(ctx) {
 				// ! called two times if meta is "large"
 				this.logger.info("call receive handler", ctx.params, ctx.meta);
-				if (ctx.params) {
+				if (ctx.stream) {
 					const participants = [];
-					ctx.params.on("data", d => participants.push(d));
-					ctx.params.on("end", () =>
-						this.logger.info(
-							"received stream data",
-							participants.length,
-							ctx.meta,
-							participants
-						)
+					ctx.stream.on("data", d => participants.push(d));
+					ctx.stream.on("end", () =>
+						this.logger.info("received stream data", participants.length, ctx.meta)
 					);
 					return "OK";
 				} else {
-					this.logger.error("No stream", ctx.params, ctx.meta);
+					this.logger.error("No stream", ctx.stream, ctx.meta);
 					return "no stream";
 				}
 			}

--- a/dev/issue-1100-sender.js
+++ b/dev/issue-1100-sender.js
@@ -35,7 +35,8 @@ broker.createService({
 				stream.push(Buffer.from(JSON.stringify(participants)));
 				stream.push(null);
 				this.logger.info("sending stream...");
-				const res = await ctx.call("receiver.receive", stream, {
+				const res = await ctx.call("receiver.receive", null, {
+					stream,
 					meta: {
 						//! meta data is missing on receiver side
 						testMeta: "testMeta",

--- a/dev/stream-caller.js
+++ b/dev/stream-caller.js
@@ -37,8 +37,8 @@ broker
 			const stream = fs.createReadStream(fileName);
 
 			broker
-				.call("aes.encrypt", stream)
-				.then(stream => broker.call("aes.decrypt", stream))
+				.call("aes.encrypt", null, { stream })
+				.then(stream => broker.call("aes.decrypt", null, { stream }))
 				.then(stream => {
 					const s = fs.createWriteStream(fileName2);
 					stream.pipe(s);

--- a/dev/stream-demo.js
+++ b/dev/stream-demo.js
@@ -18,7 +18,7 @@ const broker1 = new ServiceBroker({
 	nodeID: "client-" + process.pid,
 	transporter: "TCP",
 	logger: console,
-	logLevel: "info"
+	logLevel: "debug"
 });
 
 // Create broker #2
@@ -26,14 +26,14 @@ const broker2 = new ServiceBroker({
 	nodeID: "converter-" + process.pid,
 	transporter: "TCP",
 	logger: console,
-	logLevel: "info"
+	logLevel: "debug"
 });
 
 broker2.createService({
 	name: "text-converter",
 	actions: {
 		upper(ctx) {
-			return ctx.params.pipe(
+			return ctx.stream.pipe(
 				new Transform({
 					transform: function (chunk, encoding, done) {
 						this.push(chunk.toString().toUpperCase());
@@ -48,7 +48,7 @@ broker2.createService({
 broker1.Promise.all([broker1.start(), broker2.start()])
 	.then(() => broker1.waitForServices("text-converter"))
 	.then(() => {
-		broker1.call("text-converter.upper", process.stdin).then(stream => {
+		broker1.call("text-converter.upper", null, { stream: process.stdin }).then(stream => {
 			console.log(
 				"\nWrite something to the console and press ENTER. The data is transferred via streams:"
 			);

--- a/dev/stream-echo.js
+++ b/dev/stream-echo.js
@@ -5,18 +5,16 @@ const { ServiceBroker } = require("../");
 const broker = new ServiceBroker({
 	//namespace: "streaming",
 	nodeID: "node-echo",
-	//transporter: "nats://192.168.51.100:4222",
-	transporter: "redis://192.168.51.100:6379",
-	serializer: "MsgPack",
-	logger: console,
-	logLevel: "info"
+	transporter: "NATS",
+	serializer: "JSON",
+	logLevel: "debug"
 });
 
 broker.createService({
 	name: "echo",
 	actions: {
 		reply(ctx) {
-			return ctx.params;
+			return ctx.stream;
 		}
 	}
 });

--- a/dev/stream-java.js
+++ b/dev/stream-java.js
@@ -52,7 +52,7 @@ broker.start()
 
 			const stream = fs.createReadStream(fileName);
 
-			broker.call("stream.sha", stream)
+			broker.call("stream.sha", null, { stream })
 				.then(({ digest }) => {
 					broker.logger.info("Time:", Date.now() - startTime + "ms");
 					broker.logger.info("Received SHA:", digest);
@@ -84,7 +84,7 @@ broker
 
 			const stream = fs.createReadStream(fileName);
 
-			broker.call("echo.reply", stream).then(stream => {
+			broker.call("echo.reply", null, { stream }).then(stream => {
 				const s = fs.createWriteStream(fileName2);
 				stream.pipe(s);
 				s.on("close", () => {

--- a/dev/stream-obj.js
+++ b/dev/stream-obj.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const ServiceBroker = require("../src/service-broker");
+const Stream = require("stream");
+
+const broker = new ServiceBroker({
+	nodeID: "sender",
+	transporter: "NATS",
+	serializer: "JSON",
+	logLevel: "debug"
+});
+
+broker.createService({
+	name: "sender",
+	dependencies: ["echo"],
+
+	actions: {
+		send: {
+			async handler(ctx) {
+				const stream = new Stream.Readable({ objectMode: true, read() {} });
+				for (let i = 0; i < 10; i++) {
+					stream.push({ entry: i });
+				}
+				this.logger.info("sending stream...");
+				const res = await ctx.call("echo.reply", null, { stream });
+				this.logger.info("finished sending stream", res.readableObjectMode);
+
+				res.on("data", data => {
+					this.logger.info("data received", data);
+				});
+
+				res.on("error", err => {
+					this.logger.error("error received", err);
+				});
+
+				res.on("end", () => {
+					this.logger.error("receiving finished");
+				});
+			}
+		}
+	}
+});
+
+broker.start().then(async () => {
+	broker.repl();
+	await broker.Promise.delay(2000);
+	broker.logger.info("Calling send...");
+	await broker.call("sender.send");
+});

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -33,6 +33,22 @@ const { Tracer } = require("./tracing");
 const C = require("./constants");
 
 /**
+ * @typedef {Object} CallingOptions Calling options
+ * @property {number?} timeout
+ * @property {number?} retries
+ * @property {Function?} fallbackResponse
+ * @property {string?} nodeID
+ * @property {object?} meta
+ * @property {object?} parentSpan
+ * @property {Context?} parentCtx
+ * @property {string?} requestID
+ * @property {boolean?} tracking
+ * @property {boolean?} paramsCloning
+ * @property {string?} caller
+ * @property {Stream?} stream
+ */
+
+/**
  * Default broker options
  */
 const defaultOptions = {
@@ -1151,9 +1167,9 @@ class ServiceBroker {
 	/**
 	 * Call an action
 	 *
-	 * @param {String} actionName	name of action
-	 * @param {Object?} params		params of action
-	 * @param {Object?} opts		options of call (optional)
+	 * @param {String} actionName		name of action
+	 * @param {Object?} params			params of action
+	 * @param {CallingOptions?} opts	options of call (optional)
 	 * @returns {Promise}
 	 *
 	 * @performance-critical
@@ -1192,17 +1208,23 @@ class ServiceBroker {
 			ctx.setEndpoint(endpoint);
 		}
 
-		if (ctx.endpoint.local)
+		if (ctx.endpoint.local) {
 			this.logger.debug("Call action locally.", {
 				action: ctx.action.name,
 				requestID: ctx.requestID
 			});
-		else
+
+			// Stream redirection
+			if (opts.stream) {
+				ctx.stream = opts.stream;
+			}
+		} else {
 			this.logger.debug("Call action on remote node.", {
 				action: ctx.action.name,
 				nodeID: ctx.nodeID,
 				requestID: ctx.requestID
 			});
+		}
 
 		//this.setCurrentContext(ctx);
 

--- a/test/e2e/scenarios/basic/scenario.js
+++ b/test/e2e/scenarios/basic/scenario.js
@@ -141,8 +141,8 @@ addScenario("send & receive stream", async () => {
 	// ---- ^ SETUP ^ ---
 
 	const s1 = fs.createReadStream(filename);
-	const s2 = await broker.call("aes.encrypt", s1);
-	const s3 = await broker.call("aes.decrypt", s2);
+	const s2 = await broker.call("aes.encrypt", null, { stream: s1 });
+	const s3 = await broker.call("aes.decrypt", null, { stream: s2 });
 
 	const receivedSHA = await getStreamSHA(s3);
 

--- a/test/e2e/services/aes.service.js
+++ b/test/e2e/services/aes.service.js
@@ -9,12 +9,12 @@ module.exports = {
 	actions: {
 		encrypt(ctx) {
 			const encrypter = crypto.createCipheriv("aes-256-ctr", password, iv);
-			return ctx.params.pipe(encrypter);
+			return ctx.stream.pipe(encrypter);
 		},
 
 		decrypt(ctx) {
 			const decrypter = crypto.createDecipheriv("aes-256-ctr", password, iv);
-			return ctx.params.pipe(decrypter);
+			return ctx.stream.pipe(decrypter);
 		}
 	}
 };

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -39,6 +39,7 @@ describe("Test Context", () => {
 		expect(ctx.headers).toEqual({});
 		expect(ctx.responseHeaders).toEqual({});
 		expect(ctx.locals).toEqual({});
+		expect(ctx.stream).toEqual(null);
 
 		expect(ctx.requestID).toBe(ctx.id);
 
@@ -901,29 +902,9 @@ describe("Test emit method", () => {
 		});
 	});
 
-	it("should call broker.emit method with string param", () => {
-		broker.emit.mockClear();
-		ctx.emit("request.rest", "string-data");
-		expect(broker.emit).toHaveBeenCalledTimes(1);
-		expect(broker.emit).toHaveBeenCalledWith("request.rest", "string-data", {
-			parentCtx: ctx,
-			groups: undefined
-		});
-	});
-
-	it("should call broker.emit method without payload & group", () => {
-		broker.emit.mockClear();
-		ctx.emit("request.rest", null, "mail");
-		expect(broker.emit).toHaveBeenCalledTimes(1);
-		expect(broker.emit).toHaveBeenCalledWith("request.rest", null, {
-			parentCtx: ctx,
-			groups: ["mail"]
-		});
-	});
-
 	it("should call broker.emit method without payload & groups", () => {
 		broker.emit.mockClear();
-		ctx.emit("request.rest", null, ["mail", "users"]);
+		ctx.emit("request.rest", null, { groups: ["mail", "users"] });
 		expect(broker.emit).toHaveBeenCalledTimes(1);
 		expect(broker.emit).toHaveBeenCalledWith("request.rest", null, {
 			parentCtx: ctx,
@@ -935,7 +916,7 @@ describe("Test emit method", () => {
 		const data = { id: 5 };
 		broker.emit.mockClear();
 		ctx.emit("request.rest", data, {
-			groups: ["mail"],
+			groups: "mail",
 			headers: {
 				contentType: "json"
 			}
@@ -978,19 +959,9 @@ describe("Test broadcast method", () => {
 		});
 	});
 
-	it("should call broker.broadcast method without payload & group", () => {
-		broker.broadcast.mockClear();
-		ctx.broadcast("request.rest", null, "users");
-		expect(broker.broadcast).toHaveBeenCalledTimes(1);
-		expect(broker.broadcast).toHaveBeenCalledWith("request.rest", null, {
-			parentCtx: ctx,
-			groups: ["users"]
-		});
-	});
-
 	it("should call broker.broadcast method without payload & groups", () => {
 		broker.broadcast.mockClear();
-		ctx.broadcast("request.rest", null, ["mail", "users"]);
+		ctx.broadcast("request.rest", null, { groups: ["mail", "users"] });
 		expect(broker.broadcast).toHaveBeenCalledTimes(1);
 		expect(broker.broadcast).toHaveBeenCalledWith("request.rest", null, {
 			parentCtx: ctx,
@@ -1002,7 +973,7 @@ describe("Test broadcast method", () => {
 		const data = { id: 5 };
 		broker.broadcast.mockClear();
 		ctx.broadcast("request.rest", data, {
-			groups: ["mail"],
+			groups: "mail",
 			headers: {
 				contentType: "json"
 			}


### PR DESCRIPTION
## :memo: Description

This PR changes the stream sending & receiving logic to give the possibility to send `params` besides the stream. 

New Stream sending:

```js
ctx.call("file.save", { filename: "aaa.txt" }, { stream: fs.createReadStream() });
```

Receiving stream inside action:

```js
module.exports = {
    name: "file",
    actions: {
        save(ctx) {
		const stream = ctx.stream;
		const s = fs.createWriteStream(ctx.params.filename);
		stream.pipe(s);
        }
    }
};
```

### :dart: Relevant issues

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
