### PR TITLE
fix: Typing of opts Parameter of get*List Methods in Registry

### DIFF
--- a/src/registry/registry.d.ts
+++ b/src/registry/registry.d.ts
@@ -2,6 +2,9 @@ import type ServiceBroker = require("../service-broker");
 import type MetricRegistry = require("../metrics/registry");
 import type BaseStrategy = require("../strategies/base");
 import type { ActionCatalogListOptions } from "./action-catalog";
+import type { ServiceCatalogListOptions } from "./service-catalog";
+import type { NodeCatalogListOptions } from "./node-catalog";
+import type { EventCatalogListOptions } from "./event-catalog";
 import type { Logger } from "../logger-factory";
 import type { ActionSchema, EventSchema } from "../service";
 import type ServiceItem = require("./service-item");
@@ -111,10 +114,10 @@ declare class ServiceRegistry {
 	getNodeInfo(nodeID: string): ServiceRegistry.NodeRawInfo;
 	processNodeInfo(payload: any): any;
 
-	getNodeList(opts?: ActionCatalogListOptions): ReturnType<NodeCatalog["list"]>;
-	getServiceList(opts?: ActionCatalogListOptions): ReturnType<ServiceCatalog["list"]>;
+	getNodeList(opts?: NodeCatalogListOptions): ReturnType<NodeCatalog["list"]>;
+	getServiceList(opts?: ServiceCatalogListOptions): ReturnType<ServiceCatalog["list"]>;
 	getActionList(opts?: ActionCatalogListOptions): ReturnType<ActionCatalog["list"]>;
-	getEventList(opts?: ActionCatalogListOptions): ReturnType<EventCatalog["list"]>;
+	getEventList(opts?: EventCatalogListOptions): ReturnType<EventCatalog["list"]>;
 
 	getNodeRawList(): Array<ServiceRegistry.NodeRawInfo>;
 }


### PR DESCRIPTION
## :memo: Description

In `v0.15.0-beta1` the typing of the `opts` parameter for `getNodeList`, `getServiceList`, and `getEventList` is wrong. They all have the `ActionCatalogListOptions` type. The PR sets the correct type.

### :dart: Relevant issues
None

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

None

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
