### PR TITLE
Remove unnecessary clone in node update method

### DIFF
--- a/src/registry/node.js
+++ b/src/registry/node.js
@@ -62,8 +62,7 @@ class Node {
 		this.client = payload.client || {};
 		this.config = payload.config || {};
 
-		// Process services & events (should make a clone because it will manipulate the objects (add handlers))
-		this.services = _.cloneDeep(payload.services);
+		this.services = payload.services;
 		this.rawInfo = payload;
 
 		const newSeq = payload.seq || 1;

--- a/src/registry/node.js
+++ b/src/registry/node.js
@@ -6,8 +6,6 @@
 
 "use strict";
 
-const _ = require("lodash");
-
 /**
  * Node class
  *

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -429,15 +429,17 @@ class Registry {
 	 */
 	registerEvents(node, service, events) {
 		_.forIn(events, event => {
+			const serviceEvent = { ...event };
+
 			if (node.local)
-				event.handler = this.broker.middlewares.wrapHandler(
+				serviceEvent.handler = this.broker.middlewares.wrapHandler(
 					"localEvent",
 					event.handler,
 					event
 				);
 
-			this.events.add(node, service, event);
-			service.addEvent(event);
+			this.events.add(node, service, serviceEvent);
+			service.addEvent(serviceEvent);
 		});
 	}
 

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -300,28 +300,31 @@ class Registry {
 		_.forIn(actions, action => {
 			if (!this.checkActionVisibility(action, node)) return;
 
+			// Clone fields to have independent action object
+			const serviceAction = { ...action };
+
 			if (node.local) {
-				action.handler = this.broker.middlewares.wrapHandler(
+				serviceAction.handler = this.broker.middlewares.wrapHandler(
 					"localAction",
 					action.handler,
 					action
 				);
 			} else if (this.broker.transit) {
-				action.handler = this.broker.middlewares.wrapHandler(
+				serviceAction.handler = this.broker.middlewares.wrapHandler(
 					"remoteAction",
 					this.broker.transit.request.bind(this.broker.transit),
 					{ ...action, service }
 				);
 			}
 			if (this.broker.options.disableBalancer && this.broker.transit)
-				action.remoteHandler = this.broker.middlewares.wrapHandler(
+				serviceAction.remoteHandler = this.broker.middlewares.wrapHandler(
 					"remoteAction",
 					this.broker.transit.request.bind(this.broker.transit),
 					{ ...action, service }
 				);
 
-			this.actions.add(node, service, action);
-			service.addAction(action);
+			this.actions.add(node, service, serviceAction);
+			service.addAction(serviceAction);
 		});
 	}
 

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -434,8 +434,8 @@ class Registry {
 			if (node.local)
 				serviceEvent.handler = this.broker.middlewares.wrapHandler(
 					"localEvent",
-					event.handler,
-					event
+					serviceEvent.handler,
+					serviceEvent
 				);
 
 			this.events.add(node, service, serviceEvent);


### PR DESCRIPTION
## :memo: Description
We have a lot of instances of the app, with a bunch of services.
When app starts it took too long(4 sec on average) of active node cpu workload.
I've used the node debug to find a hot spot. 
That was a deepClone in update method of node.js.
It might be not necessary to clone the object because it comes from transport and it isn't used after.
I think current tests it has to be enough to prove that everything ok with the registry

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

It has to be enough current tests of node-catalog

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
