### PR TITLE
Transit improve

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -231,10 +231,9 @@ class Transit {
 
 		return this.Promise.resolve()
 			.then(() => {
-				if (this.tx.connected) {
-					return this.discoverer.localNodeDisconnected().then(() => this.tx.disconnect());
-				}
+				return this.tx.connected && this.discoverer.localNodeDisconnected();
 			})
+			.then(() => this.tx.disconnect())
 			.then(() => (this.disconnecting = false));
 	}
 


### PR DESCRIPTION
while transporter instance is at 'connecting' state, if broker.stop is called, the transit will not ask transporter to disconnect.