### PR TITLE
fix: wrong event typing referenced for service schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -500,7 +500,7 @@ declare namespace Moleculer {
 		service?: Service;
 		tracing?: boolean | TracingEventOptions;
 		bulkhead?: BulkheadOptions;
-		handler?: ActionHandler;
+		handler?: ServiceEventHandler | ServiceEventLegacyHandler;
 		context?: boolean;
 
 		[key: string]: any;
@@ -508,6 +508,10 @@ declare namespace Moleculer {
 
 	type ServiceActionsSchema<S = ServiceSettingSchema> = {
 		[key: string]: ActionSchema | ActionHandler | boolean;
+	} & ThisType<Service<S>>;
+
+	type ServiceEventsSchema<S = ServiceSettingSchema> = {
+		[key: string]: EventSchema | ServiceEventHandler | ServiceEventLegacyHandler | boolean;
 	} & ThisType<Service<S>>;
 
 	class BrokerNode {
@@ -662,7 +666,7 @@ declare namespace Moleculer {
 	type Middleware = {
 		[name: string]:
 			| ((handler: ActionHandler, action: ActionSchema) => any)
-			| ((handler: ActionHandler, event: ServiceEvent) => any)
+			| ((handler: ActionHandler, event: EventSchema) => any)
 			| ((handler: ActionHandler) => any)
 			| ((service: Service) => any)
 			| ((broker: ServiceBroker) => any)
@@ -733,7 +737,7 @@ declare namespace Moleculer {
 		methods?: ServiceMethods;
 		hooks?: ServiceHooks;
 
-		events?: ServiceEvents;
+		events?: ServiceEventsSchema;
 		created?: ServiceSyncLifecycleHandler<S> | ServiceSyncLifecycleHandler<S>[];
 		started?: ServiceAsyncLifecycleHandler<S> | ServiceAsyncLifecycleHandler<S>[];
 		stopped?: ServiceAsyncLifecycleHandler<S> | ServiceAsyncLifecycleHandler<S>[];
@@ -771,6 +775,7 @@ declare namespace Moleculer {
 		broker: ServiceBroker;
 		logger: LoggerInstance;
 		actions: ServiceActions;
+		events: ServiceEvents;
 		Promise: PromiseConstructorLike;
 
 		_init(): void;


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

> Still validating the accuracy of this typing change on my end. 

The typings for the event schema did not align with the practical usage of the objects. IE: `ServiceEvent` typing did not include a `tracing` property, yet the tracing middleware does expect to [read tracing opts](https://github.com/moleculerjs/moleculer/blob/master/src/middlewares/tracing.js#L142) when processing the event. 

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
