### PR TITLE
Improve logger types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,8 +21,8 @@ declare namespace Moleculer {
 		constructor(broker: ServiceBroker);
 		init(opts: LoggerConfig | LoggerConfig[]): void;
 		stop(): void;
-		getLogger(bindings: GenericObject): LoggerInstance;
-		getBindingsKey(bindings: GenericObject): string;
+		getLogger(bindings: LoggerBindings): LoggerInstance;
+		getBindingsKey(bindings: LoggerBindings): string;
 
 		broker: ServiceBroker;
 	}
@@ -32,7 +32,7 @@ declare namespace Moleculer {
 		ns: string;
 		mod: string;
 		svc: string;
-		ver: string | void;
+		ver?: string;
 	}
 
 	class LoggerInstance {
@@ -1165,12 +1165,14 @@ declare namespace Moleculer {
 	}
 
 	namespace Loggers {
+		type LogHandler = (level: LogLevels, args: unknown[]) => void;
+
 		class Base {
 			constructor(opts?: GenericObject);
 			init(loggerFactory: LoggerFactory): void;
 			stop(): void;
-			getLogLevel(mod: string): string;
-			getLogHandler(bindings: GenericObject): GenericObject;
+			getLogLevel(mod: string): LogLevels | null;
+			getLogHandler(bindings?: LoggerBindings): LogHandler | null;
 		}
 	}
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The current types for the `LoggerFactory` and `Base` Logger are incorrect in some cases or not specific enough in others.  Multiple methods are accepting `GenericObject` instead of the more accurate `LoggerBindings` type and have been updated accordingly.  Additionally, rather than allowing `string` as a type for the log levels return value, the more specific `LogLevels` type was used.  Finally, the return types for `getLogHandler` was updated to reflect the correct return type of the function.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

I've patched my local moleculer installation with these changes and implemented a custom logger using those fixed types.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
