### PR TITLE
[0.15] New "replOptions" broker option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,45 @@ module.exports = {
 };
 ```
 
+## New REPL options
+
+In order to the REPL options can be more extensible, a new `replOptions` broker option is introduces. You can use it instead of the old `replCommands` and `replDelimiter` broker options.
+
+**Old REPL options**
+```js
+// moleculer.config.js
+module.exports = {
+    replDelimiter: "mol # ",
+    replCommands: [
+		{
+			command: "hello <name>",			
+			action(broker, args) {
+				// ...
+			}
+		}
+	]
+}
+```
+
+**New REPL options**
+```js
+// moleculer.config.js
+module.exports = {
+    replOptions: {
+        delimiter: "mol # ",
+        customCommands: [
+            {
+                command: "hello <name>",			
+                action(broker, args) {
+                    // ...
+                }
+            }
+        ]
+    }
+}
+```
+> Please note, you should rename the `replCommands` property to `customCommands`, as well.
+
 ## Action streaming
 
 The built-in `Stream` sending has been rewritten. Now it accepts `params` besides the `Stream` instance.

--- a/dev/dev.config.js
+++ b/dev/dev.config.js
@@ -11,14 +11,14 @@
 
 */
 
-function myMiddleware() {
-	return handler => async ctx => {
+const myMiddleware = {
+	localAction: handler => async ctx => {
 		ctx.broker.logger.warn(">> MW1-before (from config)");
 		const res = await handler(ctx);
 		ctx.broker.logger.warn("<< MW1-after (from config)");
 		return res;
-	};
-}
+	}
+};
 
 module.exports = {
 	namespace: "config-test",
@@ -26,7 +26,7 @@ module.exports = {
 	logger: true,
 	logLevel: "debug",
 
-	middlewares: [myMiddleware()],
+	middlewares: [myMiddleware],
 
 	created(broker) {
 		broker.logger.warn("--- Broker created (from config)!");
@@ -50,24 +50,26 @@ module.exports = {
 	stopped(broker) {
 		return broker.Promise.delay(2000).then(() => broker.logger.warn("--- Broker stopped"));
 	},
-	replCommands: [
-		{
-			command: "hello <name>",
-			description: "Call the greeter.hello service with name",
-			alias: "hi",
-			options: [{ option: "-u, --uppercase", description: "Uppercase the name" }],
-			types: {
-				string: ["name"],
-				boolean: ["u", "uppercase"]
-			},
-			//parse(command, args) {},
-			//validate(args) {},
-			//help(args) {},
-			allowUnknownOptions: true,
-			action(broker, args) {
-				const name = args.options.uppercase ? args.name.toUpperCase() : args.name;
-				return broker.call("greeter.hello", { name }).then(console.log);
+	replOptions: {
+		customCommands: [
+			{
+				command: "hello <name>",
+				description: "Call the greeter.hello service with name",
+				alias: "hi",
+				options: [{ option: "-u, --uppercase", description: "Uppercase the name" }],
+				types: {
+					string: ["name"],
+					boolean: ["u", "uppercase"]
+				},
+				//parse(command, args) {},
+				//validate(args) {},
+				//help(args) {},
+				allowUnknownOptions: true,
+				action(broker, args) {
+					const name = args.options.uppercase ? args.name.toUpperCase() : args.name;
+					return broker.call("greeter.hello", { name }).then(console.log);
+				}
 			}
-		}
-	]
+		]
+	}
 };

--- a/docs/MIGRATION_GUIDE_0.15.md
+++ b/docs/MIGRATION_GUIDE_0.15.md
@@ -47,6 +47,45 @@ module.exports = {
 };
 ```
 
+## New REPL options
+
+In order to the REPL options can be more extensible, a new `replOptions` broker option is introduces. You can use it instead of the old `replCommands` and `replDelimiter` broker options.
+
+**Old REPL options**
+```js
+// moleculer.config.js
+module.exports = {
+    replDelimiter: "mol # ",
+    replCommands: [
+		{
+			command: "hello <name>",			
+			action(broker, args) {
+				// ...
+			}
+		}
+	]
+}
+```
+
+**New REPL options**
+```js
+// moleculer.config.js
+module.exports = {
+    replOptions: {
+        delimiter: "mol # ",
+        customCommands: [
+            {
+                command: "hello <name>",			
+                action(broker, args) {
+                    // ...
+                }
+            }
+        ]
+    }
+}
+```
+> Please note, you should rename the `replCommands` property to `customCommands`, as well.
+
 ## New action streaming
 
 The built-in `Stream` sending has been rewritten. Now it accepts `params` besides the `Stream` instance.

--- a/examples/multi-nodes/master.js
+++ b/examples/multi-nodes/master.js
@@ -42,27 +42,29 @@ const broker = new ServiceBroker({
 		}
 	},
 	//heartbeatInterval: 10,
-	replCommands: [
-		{
-			command: "scale <count>",
-			alias: "s",
-			description: "Scaling up/down nodes",
-			options: [
-				{ option: "-k, --kill", description: "Kill nodes" }
-				//{ option: "--nodeID <nodeID>", description: "NodeID" }
-			],
-			types: {
-				//number: ["service"]
-			},
-			action(broker, args) {
-				console.log(args);
-				return broker.call("nodes.scale", {
-					count: Number(args.count != null ? args.count : 0),
-					kill: args.kill
-				});
+	replOptions: {
+		customCommands: [
+			{
+				command: "scale <count>",
+				alias: "s",
+				description: "Scaling up/down nodes",
+				options: [
+					{ option: "-k, --kill", description: "Kill nodes" }
+					//{ option: "--nodeID <nodeID>", description: "NodeID" }
+				],
+				types: {
+					//number: ["service"]
+				},
+				action(broker, args) {
+					console.log(args);
+					return broker.call("nodes.scale", {
+						count: Number(args.count != null ? args.count : 0),
+						kill: args.kill
+					});
+				}
 			}
-		}
-	]
+		]
+	}
 });
 
 broker.loadService(path.join(__dirname, "node-controller.service.js"));

--- a/src/service-broker.d.ts
+++ b/src/service-broker.d.ts
@@ -28,6 +28,7 @@ import type EventEndpoint = require("./registry/endpoint-event");
 import type Service = require("./service");
 import type { ServiceDependency } from "./service";
 import type { Stream } from "stream";
+import { ReplOptions } from "repl";
 
 declare namespace ServiceBroker {
 	type BrokerSyncLifecycleHandler = (broker: ServiceBroker) => void;
@@ -87,8 +88,7 @@ declare namespace ServiceBroker {
 
 		middlewares?: (Middleware | string)[];
 
-		replCommands?: Record<string, any>[] | null;
-		replDelimiter?: string;
+		replOptions?: ReplOptions | null;
 
 		metadata?: Record<string, any>;
 
@@ -107,6 +107,11 @@ declare namespace ServiceBroker {
 		skipProcessEventRegistration?: boolean;
 
 		maxSafeObjectSize?: number;
+	}
+
+	export interface ReplOptions {
+		customCommands?: Record<string, any>[] | null;
+		delimiter?: string;
 	}
 
 	export interface BrokerRegistryOptions {

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -33,19 +33,9 @@ const { Tracer } = require("./tracing");
 const C = require("./constants");
 
 /**
- * @typedef {Object} CallingOptions Calling options
- * @property {number?} timeout
- * @property {number?} retries
- * @property {Function?} fallbackResponse
- * @property {string?} nodeID
- * @property {object?} meta
- * @property {object?} parentSpan
- * @property {Context?} parentCtx
- * @property {string?} requestID
- * @property {boolean?} tracking
- * @property {boolean?} paramsCloning
- * @property {string?} caller
- * @property {Stream?} stream
+ * Import types
+ *
+ * @typedef {import("./service-broker").CallingOptions} CallingOptions Calling options
  */
 
 /**
@@ -134,8 +124,7 @@ const defaultOptions = {
 
 	middlewares: null,
 
-	replCommands: null,
-	replDelimiter: null,
+	replOptions: null,
 
 	metadata: {},
 
@@ -633,12 +622,7 @@ class ServiceBroker {
 		}
 
 		if (repl) {
-			let opts = null;
-			const delimiter = this.options.replDelimiter;
-			const customCommands = this.options.replCommands;
-			delimiter && (opts = { delimiter });
-			customCommands && (opts = { ...opts, customCommands });
-			return repl(this, opts);
+			return repl(this, this.options.replOptions);
 		}
 	}
 

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -287,8 +287,7 @@ describe("Test ServiceBroker constructor", () => {
 			dependencyTimeout: 0,
 			hotReload: true,
 			middlewares: null,
-			replCommands: null,
-			replDelimiter: null,
+			replOptions: null,
 			metadata: {
 				region: "eu-west1"
 			},
@@ -975,23 +974,27 @@ describe("Test broker.repl", () => {
 		repl.mockClear();
 		let broker = new ServiceBroker({
 			logger: false,
-			replCommands: []
+			replOptions: {
+				customCommands: []
+			}
 		});
 		broker.repl();
 
 		expect(repl).toHaveBeenCalledTimes(1);
-		expect(repl).toHaveBeenCalledWith(broker, { customCommands: broker.options.replCommands });
+		expect(repl).toHaveBeenCalledWith(broker, { customCommands: [] });
 	});
 	it("should switch to repl mode with delimiter", () => {
 		repl.mockClear();
 		let broker = new ServiceBroker({
 			logger: false,
-			replDelimiter: "mol # "
+			replOptions: {
+				delimiter: "mol # "
+			}
 		});
 		broker.repl();
 
 		expect(repl).toHaveBeenCalledTimes(1);
-		expect(repl).toHaveBeenCalledWith(broker, { delimiter: broker.options.replDelimiter });
+		expect(repl).toHaveBeenCalledWith(broker, { delimiter: "mol # " });
 	});
 });
 


### PR DESCRIPTION
## :memo: Description

This PR introduces a new `replOptions` broker option instead of `replCommands` and `replDelimiter` options.

### :dart: Relevant issues
It covers #1153 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
// moleculer.config.js
module.exports = {
    replOptions: {
        delimiter: "mol # ",
        customCommands: [
            {
                command: "hello <name>",			
                action(broker, args) {
                    // ...
                }
            }
        ]
    }
}
```

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
