### PR TITLE
runner multi env load

### DIFF
--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -69,7 +69,7 @@ export default class MoleculerRunner {
 	 * Available options:
 		-c, --config     Load the configuration from a file
 		-e, --env        Load .env file from the current directory
-		-E, --envfile    Load a specified .env file
+		-E, --envfile    Load specified .env files using glob patterns that are separated by commas. For example, '-E .env,.env.dev.*' loads the .env file and all .env.dev.* files.
 		-h, --help       Output usage information
 		-H, --hot        Hot reload services if changed (disabled by default)
 		-i, --instances  Launch [number] instances node (load balanced)
@@ -116,8 +116,17 @@ export default class MoleculerRunner {
 			try {
 				const dotenv = await import("dotenv");
 
-				if (this.flags.envfile) dotenv.config({ path: this.flags.envfile });
-				else dotenv.config();
+				if (this.flags.envfile) {
+					this.flags.envfile.split(",").forEach(envFile => {
+						glob.sync(path.join(process.cwd(), envFile), { absolute: true }).forEach(
+							envFile => {
+								dotenv.config({ path: envFile });
+							}
+						);
+					});
+				} else {
+					dotenv.config();
+				}
 			} catch (err) {
 				throw new Error(
 					"The 'dotenv' package is missing! Please install it with 'npm install dotenv --save' command."

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -406,7 +406,9 @@ export default class MoleculerRunner {
 							return this.broker.logger.warn(
 								kleur
 									.yellow()
-									.bold(`There is no service files in directory: '${svcPath}'`)
+									.bold(
+										`There is no service files in directory: '${svcPath}'`
+									)
 							);
 					} else if (this.isServiceFile(svcPath)) {
 						files = [svcPath.replace(/\\/g, "/")];
@@ -417,7 +419,9 @@ export default class MoleculerRunner {
 						files = glob.sync(p, { cwd: svcDir, absolute: true });
 						if (files.length == 0)
 							this.broker.logger.warn(
-								kleur.yellow().bold(`There is no matched file for pattern: '${p}'`)
+								kleur
+									.yellow()
+									.bold(`There is no matched file for pattern: '${p}'`)
 							);
 					}
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -66,7 +66,7 @@ class MoleculerRunner {
 	 * Available options:
 		-c, --config     Load the configuration from a file
 		-e, --env        Load .env file from the current directory
-		-E, --envfile    Load a specified .env file
+		-E, --envfile    Load specified .env files using glob patterns that are separated by commas. For example, '-E .env,.env.dev.*' loads the .env file and all .env.dev.* files.
 		-h, --help       Output usage information
 		-H, --hot        Hot reload services if changed (disabled by default)
 		-i, --instances  Launch [number] instances node (load balanced)
@@ -113,8 +113,17 @@ class MoleculerRunner {
 			try {
 				const dotenv = require("dotenv");
 
-				if (this.flags.envfile) dotenv.config({ path: this.flags.envfile });
-				else dotenv.config();
+				if (this.flags.envfile) {
+					this.flags.envfile.split(",").forEach(envFile => {
+						glob.sync(path.join(process.cwd(), envFile), { absolute: true }).forEach(
+							envFile => {
+								dotenv.config({ path: envFile });
+							}
+						);
+					});
+				} else {
+					dotenv.config();
+				}
 			} catch (err) {
 				throw new Error(
 					"The 'dotenv' package is missing! Please install it with 'npm install dotenv --save' command."

--- a/src/runner.js
+++ b/src/runner.js
@@ -9,7 +9,7 @@ const ServiceBroker = require("./service-broker");
 const utils = require("./utils");
 const fs = require("fs");
 const path = require("path");
-const glob = require("glob").sync;
+const glob = require("glob");
 const _ = require("lodash");
 const Args = require("args");
 const os = require("os");
@@ -403,7 +403,7 @@ class MoleculerRunner {
 							if (this.config.hotReload) {
 								this.watchFolders.push(svcPath);
 							}
-							files = glob(svcPath + "/" + fileMask, { absolute: true });
+							files = glob.sync(svcPath + "/" + fileMask, { absolute: true });
 							if (files.length == 0)
 								return this.broker.logger.warn(
 									kleur


### PR DESCRIPTION
Load specified .env files using glob patterns that are separated by commas. For example, '-E .env,.env.dev.*' loads the .env file and all .env.dev.* files.