### PR TITLE
Update middleware typings

### DIFF
--- a/src/middleware.d.ts
+++ b/src/middleware.d.ts
@@ -28,7 +28,7 @@ declare namespace MiddlewareHandler {
 		emit?: (next: ServiceBroker['emit']) => ServiceBroker['emit'];
 		broadcast?: (next: ServiceBroker['broadcast']) => ServiceBroker['broadcast'];
 		broadcastLocal?: (next: ServiceBroker['broadcastLocal']) => ServiceBroker['broadcastLocal'];
-		serviceCreating?: (service: Service, schema: Service.Schema) => void;
+		serviceCreating?: (service: Service, schema: Service.ServiceSchema) => void;
 		serviceCreated?: (service: Service) => void;
 		serviceStarting?: (service: Service) => Promise<void>;
 		serviceStarted?: (service: Service) => Promise<void>;

--- a/src/service.d.ts
+++ b/src/service.d.ts
@@ -127,6 +127,7 @@ declare namespace Service {
 		[key: string]: ActionSchema | ActionHandler | boolean;
 	} & ThisType<Service<S>>;
 
+	export type ServiceMethod = (...args: any[]) => any & ThisType<Service>;
 	export type ServiceMethods = { [key: string]: (...args: any[]) => any } & ThisType<Service>;
 
 	export interface ServiceDependency {

--- a/test/typescript/hello-world/index.ts
+++ b/test/typescript/hello-world/index.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as path from "path";
-import { ServiceBroker } from "../../../";
+import { ServiceBroker, Service } from "../../../";
 
 const broker = new ServiceBroker({
 	logger: {
@@ -35,7 +35,17 @@ const broker = new ServiceBroker({
 				}
 			}
 		]
-	}
+	},
+	middlewares: [
+		{
+			localAction(this: Service, next, action) {
+				return ctx => {
+					this.logger.info("Local action middleware", action.name);
+					return next(ctx);
+				};
+			},
+		}
+	]
 });
 
 broker.loadService(path.join(__dirname, "greeter.service.ts"));


### PR DESCRIPTION
## :memo: Description

This makes middleware typings more accurate.  This makes it so when working in typescript a `Middlware` doesn't error out on things such as `name` being included, it alos makes it so that  instead of doing something like this:

```typescript
import { Middleware, ServiceBroker, Transporters } from "moleculer";
import { decrypt, encrypt } from "../util/encryption";

export const EncryptionMiddleware: Middleware = {
  name: "EncryptionMiddleware",

  transporterSend(next: Transporters.Base["send"]): Transporters.Base["send"] {
    return async function (topic: string, data: Buffer, opts: any): Promise<void> {
      const res = Buffer.from(await encrypt(data));
      return next(topic, res, opts);
    };
  },

  transporterReceive(next: Transporters.Base["receive"]): Transporters.Base["receive"] {
    return async function (this: Transporters.Base, cmd: string, data: Buffer, s: any): Promise<void> {
      try {
        const res = Buffer.from(await decrypt(data));
        return next(cmd, res, s);
      } catch (e) {
        this.broker.logger.error(e);
      }
    };
  }
};
```

you can do this:

```typescript
import { Transporters, type Middleware } from "moleculer";
import { decrypt, encrypt } from "../util/encryption.ts";

/**
 * This middleware encrypts and decrypts all transit data. This is similar to Moleculer's built in
 * encryption middleware differing in that it does not require the initialization vector to be 
 * configured in the broker options, but instead using a random IV at encryption time.
 */
export const EncryptionMiddleware: Middleware = {
  name: "EncryptionMiddleware",

  transporterSend(next) {
    return async function (topic, data, opts) {
      const res = Buffer.from(await encrypt(data))
      return next(topic, res, opts)
    }
  },
  transporterReceive(next) {
    return async function (this: Transporters.Base, cmd, data, s) {
      try {
        const res = Buffer.from(await decrypt(data))
        return next(cmd, res, s)
      } catch (e) {
        this.broker.logger.error(e)
      }
    }
  }
}
````
As you can see the typing on this is much cleaner, and easy to use

### :gem: Type of change
- [x] Typescript change