### PR TITLE
fix: do not emit send node info during broker stopping event

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -942,7 +942,6 @@ class ServiceBroker {
 	 */
 	servicesChanged(localService = false) {
 		this.broadcastLocal("$services.changed", { localService });
-
 		// Should notify remote nodes, because our service list is changed.
 		if (localService && this.transit) {
 			this.localServiceChanged();
@@ -953,7 +952,9 @@ class ServiceBroker {
 	 * It's a debounced method to send INFO packets to remote nodes.
 	 */
 	localServiceChanged() {
-		this.registry.discoverer.sendLocalNodeInfo();
+		if (!this.stopping) {
+			this.registry.discoverer.sendLocalNodeInfo();
+		}
 	}
 
 	/**

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1695,7 +1695,6 @@ describe("Test broker.servicesChanged", () => {
 		broker.registry.discoverer.sendLocalNodeInfo.mockClear();
 		broker.servicesChanged(true);
 
-		jest.runAllTimers();
 		expect(broker.broadcastLocal).toHaveBeenCalledTimes(1);
 		expect(broker.broadcastLocal).toHaveBeenCalledWith("$services.changed", {
 			localService: true
@@ -1710,7 +1709,6 @@ describe("Test broker.servicesChanged", () => {
 		broker.registry.discoverer.sendLocalNodeInfo.mockClear();
 		broker.servicesChanged(true);
 
-		jest.runAllTimers();
 		expect(broker.broadcastLocal).toHaveBeenCalledTimes(1);
 		expect(broker.broadcastLocal).toHaveBeenCalledWith("$services.changed", {
 			localService: true


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added a check for the broker state before emitting node info on debounced events.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

#1185

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
