### PR TITLE
Don't plugging third-party Promise library for ioredis in RedisTransporter

### DIFF
--- a/src/transporters/redis.js
+++ b/src/transporters/redis.js
@@ -164,7 +164,6 @@ class RedisTransporter extends Transporter {
 		let Redis;
 		try {
 			Redis = require("ioredis");
-			Redis.Promise = this.broker.Promise;
 		} catch (err) {
 			/* istanbul ignore next */
 			this.broker.fatal(

--- a/src/transporters/redis.js
+++ b/src/transporters/redis.js
@@ -1,6 +1,6 @@
 /*
  * moleculer
- * Copyright (c) 2020 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * Copyright (c) 2024 MoleculerJS (https://github.com/moleculerjs/moleculer)
  * MIT Licensed
  */
 
@@ -38,7 +38,7 @@ class RedisTransporter extends Transporter {
 	 * @memberof RedisTransporter
 	 */
 	connect() {
-		return new Promise((resolve, reject) => {
+		return new this.broker.Promise((resolve, reject) => {
 			let clientSub = this.getRedisClient(this.opts);
 			this._clientSub = clientSub; // For tests
 


### PR DESCRIPTION
## 📝  Description

ioredis v5 does not support plugging third-party Promise library anymore.
Now, when Redis transporter starts, the corresponding message is displayed in the console: "ioredis v5 does not support plugging third-party Promise library anymore. Native Promise will be used". See [this](https://github.com/redis/ioredis/blob/af832752040e616daf51621681bcb40cab965a9b/lib/index.ts#L76-L88) block of code in ioredis package.

### 💎  Type of change

- ✅  Bug fix (non-breaking change which fixes an issue)

## 🏁  Checklist:

- ✅  My code follows the style guidelines of this project
- ✅  I have performed a self-review of my own code
- ✅  **I have added tests that prove my fix is effective or that my feature works**
- ✅  **New and existing unit tests pass locally with my changes**
- ✅  I have commented my code, particularly in hard-to-understand areas
