### PR TITLE
add typings to package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.js",
       "import": "./index.mjs"
     }


### PR DESCRIPTION
## :memo: Description

With TS 5.0 introducing "bundler" / "NodeNext" module resolution, importing types from moleculer will result in TS complaining that it can't resolve type declarations. TS seems to find the type declaration file but won't use it because it's not explicitly listed under "exports" in package.json.

See this issue for more details: https://github.com/microsoft/TypeScript/issues/52363

Also relevant discussion here: https://github.com/gxmari007/vite-plugin-eslint/pull/60 , which implies that this fix is better, but not really considered good. Unfortunately I couldn't get re-exporting types to work, and copy-ing `index.d.ts` and having to maintain 2 same files seems worse at the moment.

This PR just adds a "types" export line to the package.json, which seems to keep TS happy and resolve the error.

### :dart: Relevant issues
- https://github.com/moleculerjs/moleculer/issues/1159

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] packaged moleculer locally, and installed resulting package
- [x] npm run test

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [ x I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
