### PR TITLE
fix memory leak

### DIFF
--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -1931,6 +1931,10 @@ describe("Test Transit._sendRequest", () => {
 		const resolve = jest.fn();
 		const reject = jest.fn();
 
+		beforeEach(() => {
+			transit.publish = jest.fn(() => Promise.resolve().delay(40));
+		});
+
 		it("should send stream chunks", () => {
 			transit.publish.mockClear();
 
@@ -2070,8 +2074,11 @@ describe("Test Transit._sendRequest", () => {
 					transit.publish.mockClear();
 					stream.push(randomData);
 				})
-				.delay(100)
+				.delay(20)
+				.then(() => expect(stream.isPaused()).toBeTruthy())
+				.delay(80)
 				.then(() => {
+					expect(stream.isPaused()).toBeFalsy();
 					expect(transit.publish).toHaveBeenCalledTimes(
 						Math.ceil(randomData.length / transit.opts.maxChunkSize)
 					);
@@ -2163,8 +2170,11 @@ describe("Test Transit._sendRequest", () => {
 					});
 					transit.publish.mockClear();
 				})
-				.delay(100)
+				.delay(20)
+				.then(() => expect(stream.isPaused()).toBeTruthy())
+				.delay(80)
 				.then(() => {
+					expect(stream.isPaused()).toBeFalsy();
 					expect(transit.publish).toHaveBeenCalledTimes(
 						Math.ceil(randomData.length / transit.opts.maxChunkSize) + 1
 					);
@@ -2715,6 +2725,10 @@ describe("Test Transit.sendResponse", () => {
 	});
 
 	describe("with Stream", () => {
+		beforeEach(() => {
+			transit.publish = jest.fn(() => Promise.resolve().delay(40));
+		});
+
 		it("should send stream chunks", () => {
 			transit.publish.mockClear();
 
@@ -2819,8 +2833,11 @@ describe("Test Transit.sendResponse", () => {
 					transit.publish.mockClear();
 					stream.push("first chunk");
 				})
-				.delay(100)
+				.delay(20)
+				.then(() => expect(stream.isPaused()).toBeTruthy())
+				.delay(80)
 				.then(() => {
+					expect(stream.isPaused()).toBeFalsy();
 					expect(transit.publish).toHaveBeenCalledTimes(1);
 					expect(transit.publish).toHaveBeenCalledWith({
 						payload: {
@@ -2889,8 +2906,11 @@ describe("Test Transit.sendResponse", () => {
 					transit.publish.mockClear();
 					stream.push(randomData);
 				})
-				.delay(100)
+				.delay(20)
+				.then(() => expect(stream.isPaused()).toBeTruthy())
+				.delay(80)
 				.then(() => {
+					expect(stream.isPaused()).toBeFalsy();
 					expect(transit.publish).toHaveBeenCalledTimes(
 						Math.ceil(randomData.length / transit.opts.maxChunkSize)
 					);


### PR DESCRIPTION
Resume stream after all chunks are published to prevent memory leak

## :memo: Description

Memory leak scenario: we have two machines with each deployed a node. We use molecularr-web as a proxy to implement the file upload function. The files are first sent to the gateway and then forwarded to the service on the other machine using streams.
However, due to the file storage speed being slower than the internal network speed between the two machines, data starts to accumulate in the gateway.
As we had not handled this situation correctly before, it caused significant memory leaks in our production environment when users uploaded files. I identified the issue and fixed it.

### :dart: Relevant issues

None.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## :vertical_traffic_light: How Has This Been Tested?

As the description above

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
