### PR TITLE
Improve broker error handler types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -985,7 +985,11 @@ declare namespace Moleculer {
 		nodeId?: string;
 	}
 	type BrokerErrorHandlerInfo = BrokerErrorHandlerInfoAction | BrokerErrorHandlerInfoBroker;
-	type BrokerErrorHandler = (err: Error, info: BrokerErrorHandlerInfo) => void;
+	type BrokerErrorHandler = (
+		this: ServiceBroker,
+		err: Error,
+		info: BrokerErrorHandlerInfo
+	) => void;
 
 	type BrokerSyncLifecycleHandler = (broker: ServiceBroker) => void;
 	type BrokerAsyncLifecycleHandler = (broker: ServiceBroker) => void | Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter2 } from "eventemitter2";
-import type { BinaryLike, CipherCCMTypes, CipherGCMTypes, CipherKey, CipherOCBTypes } from 'crypto'
+import type { BinaryLike, CipherCCMTypes, CipherGCMTypes, CipherKey, CipherOCBTypes } from "crypto";
 import type { Worker } from "cluster";
 
 declare namespace Moleculer {
@@ -720,9 +720,7 @@ declare namespace Moleculer {
 		version?: string | number;
 	}
 
-	type ServiceSyncLifecycleHandler<S = ServiceSettingSchema, T = Service<S>> = (
-		this: T
-	) => void;
+	type ServiceSyncLifecycleHandler<S = ServiceSettingSchema, T = Service<S>> = (this: T) => void;
 	type ServiceAsyncLifecycleHandler<S = ServiceSettingSchema, T = Service<S>> = (
 		this: T
 	) => void | Promise<void>;
@@ -975,6 +973,20 @@ declare namespace Moleculer {
 		options?: GenericObject;
 	}
 
+	interface BrokerErrorHandlerInfoAction {
+		ctx: Context;
+		service: Context["service"];
+		action: Context["action"];
+	}
+	interface BrokerErrorHandlerInfoBroker {
+		actionName: string;
+		params: unknown;
+		opts: CallingOptions;
+		nodeId?: string;
+	}
+	type BrokerErrorHandlerInfo = BrokerErrorHandlerInfoAction | BrokerErrorHandlerInfoBroker;
+	type BrokerErrorHandler = (err: Error, info: BrokerErrorHandlerInfo) => void;
+
 	type BrokerSyncLifecycleHandler = (broker: ServiceBroker) => void;
 	type BrokerAsyncLifecycleHandler = (broker: ServiceBroker) => void | Promise<void>;
 
@@ -1008,7 +1020,7 @@ declare namespace Moleculer {
 
 		uidGenerator?: () => string;
 
-		errorHandler?: ((err: Error, info: any) => void) | null;
+		errorHandler?: BrokerErrorHandler;
 
 		cacher?: boolean | Cacher | string | GenericObject | null;
 		serializer?: Serializer | string | GenericObject | null;
@@ -1201,7 +1213,7 @@ declare namespace Moleculer {
 		start(): Promise<void>;
 		stop(): Promise<void>;
 
-		errorHandler(err: Error, info: GenericObject): void;
+		errorHandler(err: Error, info: BrokerErrorHandlerInfo): void;
 
 		wrapMethod(
 			method: string,
@@ -1844,7 +1856,6 @@ declare namespace Moleculer {
 	 * Parsed CLI flags
 	 */
 	interface RunnerFlags {
-
 		/**
 		 * Path to load configuration from a file
 		 */
@@ -1884,7 +1895,6 @@ declare namespace Moleculer {
 		 * File mask for loading services
 		 */
 		mask?: string;
-
 	}
 
 	/**
@@ -2011,12 +2021,16 @@ declare namespace Moleculer {
 			 *   ]
 			 * };
 			 */
-			Encryption: (key: CipherKey, algorithm?: CipherCCMTypes|CipherOCBTypes|CipherGCMTypes|string, iv?: BinaryLike | null)=> Middleware,
+			Encryption: (
+				key: CipherKey,
+				algorithm?: CipherCCMTypes | CipherOCBTypes | CipherGCMTypes | string,
+				iv?: BinaryLike | null
+			) => Middleware;
 			Compression: (opts?: {
 				/**
 				 * @default deflate
 				 */
-				method?: 'gzip' | 'deflate' | 'deflateRaw'
+				method?: "gzip" | "deflate" | "deflateRaw";
 				/**
 				 * Compression middleware reduces the size of the messages that go through the transporter module.
 				 * This middleware uses built-in Node zlib lib.
@@ -2037,11 +2051,11 @@ declare namespace Moleculer {
 				 *   ]
 				 * };
 				 */
-				threshold?: number | string
-			}) => Middleware,
-		}
+				threshold?: number | string;
+			}) => Middleware;
+		};
 	}
-	const Middlewares: MoleculerMiddlewares
+	const Middlewares: MoleculerMiddlewares;
 }
 
 export = Moleculer;


### PR DESCRIPTION
## :memo: Description
The `errorHandler` option that can be supplied to the service broker options has loose type definitions for the `info` parameter. In one case it is defined as `any`, and in the other it is defined as `GenericObject` (i.e. `Record<string,any>`). The signature of the callers to the `errorHandler` is variable, but it falls into two distinct categories: when called from the error handler middleware and when called from other broker workflows. These results in two possible types for the `info` parameter.

This PR updates the type definitions to be more specific about the types for the `info` parameter for the broker's `errorHandler` option.

### :dart: Relevant issues
None

### :gem: Type of change

- [X] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

I patched these changes into my repository and then created a new error handler function which used the `info` parameter.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
