### PR TITLE
replace deprecated redis.setex with redis.set method 

### DIFF
--- a/src/cachers/redis.js
+++ b/src/cachers/redis.js
@@ -223,7 +223,7 @@ class RedisCacher extends BaseCacher {
 
 		let p;
 		if (ttl) {
-			p = this.client.setex(this.prefix + key, ttl, data);
+			p = this.client.set(this.prefix + key, data, "EX", ttl);
 		} else {
 			p = this.client.set(this.prefix + key, data);
 		}

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -14,7 +14,7 @@ Redis.mockImplementation(() => {
 		subscribe: jest.fn(),
 		publish: jest.fn(),
 		quit: jest.fn(),
-		setex: jest.fn(),
+		set: jest.fn(),
 
 		onCallbacks
 	};
@@ -320,7 +320,6 @@ describe("Test RedisCacher set & get without prefix", () => {
 			prefix + key,
 			cacher.serializer.serialize(data1)
 		);
-		expect(cacher.client.setex).toHaveBeenCalledTimes(0);
 	});
 
 	it("should call client.getBuffer with key & return with data1", () => {
@@ -439,16 +438,17 @@ describe("Test RedisCacher set & get with namespace & ttl", () => {
 			cacher.logger[level].mockClear()
 		);
 
-		cacher.client.setex = jest.fn(() => Promise.resolve());
+		cacher.client.set = jest.fn(() => Promise.resolve());
 	});
 
-	it("should call client.setex with key & data", () => {
+	it("should call client.set with key & data", () => {
 		cacher.set(key, data1);
-		expect(cacher.client.setex).toHaveBeenCalledTimes(1);
-		expect(cacher.client.setex).toHaveBeenCalledWith(
+		expect(cacher.client.set).toHaveBeenCalledTimes(1);
+		expect(cacher.client.set).toHaveBeenCalledWith(
 			prefix + key,
-			60,
-			cacher.serializer.serialize(data1)
+			cacher.serializer.serialize(data1),
+			"EX",
+			60			
 		);
 	});
 

--- a/test/unit/cachers/redis.spec.js
+++ b/test/unit/cachers/redis.spec.js
@@ -448,7 +448,7 @@ describe("Test RedisCacher set & get with namespace & ttl", () => {
 			prefix + key,
 			cacher.serializer.serialize(data1),
 			"EX",
-			60			
+			60
 		);
 	});
 


### PR DESCRIPTION
## :memo: Description

The change involves refactoring the cachers/redis.js file to replace the deprecated setex method with the set method for setting key-value pairs. 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


