### PR TITLE
chore(types): add service list options & define getActionList type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1720,6 +1720,15 @@ declare namespace Moleculer {
 		withEndpoints?: boolean;
 	}
 
+	interface ServiceListCatalogOptions {
+		onlyLocal?: boolean;
+		onlyAvailable?: boolean;
+		skipInternal?: boolean;
+		withActions?: boolean;
+		withEvents?: boolean;
+		grouping?: boolea;
+	}
+
 	class ServiceRegistry {
 		broker: ServiceBroker;
 		metrics: MetricRegistry;
@@ -1734,7 +1743,8 @@ declare namespace Moleculer {
 		actions: any;
 		events: any;
 
-		getServiceList(opts?: ActionCatalogListOptions): ServiceSchema[];
+		getServiceList<S = ServiceSettingSchema>(opts?: ServiceListCatalogOptions): ServiceSchema<S>[];
+		getActionList(opts?: ActionCatalogListOptions): ActionSchema[];
 	}
 
 	class AsyncStorage {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1726,7 +1726,7 @@ declare namespace Moleculer {
 		skipInternal?: boolean;
 		withActions?: boolean;
 		withEvents?: boolean;
-		grouping?: boolea;
+		grouping?: boolean;
 	}
 
 	class ServiceRegistry {


### PR DESCRIPTION
## :memo: Description

The`getServiceList` method in the service registry has the wrong option type; therefore, I made this change to correct the types and also add typings for `getActionList`

AS-IS:

```ts
getServiceList(opts?: ActionCatalogListOptions): ServiceSchema[];
```

The `ActionCatalogListOtions` does not match with `getServiceList` options.

TO-BE: In this PR.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Typings
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```ts
getServiceList<S = ServiceSettingSchema>(opts?: ServiceListCatalogOptions): ServiceSchema<S>[];
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
