### PR TITLE
fix: updated removePendingRequestByNodeID

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -548,7 +548,7 @@ class Transit {
 			pass.$prevSeq = -1;
 			pass.$pool = new Map();
 
-			this.pendingReqStreams.set(payload.id, pass);
+			this.pendingReqStreams.set(payload.id, { sender: payload.sender, stream: pass });
 		}
 
 		if (payload.seq > pass.$prevSeq + 1) {
@@ -1028,6 +1028,17 @@ class Transit {
 	 */
 	removePendingRequestByNodeID(nodeID) {
 		this.logger.debug(`Remove pending requests of '${nodeID}' node.`);
+
+		// Close pending request streams of the node
+		this.pendingReqStreams.forEach(({ sender, stream }, id) => {
+			if (sender === nodeID) {
+				// Close the stream
+				stream.push(null);
+
+				this.pendingReqStreams.delete(id);
+			}
+		});
+
 		this.pendingRequests.forEach((req, id) => {
 			if (req.nodeID === nodeID) {
 				this.pendingRequests.delete(id);

--- a/src/transit.js
+++ b/src/transit.js
@@ -1035,7 +1035,7 @@ class Transit {
 			if (sender === nodeID) {
 				// Close the stream with error
 				if (!stream.destroyed) {
-					stream.destroy(new Error('Request stream closed by ' + nodeID));
+					stream.destroy(new Error("Request stream closed by " + nodeID));
 				}
 
 				this.pendingReqStreams.delete(id);

--- a/src/transit.js
+++ b/src/transit.js
@@ -1033,7 +1033,9 @@ class Transit {
 		this.pendingReqStreams.forEach(({ sender, stream }, id) => {
 			if (sender === nodeID) {
 				// Close the stream
-				stream.push(null);
+				if (!stream.readableEnded) {
+					stream.push(null);
+				}
 
 				this.pendingReqStreams.delete(id);
 			}

--- a/src/transit.js
+++ b/src/transit.js
@@ -520,7 +520,8 @@ class Transit {
 	 * @returns {Stream}
 	 */
 	_handleIncomingRequestStream(payload) {
-		let pass = this.pendingReqStreams.get(payload.id);
+		const reqStream = this.pendingReqStreams.get(payload.id);
+		let pass = reqStream ? reqStream.stream : undefined;
 		let isNew = false;
 
 		if (!payload.stream && !pass && !payload.seq) {

--- a/src/transit.js
+++ b/src/transit.js
@@ -1035,7 +1035,7 @@ class Transit {
 			if (sender === nodeID) {
 				// Close the stream with error
 				if (!stream.destroyed) {
-					stream.destroy(new Error("Request stream closed by " + nodeID));
+					stream.destroy(new Error(`Request stream closed by ${nodeID}`));
 				}
 
 				this.pendingReqStreams.delete(id);

--- a/src/transit.js
+++ b/src/transit.js
@@ -1033,9 +1033,9 @@ class Transit {
 		// Close pending request streams of the node
 		this.pendingReqStreams.forEach(({ sender, stream }, id) => {
 			if (sender === nodeID) {
-				// Close the stream
-				if (!stream.readableEnded) {
-					stream.push(null);
+				// Close the stream with error
+				if (!stream.destroyed) {
+					stream.destroy(new Error('Request stream closed by ' + nodeID));
 				}
 
 				this.pendingReqStreams.delete(id);


### PR DESCRIPTION
added clean and close this.pendingReqStreams when node disconnected

## :memo: Description
Fixed memory leak when another microservice started stream with broker.call and then switched off (with reboot for example)

Create two services, a caller and a listener
Listener implements an action stream
Caller calls the listener action stream
Make Caller fail (restart microservice) and Listener memory/stream (in src/transit.js -> this.pendingReqStreams) is not released.
Caller calls again
Caller fails again
After several retries listener may throws a out of memory exception.

PS 
this.pendingRequests was **empty** on Listener microservice 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Repo for reproduce this bug
https://github.com/JS-AK/moleculer-pr-1306-example