### PR TITLE
Add validation service settings by provided schema ability.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter2 } from "eventemitter2";
 import type { BinaryLike, CipherCCMTypes, CipherGCMTypes, CipherKey, CipherOCBTypes } from 'crypto'
 import type { Worker } from "cluster";
+import { ValidationSchema } from "fastest-validator";
 
 declare namespace Moleculer {
 	/**
@@ -628,6 +629,7 @@ declare namespace Moleculer {
 		$dependencyTimeout?: number;
 		$shutdownTimeout?: number;
 		$secureSettings?: string[];
+		$validationSchema?: ValidationSchema | GenericObject;
 		[name: string]: any;
 	}
 

--- a/src/service.js
+++ b/src/service.js
@@ -253,12 +253,31 @@ class Service {
 	}
 
 	/**
+	 * Validate service settings by provided validation schema.
+	 *
+	 * @param {Object} settings
+	 * @memberof Service
+	 */
+	_validateSettings(settings) {
+		return this.broker.validator.validate(settings, settings.$validationSchema);
+	}
+
+	/**
 	 * Initialize service. It called `created` handler in schema
 	 *
 	 * @private
 	 * @memberof Service
 	 */
 	_init() {
+		if (this.settings && this.settings.$validationSchema) {
+			this.logger.debug("Service settings validation schema found. Try to use it...");
+			if (this.broker.validator) {
+				this._validateSettings(this.settings);
+			} else {
+				this.logger.warn("Validator not enabled. Skip service settings validation.");
+			}
+		}
+
 		this.logger.debug(`Service '${this.fullName}' is creating...`);
 		if (isFunction(this.schema.created)) {
 			this.schema.created.call(this);

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -5,7 +5,6 @@ const Context = require("../../src/context");
 const ServiceBroker = require("../../src/service-broker");
 const { ValidationError } = require("../../src/errors");
 
-
 describe("Test Service class", () => {
 	describe("Test constructor", () => {
 		const broker = new ServiceBroker({ logger: false });


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Add new setting "$validationSchema" and validation step.
With it (if broker.validator is defined) we can validate service settings object after merged() (means after merging all mixins with own settings) but before created() calls.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### :scroll: Example code
```ts
import { ValidationSchema } from "fastest-validator";

const $validationSchema: ValidationSchema = {
  $$strict: false,

  batchSize: { integer: true, positive: true, type: "number" },
};


const serviceSchema: ServiceSchema = {
    settings: {
        $validationSchema,

        // throws ValidationError, because batchSize setting expects number.
        batchSize: "10",
    },
};
``` 
## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
