### PR TITLE
feat: Expand the type for ServiceSchema to allow for typed lifecycle handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -720,12 +720,14 @@ declare namespace Moleculer {
 		version?: string | number;
 	}
 
-	type ServiceSyncLifecycleHandler<S = ServiceSettingSchema> = (this: Service<S>) => void;
-	type ServiceAsyncLifecycleHandler<S = ServiceSettingSchema> = (
-		this: Service<S>
+	type ServiceSyncLifecycleHandler<S = ServiceSettingSchema, T = Service<S>> = (
+		this: T
+	) => void;
+	type ServiceAsyncLifecycleHandler<S = ServiceSettingSchema, T = Service<S>> = (
+		this: T
 	) => void | Promise<void>;
 
-	interface ServiceSchema<S = ServiceSettingSchema> {
+	interface ServiceSchema<S = ServiceSettingSchema, T = void> {
 		name: string;
 		version?: string | number;
 		settings?: S;
@@ -737,9 +739,9 @@ declare namespace Moleculer {
 		hooks?: ServiceHooks;
 
 		events?: ServiceEvents;
-		created?: ServiceSyncLifecycleHandler<S> | ServiceSyncLifecycleHandler<S>[];
-		started?: ServiceAsyncLifecycleHandler<S> | ServiceAsyncLifecycleHandler<S>[];
-		stopped?: ServiceAsyncLifecycleHandler<S> | ServiceAsyncLifecycleHandler<S>[];
+		created?: ServiceSyncLifecycleHandler<S, T> | ServiceSyncLifecycleHandler<S, T>[];
+		started?: ServiceAsyncLifecycleHandler<S, T> | ServiceAsyncLifecycleHandler<S, T>[];
+		stopped?: ServiceAsyncLifecycleHandler<S, T> | ServiceAsyncLifecycleHandler<S, T>[];
 
 		[name: string]: any;
 	}

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -30,9 +30,9 @@ const GreeterService: ServiceSchema<GreeterSettings, GreeterThis> = {
 	 */
 	hooks: {
 		before: {
-			welcome(ctx: Context<ActionWelcomeParams>): void {
+			welcome(this: GreeterThis, ctx: Context<ActionWelcomeParams>): void {
 				// console.log(`Service hook "before".`);
-				ctx.params.name = ctx.params.name.toUpperCase();
+				ctx.params.name = this.uppercase(ctx.params.name);
 			}
 		},
 		after: {
@@ -116,7 +116,11 @@ const GreeterService: ServiceSchema<GreeterSettings, GreeterThis> = {
 	 * Methods
 	 */
 	methods: {
-		async anotherHookAfter(ctx: Context, res: any): Promise<void> {
+		uppercase(this: GreeterThis, str: string): string {
+			return str.toUpperCase();
+		},
+
+		async anotherHookAfter(this: GreeterThis, ctx: Context, res: any): Promise<void> {
 			return await Promise.resolve(res);
 		}
 	},

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -38,11 +38,11 @@ const GreeterService: ServiceSchema<GreeterSettings, GreeterThis> = {
 		after: {
 			hello: "anotherHookAfter",
 			welcome: [
-				function (ctx: Context<ActionWelcomeParams>, res: any): any {
+				function (this: GreeterThis, ctx: Context<ActionWelcomeParams>, res: any): any {
 					// console.log(`Service sync hook "after".`);
 					return res;
 				},
-				async (ctx: Context<ActionWelcomeParams>, res: any): Promise<any> => {
+				async function (this: GreeterThis, ctx: Context<ActionWelcomeParams>, res: any): Promise<any> {
 					// console.log(`Service async hook "after".`);
 					return await Promise.resolve(res);
 				},
@@ -50,7 +50,7 @@ const GreeterService: ServiceSchema<GreeterSettings, GreeterThis> = {
 			],
 		},
 		error: {
-			welcome(ctx: Context<ActionWelcomeParams>, err: Error): void {
+			welcome(this: GreeterThis, ctx: Context<ActionWelcomeParams>, err: Error): void {
 				// console.log(`Service hook "error".`);
 				throw err;
 			}
@@ -83,11 +83,11 @@ const GreeterService: ServiceSchema<GreeterSettings, GreeterThis> = {
 			},
 			hooks: {
 				after: [
-					(ctx: Context, res: any): any => {
+					function (this: GreeterThis, ctx: Context, res: any): any {
 						// console.log(`Action sync hook "after".`);
 						return res;
 					},
-					async (ctx: Context, res: any): Promise<any> => {
+					async function (ctx: Context, res: any): Promise<any> {
 						// console.log(`Action async hook "after".`);
 						return await Promise.resolve(res);
 					},

--- a/test/typescript/hello-world/greeter.service.ts
+++ b/test/typescript/hello-world/greeter.service.ts
@@ -2,88 +2,96 @@
 
 import { Service } from "../../../";
 import { Context } from "../../../";
-import { ActionHooks, ServiceHooks, ServiceHooksAfter, ServiceSchema } from "../../../";
+import { ServiceSettingSchema, ServiceSchema } from "../../../";
 
-type GreeterWelcomeParams = {
-	name: string
-};
+export interface ActionHelloParams {
+	name: string;
+}
 
-export default class GreeterService extends Service {
-	constructor(broker) {
-		super(broker);
+interface GreeterSettings extends ServiceSettingSchema {
+	defaultName: string;
+}
 
-		this.parseServiceSchema({
-			name: "greeter",
-			hooks: {
-				before: {
-					welcome(ctx: Context<GreeterWelcomeParams>): void {
-						// console.log(`Service hook "before".`);
-						ctx.params.name = ctx.params.name.toUpperCase();
-					}
-				},
-				after: {
-					hello: "anotherHookAfter",
-					welcome: [
-						function (ctx: Context<GreeterWelcomeParams>, res: any): any {
-							// console.log(`Service sync hook "after".`);
-							return res;
-						},
-						async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
-							// console.log(`Service async hook "after".`);
-							return await Promise.resolve(res);
-						},
-						"anotherHookAfter"
-					],
-				} as ServiceHooksAfter,
-				error: {
-					welcome(ctx: Context<GreeterWelcomeParams>, err: Error): void {
-						// console.log(`Service hook "error".`);
-						throw err;
-					}
-				}
-			} as ServiceHooks,
-			actions: {
-				hello: {
-					handler: this.hello,
-					hooks: {
-						after: [
-							function (ctx: Context<GreeterWelcomeParams>, res: any): any {
-								// console.log(`Action sync hook "after".`);
-								return res;
-							},
-							async (ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> => {
-								// console.log(`Action async hook "after".`);
-								return await Promise.resolve(res);
-							},
-							"anotherHookAfter"
-						]
-					} as ActionHooks
-				},
-				welcome: this.welcome
-			}
-		} as ServiceSchema);
-	}
+interface GreeterMethods {
+	uppercase(str: string): string;
+}
+
+interface GreeterLocalVars {
+	myVar: string;
+}
+
+type GreeterThis = Service<GreeterSettings> & GreeterMethods & GreeterLocalVars;
+
+const GreeterService: ServiceSchema<GreeterSettings, GreeterThis> = {
+	name: "greeter",
 
 	/**
-	 * Say a 'Hello'
-	 *
-	 * @returns
+	 * Settings
 	 */
-	hello() {
-		return "Hello Moleculer TS";
-	}
+	settings: {
+		defaultName: "Moleculer",
+	},
 
 	/**
-	 * Welcome a username
-	 *
-	 * @param {String} name - User name
+	 * Dependencies
 	 */
-	welcome(ctx: Context<GreeterWelcomeParams>) {
-		return `Welcome, ${ctx.params.name}!`;
-	}
+	dependencies: [],
 
-	async anotherHookAfter(ctx: Context<GreeterWelcomeParams>, res: any): Promise<any> {
-		// console.log(`Another async hook "after".`);
-		return await Promise.resolve(res);
-	}
+	/**
+	 * Actions
+	 */
+	actions: {
+		hello: {
+			rest: {
+				method: "GET",
+				path: "/hello",
+			},
+			handler(this: GreeterThis/* , ctx: Context */): string {
+				return `Hello ${this.settings.defaultName}`;
+			},
+		},
+
+		welcome: {
+			rest: "GET /welcome/:name",
+			params: {
+				name: "string",
+			},
+			handler(this: GreeterThis, ctx: Context<ActionHelloParams>): string {
+				return `Welcome, ${ctx.params.name}`;
+			},
+		},
+	},
+
+	/**
+	 * Events
+	 */
+	events: {},
+
+	/**
+	 * Methods
+	 */
+	methods: {},
+
+	/**
+	 * Service created lifecycle event handler
+	 */
+	created(this: GreeterThis) {
+		this.logger.info(`${this.name} service - lifecycle method "created" called.`);
+	},
+
+	/**
+	 * Service started lifecycle event handler
+	 */
+	async started(this: GreeterThis) {
+		this.logger.info(`${this.name} service - lifecycle method "started" called.`);
+	},
+
+	/**
+	 * Service stopped lifecycle event handler
+	 */
+	async stopped(this: GreeterThis) {
+		this.logger.info(`${this.name} service - lifecycle method "stopped" called.`);
+	},
 };
+
+export default GreeterService;

--- a/test/typescript/hello-world/index.ts
+++ b/test/typescript/hello-world/index.ts
@@ -29,10 +29,8 @@ broker.loadService(path.join(__dirname, "greeter.service.ts"));
 
 		await broker.call("greeter.hello");
 		const res = await broker.call("greeter.welcome", { name: "Typescript" });
-		broker.logger.info("");
-		broker.logger.info("Result: ", res);
-		broker.logger.info("");
-		if (res != "Welcome, TYPESCRIPT!")
+		broker.logger.info(`Result: ${res}`);
+		if (res != "Welcome, Typescript")
 			throw new Error("Result is mismatch!");
 		else
 			await broker.stop();

--- a/test/typescript/hello-world/index.ts
+++ b/test/typescript/hello-world/index.ts
@@ -30,7 +30,7 @@ broker.loadService(path.join(__dirname, "greeter.service.ts"));
 		await broker.call("greeter.hello");
 		const res = await broker.call("greeter.welcome", { name: "Typescript" });
 		broker.logger.info(`Result: ${res}`);
-		if (res != "Welcome, Typescript")
+		if (res != "Welcome, TYPESCRIPT")
 			throw new Error("Result is mismatch!");
 		else
 			await broker.stop();


### PR DESCRIPTION
This change expands the typings for the ServiceSchema, allowing it to accept the "service-this" type used by the lifecycle handlers in the typescript template. Please see [this issue](https://github.com/moleculerjs/moleculer-template-project-typescript/issues/70) for a more complete explanation.

## :memo: Description

Change the type of the ServiceSchema to accept two generic types, latter of which is new and used to provide types for the lifecycle methods (created, started, stopped).

The typescript template will require a minor change if this change is accepted.

### :dart: Relevant issues
[moleculer-template-project-typescript #70](https://github.com/moleculerjs/moleculer-template-project-typescript/issues/70)

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

The example code to verify that this change works is outlined in [moleculer-template-project-typescript #70](https://github.com/moleculerjs/moleculer-template-project-typescript/issues/70).

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
