### PR TITLE
Fix runner use of moleculer.config function with default export

### DIFF
--- a/examples/runner/moleculer.config.async.ts
+++ b/examples/runner/moleculer.config.async.ts
@@ -1,0 +1,11 @@
+import fetch from "node-fetch";
+
+/**
+ * Test:
+ *
+ * 	npx ts-node -T bin\moleculer-runner.js -c examples\runner\moleculer.config.async.ts -r examples/user.service.js
+ */
+export default async function () {
+	const res = await fetch("https://pastebin.com/raw/SLZRqfHX");
+	return await res.json();
+}

--- a/examples/runner/moleculer.config.ts
+++ b/examples/runner/moleculer.config.ts
@@ -1,0 +1,16 @@
+/**
+ * Test:
+ *
+ * 	npx ts-node -T bin\moleculer-runner.js -c examples\runner\moleculer.config.ts -r examples/user.service.js
+ */
+export default {
+	namespace: "bbb",
+	logger: true,
+	logLevel: "debug",
+	//transporter: "TCP"
+	hotReload: true,
+
+	created(broker) {
+		broker.logger.info("Typescript configuration loaded!");
+	}
+};

--- a/src/runner.js
+++ b/src/runner.js
@@ -53,7 +53,6 @@ class MoleculerRunner {
 		this.watchFolders = [];
 
 		this.flags = null;
-		this.configFile = null;
 		this.config = null;
 		this.servicePaths = null;
 		this.broker = null;
@@ -176,27 +175,28 @@ class MoleculerRunner {
 			filePath = this.tryConfigPath(path.resolve(process.cwd(), "moleculer.config.json"));
 		}
 
-		if (filePath != null) {
-			const ext = path.extname(filePath);
-			switch (ext) {
-				case ".json":
-				case ".js":
-				case ".ts": {
-					const content = require(filePath);
-					return Promise.resolve()
-						.then(() => {
-							if (utils.isFunction(content)) return content.call(this);
-							else return content;
-						})
-						.then(
-							res =>
-								(this.configFile =
-									res.default != null && res.__esModule ? res.default : res)
-						);
-				}
-				default:
-					return Promise.reject(new Error(`Not supported file extension: ${ext}`));
+		if (filePath == null) {
+			// no configuration file found
+			return Promise.resolve({});
+		}
+
+		const ext = path.extname(filePath);
+		switch (ext) {
+			case ".json":
+			case ".js":
+			case ".ts": {
+				return Promise.resolve(require(filePath))
+					.then(content => {
+						return content.default != null && content.__esModule
+							? content.default
+							: content;
+					})
+					.then(mod => {
+						return utils.isFunction(mod) ? mod.call(this) : mod;
+					});
 			}
+			default:
+				return Promise.reject(new Error(`Not supported file extension: ${ext}`));
 		}
 	}
 
@@ -297,8 +297,8 @@ class MoleculerRunner {
 	 *  Env variable:			`CIRCUITBREAKER_ENABLED`
 	 *
 	 */
-	mergeOptions() {
-		this.config = _.defaultsDeep(this.configFile, ServiceBroker.defaultOptions);
+	mergeOptions(configFromFile) {
+		this.config = _.defaultsDeep(configFromFile, ServiceBroker.defaultOptions);
 
 		this.config = this.overwriteFromEnv(this.config);
 
@@ -525,7 +525,7 @@ class MoleculerRunner {
 		return Promise.resolve()
 			.then(() => this.loadEnvFile())
 			.then(() => this.loadConfigFile())
-			.then(() => this.mergeOptions())
+			.then(configFromFile => this.mergeOptions(configFromFile))
 			.then(() => this.startBroker())
 			.catch(err => {
 				logger.error(err);


### PR DESCRIPTION
## :memo: Description
When using moleculer-runner and a specified `moleculer.config.<ext>` file it should support both of the following:
- Use of default export syntax
- Exporting a function that returns a configuration object

The current flow of the runner is checking if the required `moleculer.config.<ext>` is a function prior to the logic which determines if the configuration file has a default export. This prevents the function from being executed if it is a default export.

This PR makes the following changes:
- Always return a configuration object from `loadConfigFile` even if a configuration file was not found
- Pass the configuration object returned from `loadConfigFile` to `mergeOptions`
- Use the passed configuration object in `mergeOptions` instead of `this.configFile`
- Eliminate use of `this.configFile`
- Change the order of processing in `loadConfigFile` so that the default export check precedes the function check and execution
- Adds support for `.mts` suffixes to the esm runner
- Adds new `moleculer.config.async.ts` and `moleculer.config.ts` files to the runner examples which validate typescript configurations and default exports for use with the runner

### :gem: Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Tested using the newly created runner examples as well as the existing examples for both cjs and esm variants.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
