### PR TITLE
Update hot-reload.js, Avoiding the occurrence of "Maximum call stack size exceeded " on  hot-reload

### DIFF
--- a/src/middlewares/hot-reload.js
+++ b/src/middlewares/hot-reload.js
@@ -276,7 +276,10 @@ module.exports = function HotReloadMiddleware(broker) {
 			} else if (parents) {
 				parents.push(fName);
 			}
-			mod.children.forEach(m => processModule(m, service, service ? level + 1 : 0, parents));
+			mod.children.forEach(m => {
+				if(m.filename.indexOf("node_modules") !== -1) return;
+				processModule(m, service, service ? level + 1 : 0, parents)
+			});
 		}
 	}
 


### PR DESCRIPTION
## :memo: Description

Error occurred when enabling -- hot

 "Maximum call stack size exceeded "

I found out I was checking the node_ The occurrence of modules dependency
