### PR TITLE
autodetect Redis type discoverer when using redis SSL URI

### DIFF
--- a/src/registry/discoverers/index.js
+++ b/src/registry/discoverers/index.js
@@ -38,7 +38,8 @@ function resolve(opt) {
 		let DiscovererClass = getByName(opt);
 		if (DiscovererClass) return new DiscovererClass();
 
-		if (opt.startsWith("redis://")) return new Discoverers.Redis(opt);
+		if (opt.startsWith("redis://") || opt.startsWith("rediss://"))
+			return new Discoverers.Redis(opt);
 
 		if (opt.startsWith("etcd3://")) return new Discoverers.Etcd3(opt);
 

--- a/test/unit/registry/discoverers/index.spec.js
+++ b/test/unit/registry/discoverers/index.spec.js
@@ -60,6 +60,12 @@ describe("Test Discoverers resolver", () => {
 		expect(discoverer.opts.redis).toEqual("redis://redis-server:6379");
 	});
 
+	it("should resolve Redis reporter from SSL connection string", () => {
+		const discoverer = Discoverers.resolve("rediss://redis-server:6379");
+		expect(discoverer).toBeInstanceOf(Discoverers.Redis);
+		expect(discoverer.opts.redis).toEqual("rediss://redis-server:6379");
+	});
+
 	it("should resolve Redis discoverer from obj", () => {
 		const options = { heartbeatInterval: 8 };
 		const discoverer = Discoverers.resolve({ type: "Redis", options });


### PR DESCRIPTION
## :memo: Description

I've encountered an error when I tried to use an SSL redis URI.
To fix this issue, I've just add another case for the match of a redis URI: `rediss://`.


### :dart: Relevant issues
https://github.com/moleculerjs/moleculer/issues/1259

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
const broker = new ServiceBroker({
    discoverer: "rediss://redis-server:6379"
});
``` 

## :vertical_traffic_light: How Has This Been Tested?

- [x] Check that uri starting with `rediss://` are identified as Redis type discoverer

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
