### PR TITLE
Improve lifecycle handler types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -334,11 +334,7 @@ declare namespace Moleculer {
 		generateSnapshot(): HistogramMetricSnapshot[];
 
 		static generateLinearBuckets(start: number, width: number, count: number): number[];
-		static generateExponentialBuckets(
-			start: number,
-			factor: number,
-			count: number
-		): number[];
+		static generateExponentialBuckets(start: number, factor: number, count: number): number[];
 	}
 
 	namespace MetricTypes {
@@ -584,7 +580,7 @@ declare namespace Moleculer {
 		call<TResult, TParams>(
 			actionName: string,
 			params: TParams,
-			opts?: CallingOptions,
+			opts?: CallingOptions
 		): Promise<TResult>;
 
 		mcall<T>(
@@ -721,7 +717,11 @@ declare namespace Moleculer {
 		version?: string | number;
 	}
 
-	type StartedStoppedHandler = () => Promise<void[]> | Promise<void> | void;
+	type ServiceSyncLifecycleHandler = <S = ServiceSettingSchema>(this: Service<S>) => void;
+	type ServiceAsyncLifecycleHandler = <S = ServiceSettingSchema>(
+		this: Service<S>
+	) => void | Promise<void>;
+
 	interface ServiceSchema<S = ServiceSettingSchema> {
 		name: string;
 		version?: string | number;
@@ -734,9 +734,9 @@ declare namespace Moleculer {
 		hooks?: ServiceHooks;
 
 		events?: ServiceEvents;
-		created?: (() => void) | (() => void)[];
-		started?: StartedStoppedHandler | StartedStoppedHandler[];
-		stopped?: StartedStoppedHandler | StartedStoppedHandler[];
+		created?: ServiceSyncLifecycleHandler | ServiceSyncLifecycleHandler[];
+		started?: ServiceAsyncLifecycleHandler | ServiceAsyncLifecycleHandler[];
+		stopped?: ServiceAsyncLifecycleHandler | ServiceAsyncLifecycleHandler[];
 
 		[name: string]: any;
 	}
@@ -967,6 +967,9 @@ declare namespace Moleculer {
 		options?: GenericObject;
 	}
 
+	type BrokerSyncLifecycleHandler = (broker: ServiceBroker) => void;
+	type BrokerAsyncLifecycleHandler = (broker: ServiceBroker) => void | Promise<void>;
+
 	interface BrokerOptions {
 		namespace?: string | null;
 		nodeID?: string | null;
@@ -1030,9 +1033,9 @@ declare namespace Moleculer {
 		ContextFactory?: typeof Context;
 		Promise?: PromiseConstructorLike;
 
-		created?: (broker: ServiceBroker) => void;
-		started?: (broker: ServiceBroker) => void;
-		stopped?: (broker: ServiceBroker) => void;
+		created?: BrokerSyncLifecycleHandler;
+		started?: BrokerAsyncLifecycleHandler;
+		stopped?: BrokerAsyncLifecycleHandler;
 
 		/**
 		 * If true, process.on("beforeExit/exit/SIGINT/SIGTERM", ...) handler won't be registered!

--- a/index.d.ts
+++ b/index.d.ts
@@ -717,8 +717,8 @@ declare namespace Moleculer {
 		version?: string | number;
 	}
 
-	type ServiceSyncLifecycleHandler = <S = ServiceSettingSchema>(this: Service<S>) => void;
-	type ServiceAsyncLifecycleHandler = <S = ServiceSettingSchema>(
+	type ServiceSyncLifecycleHandler<S = ServiceSettingSchema> = (this: Service<S>) => void;
+	type ServiceAsyncLifecycleHandler<S = ServiceSettingSchema> = (
 		this: Service<S>
 	) => void | Promise<void>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -734,9 +734,9 @@ declare namespace Moleculer {
 		hooks?: ServiceHooks;
 
 		events?: ServiceEvents;
-		created?: ServiceSyncLifecycleHandler | ServiceSyncLifecycleHandler[];
-		started?: ServiceAsyncLifecycleHandler | ServiceAsyncLifecycleHandler[];
-		stopped?: ServiceAsyncLifecycleHandler | ServiceAsyncLifecycleHandler[];
+		created?: ServiceSyncLifecycleHandler<S> | ServiceSyncLifecycleHandler<S>[];
+		started?: ServiceAsyncLifecycleHandler<S> | ServiceAsyncLifecycleHandler<S>[];
+		stopped?: ServiceAsyncLifecycleHandler<S> | ServiceAsyncLifecycleHandler<S>[];
 
 		[name: string]: any;
 	}


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR improves the `Service` and `ServiceBroker` lifecycle handler type definitions in the following ways:

#### Service Lifecycle Handlers

1. The service lifecycle methods are called with a `this` value of the `Service`.  The type was updated to have a `this` value of the `Service`.
2. The `created` handler was not consistent in structure with the `started` and `stopped` handlers.  The `created` handler was defined inline while the `started` and `stopped` handlers were aliased.  This was adjusted so that both are now aliased.
3. The `StartedStoppedHandler` type was rather specific in name, so to make it more generic it was renamed to `ServiceAsyncLifecycleHandler`.  The counterpart for the `created` handler was then a `ServiceSyncLifecycleHandler`.  These can then be reused as necessary without any naming confusion.
4. A recent PR (#1173) had adjusted the previously named `StartedStoppedHandler` to allow returning `Promise<void[]>`.  However, that is not the intent of these lifecycle methods -- they should return `void | Promise<void>`.  Any other type being returned is not appropriate, including `Promise<void[]>`.  The intent was to allow a return of `Promise.all[...]` but the preferred approach would be something like:

```
async started() {
  await Promise.all([...]);
  // implicit return of void
}
```

#### Broker Lifecycle Handlers
The main issue with the broker lifecycle handlers is that the `started` and `stopped` handlers do not allow returning `Promise<void>` and are expecting a return of `void`.  Changes have been made to address that deficiency as well as make the types used consistent with the changes that were just made to the service lifecycle handlers.

#### Other Changes
Any other changes were unintentional and only a result of prettier auto-formatting making adjustments.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Created a test repo and set it up to work with these type changes.  Confirmed the following:
1. The service broker `started` and `stopped` handlers now allow passing a Promise returning function.
2. The service `created`, `started`, and `stopped` handlers now infer `this` as the `Service` type rather than the `ServiceSchema` type.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
