### PR TITLE
feat(runner): load service by matched path

### DIFF
--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -387,6 +387,7 @@ export default class MoleculerRunner {
 
 		if (patterns.length > 0) {
 			let serviceFiles = [];
+			const allServiceFiles = glob(path.join(svcDir, fileMask), { absolute: true });
 
 			patterns
 				.map(s => s.trim())
@@ -394,37 +395,42 @@ export default class MoleculerRunner {
 					const skipping = p[0] == "!";
 					if (skipping) p = p.slice(1);
 
-					let files;
-					const svcPath = path.isAbsolute(p) ? p : path.resolve(svcDir, p);
-					// Check is it a directory?
-					if (this.isDirectory(svcPath)) {
-						if (this.config.hotReload) {
-							this.watchFolders.push(svcPath);
-						}
-						files = glob.sync(svcPath + "/" + fileMask, { absolute: true });
-						if (files.length == 0)
-							return this.broker.logger.warn(
-								kleur
-									.yellow()
-									.bold(`There is no service files in directory: '${svcPath}'`)
-							);
-					} else if (this.isServiceFile(svcPath)) {
-						files = [svcPath.replace(/\\/g, "/")];
-					} else if (this.isServiceFile(svcPath + ".service.js")) {
-						files = [svcPath.replace(/\\/g, "/") + ".service.js"];
+					if (p.startsWith("npm:")) {
+						// Load NPM module
+						this.loadNpmModule(p.slice(4));
 					} else {
-						// Load with glob
-						files = glob.sync(p, { cwd: svcDir, absolute: true });
-						if (files.length == 0)
+						const files = [];
+						const svcPath = path.isAbsolute(p) ? p : path.resolve(svcDir, p);
+						// Check is it a directory?
+						if (this.isDirectory(svcPath)) {
+							if (this.config.hotReload) {
+								this.watchFolders.push(svcPath);
+							}
+							files.push(...glob(svcPath + "/" + fileMask, { absolute: true }));
+						} else if (this.isServiceFile(svcPath)) {
+							files.push(svcPath.replace(/\\/g, "/"));
+						} else if (this.isServiceFile(svcPath + ".service.js")) {
+							files.push(svcPath.replace(/\\/g, "/") + ".service.js");
+						} else {
+							// Load with glob
+							files.push(...glob(p, { cwd: svcDir, absolute: true }));
+						}
+
+						if (files.length === 0) {
+							// eslint-disable-next-line security/detect-non-literal-regexp
+							const re = new RegExp(`${_.escapeRegExp(`${p}.service.`)}[tj]s$`);
+							files.push(...allServiceFiles.filter(file => re.test(file)));
+						}
+
+						if (files.length == 0) {
 							this.broker.logger.warn(
 								kleur.yellow().bold(`There is no matched file for pattern: '${p}'`)
 							);
-					}
-
-					if (files && files.length > 0) {
-						if (skipping)
-							serviceFiles = serviceFiles.filter(f => files.indexOf(f) === -1);
-						else serviceFiles.push(...files);
+						} else {
+							if (skipping)
+								serviceFiles = serviceFiles.filter(f => files.indexOf(f) === -1);
+							else serviceFiles.push(...files);
+						}
 					}
 				});
 


### PR DESCRIPTION
I have written about this problem with env `SERIVCES`: moleculerjs/site#160
I think SERVICES should first prefer to `service's name`
This pull will allow loading service from SERVICES if any service's file ends with `{SERVICE_ENV_VALUE}.service.[tj]s`