### PR TITLE
Add hook middlewares interceptors to preserve call context with call middlewares.

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -18,6 +18,8 @@ class MiddlewareHandler {
 		this.list = [];
 
 		this.registeredHooks = {};
+
+		this.middlewareInterceptors = {};
 	}
 
 	add(mw) {
@@ -43,9 +45,14 @@ class MiddlewareHandler {
 
 		Object.keys(mw).forEach(key => {
 			if (isFunction(mw[key])) {
-				if (Array.isArray(this.registeredHooks[key]))
-					this.registeredHooks[key].push(mw[key]);
-				else this.registeredHooks[key] = [mw[key]];
+				const handle = isFunction(this.middlewareInterceptors[key])
+					? this.middlewareInterceptors[key](mw[key])
+					: mw[key];
+				if (Array.isArray(this.registeredHooks[key])) {
+					this.registeredHooks[key].push(handle);
+				} else {
+					this.registeredHooks[key] = [handle];
+				}
 			}
 		});
 

--- a/test/integration/middlewares.spec.js
+++ b/test/integration/middlewares.spec.js
@@ -17,6 +17,15 @@ describe("Test middleware system", () => {
 							});
 						};
 					}
+				},
+				{
+					call(next) {
+						return (actionName, params, opts) => {
+							return next(actionName, params, opts).then(res => {
+								return Promise.resolve(res + "!");
+							});
+						};
+					}
 				}
 			]
 		});
@@ -48,7 +57,10 @@ describe("Test middleware system", () => {
 		afterAll(() => broker.stop());
 
 		it("The context is passed through the call middlware.", async () => {
-			await expect(broker.call("test.testAction")).resolves.toBe("testmeta");
+			const p = broker.call("test.testAction");
+			await expect(p).resolves.toBe("testmeta!");
+			expect(p.ctx).toBeDefined();
+			expect(p.ctx.meta.$metainfo).toBe("testmeta");
 		});
 	});
 

--- a/test/integration/middlewares.spec.js
+++ b/test/integration/middlewares.spec.js
@@ -3,6 +3,55 @@ const utils = require("../../src/utils");
 const { protectReject } = require("../unit/utils");
 
 describe("Test middleware system", () => {
+	describe("Test hook middleware interceptors.", () => {
+		const broker = new ServiceBroker({
+			logger: false,
+			validator: false,
+			internalMiddlewares: false,
+			middlewares: [
+				{
+					call(next) {
+						return (actionName, params, opts) => {
+							return next(actionName, params, opts).then(res => {
+								return res;
+							});
+						};
+					}
+				}
+			]
+		});
+
+		broker.createService({
+			name: "contextDataPassedTest",
+			actions: {
+				setContextMeta: {
+					handler(ctx) {
+						ctx.meta.$metainfo = "testmeta";
+					}
+				}
+			}
+		});
+
+		broker.createService({
+			name: "test",
+			actions: {
+				testAction: {
+					async handler(ctx) {
+						await ctx.call("contextDataPassedTest.setContextMeta");
+						return ctx.meta.$metainfo;
+					}
+				}
+			}
+		});
+
+		beforeAll(() => broker.start());
+		afterAll(() => broker.stop());
+
+		it("The context is passed through the call middlware.", async () => {
+			await expect(broker.call("test.testAction")).resolves.toBe("testmeta");
+		});
+	});
+
 	describe("Test with sync & async middlewares", () => {
 		let flow = [];
 		let mw1Sync = {

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -518,6 +518,32 @@ describe("Test ServiceBroker constructor", () => {
 	});
 });
 
+describe("Test broker.interceptCallMiddleware", () => {
+	const broker = new ServiceBroker({
+		logger: false,
+		transporter: null
+	});
+
+	it("should preserve the context of the call", async () => {
+		const next = () => {
+			const promise = Promise.resolve("next-result");
+			promise.ctx = { test: "test" };
+			return promise;
+		};
+
+		const createMiddleware = jest.fn(next => (...args) => {
+			return next(...args).then(() => "middleware-result");
+		});
+
+		const createInterceptedMiddleware = broker.interceptCallMiddleware(createMiddleware);
+
+		const result = createInterceptedMiddleware(next)();
+
+		expect(result.ctx).toEqual({ test: "test" });
+		await expect(result).resolves.toBe("middleware-result");
+	});
+});
+
 describe("Test broker.start", () => {
 	describe("without transporter", () => {
 		let schema;


### PR DESCRIPTION
## :memo: Description

When using middleware for the call method, the call context was lost, as described in #1241  . This issue occurred because the context was passed through the mutation of the promise. Consequently, if the middleware awaited the result from the promise and returned a new promise, the execution context was lost.

In order to maintain backward compatibility, I propose the following solution:
We can wrap the middleware for specific hooks, such as call, in an interceptor function. The interceptor is responsible for setting the context value for the promise that will be returned from the user's middleware.

In this pull request, I have added interceptor functionality to the MiddlewareHandler class, as well as an interceptor method for the call hook in the ServiceBroker class.

### :dart: Relevant issues
#1241 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration middlware test "Test hook middleware interceptors".
- [x] Unit service broker test "Test broker.interceptCallMiddleware".

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
