### PR TITLE
[0.15] Remove fetch, min Node 18

### DIFF
--- a/examples/runner/moleculer.config.async.js
+++ b/examples/runner/moleculer.config.async.js
@@ -13,8 +13,6 @@
 
 */
 
-const fetch = require("node-fetch");
-
 module.exports = async function () {
 	const res = await fetch("https://pastebin.com/raw/SLZRqfHX");
 	return await res.json();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "kleur": "^4.1.5",
         "lodash": "^4.17.21",
         "lru-cache": "^10.0.1",
-        "node-fetch": "^2.6.13",
         "recursive-watch": "^1.1.4"
       },
       "bin": {
@@ -82,7 +81,7 @@
         "winston-context": "^0.0.7"
       },
       "engines": {
-        "node": ">= 16.x.x"
+        "node": ">= 18.x.x"
       },
       "funding": {
         "url": "https://github.com/moleculerjs/moleculer?sponsor=1"
@@ -9551,6 +9550,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -11228,6 +11228,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -14933,6 +14934,7 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -14951,17 +14953,20 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -17621,6 +17626,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/semver": {
@@ -26460,6 +26466,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -27745,6 +27752,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -30520,6 +30528,7 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -30527,17 +30536,20 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -32513,6 +32525,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "optional": true
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "kleur": "^4.1.5",
     "lodash": "^4.17.21",
     "lru-cache": "^10.0.1",
-    "node-fetch": "^2.6.13",
     "recursive-watch": "^1.1.4"
   },
   "peerDependencies": {
@@ -207,7 +206,7 @@
     }
   },
   "engines": {
-    "node": ">= 16.x.x"
+    "node": ">= 18.x.x"
   },
   "types": "./index.d.ts",
   "tsd": {

--- a/src/loggers/datadog.js
+++ b/src/loggers/datadog.js
@@ -9,8 +9,6 @@
 const BaseLogger = require("./base");
 const _ = require("lodash");
 const os = require("os");
-const fetch = require("node-fetch");
-fetch.Promise = Promise;
 const { MoleculerError } = require("../errors");
 
 const util = require("util");

--- a/src/metrics/reporters/datadog.js
+++ b/src/metrics/reporters/datadog.js
@@ -9,7 +9,6 @@
 const BaseReporter = require("./base");
 const _ = require("lodash");
 const os = require("os");
-const fetch = require("node-fetch");
 const { MoleculerError } = require("../../errors");
 const METRIC = require("../constants");
 const { isFunction } = require("../../utils");

--- a/src/tracing/exporters/datadog-simple.js
+++ b/src/tracing/exporters/datadog-simple.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const _ = require("lodash");
-const fetch = require("node-fetch");
 const BaseTraceExporter = require("./base");
 const { isFunction } = require("../../utils");
 

--- a/src/tracing/exporters/newrelic.js
+++ b/src/tracing/exporters/newrelic.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const _ = require("lodash");
-const fetch = require("node-fetch");
 const BaseTraceExporter = require("./base");
 const { isFunction } = require("../../utils");
 

--- a/src/tracing/exporters/zipkin.js
+++ b/src/tracing/exporters/zipkin.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const _ = require("lodash");
-const fetch = require("node-fetch");
 const BaseTraceExporter = require("./base");
 const { isFunction } = require("../../utils");
 

--- a/test/unit/loggers/datadog.spec.js
+++ b/test/unit/loggers/datadog.spec.js
@@ -1,8 +1,6 @@
 "use strict";
 
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
-fetch.mockImplementation(() => Promise.resolve({ statusText: "" }));
+global.fetch = jest.fn(() => Promise.resolve({ statusText: "" }));
 
 const DatadogLogger = require("../../../src/loggers/datadog");
 

--- a/test/unit/metrics/reporters/datadog.spec.js
+++ b/test/unit/metrics/reporters/datadog.spec.js
@@ -2,9 +2,7 @@
 
 const os = require("os");
 const lolex = require("@sinonjs/fake-timers");
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
-fetch.mockImplementation(() => Promise.resolve({ statusText: "" }));
+global.fetch = jest.fn(() => Promise.resolve({ statusText: "" }));
 
 const DatadogReporter = require("../../../../src/metrics/reporters/datadog");
 const ServiceBroker = require("../../../../src/service-broker");

--- a/test/unit/tracing/exporters/newrelic.spec.js
+++ b/test/unit/tracing/exporters/newrelic.spec.js
@@ -2,9 +2,7 @@
 
 const lolex = require("@sinonjs/fake-timers");
 
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
-fetch.mockImplementation(() => Promise.resolve({ statusText: "" }));
+global.fetch = jest.fn(() => Promise.resolve({ statusText: "" }));
 
 const NewRelicTraceExporter = require("../../../../src/tracing/exporters/newrelic");
 const ServiceBroker = require("../../../../src/service-broker");

--- a/test/unit/tracing/exporters/zipkin.spec.js
+++ b/test/unit/tracing/exporters/zipkin.spec.js
@@ -2,9 +2,7 @@
 
 const lolex = require("@sinonjs/fake-timers");
 
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
-fetch.mockImplementation(() => Promise.resolve({ statusText: "" }));
+global.fetch = jest.fn(() => Promise.resolve({ statusText: "" }));
 
 const ZipkinTraceExporter = require("../../../../src/tracing/exporters/zipkin");
 const ServiceBroker = require("../../../../src/service-broker");


### PR DESCRIPTION
## :memo: Description

This PR removes the `node-fetch` library and use the built-in `fetch` implementation. Besides it, the minimum Node version is bumped to Node 18