### PR TITLE
fix: updated closing dangling streams at src/transit.js

### DIFF
--- a/src/transit.js
+++ b/src/transit.js
@@ -1016,8 +1016,8 @@ class Transit {
 	removePendingRequest(id) {
 		this.pendingRequests.delete(id);
 
-		this._softDeletePendingReqStream(id);
-		this._softDeletePendingResStream(id);
+		this.pendingReqStreams.delete(id);
+		this.pendingResStreams.delete(id);
 	}
 
 	/**
@@ -1058,22 +1058,6 @@ class Transit {
 
 	/**
 	 * Internal method to delete a pending response stream from `pendingResStreams`
-	 * and soft-end it (if not already ended) without error.
-	 *
-	 * @param {String} id ID of the stream in `pendingResStreams`
-	 * @memberof Transit
-	 */
-	_softDeletePendingResStream(id) {
-		const stream = this.pendingResStreams.get(id);
-		this.pendingResStreams.delete(id);
-
-		if (stream) {
-			this._destroyStreamIfPossible(stream);
-		}
-	}
-
-	/**
-	 * Internal method to delete a pending response stream from `pendingResStreams`
 	 * and destroy it (if not already destroyed) with error.
 	 *
 	 * @param {String} id ID of the stream in `pendingResStreams`
@@ -1091,23 +1075,6 @@ class Transit {
 
 	/**
 	 * Internal method to delete a pending request stream from `pendingReqStreams`
-	 * and soft-end it (if not already ended) without error.
-	 *
-	 * @param {String} id ID of the stream in `pendingReqStreams`
-	 * @memberof Transit
-	 */
-	_softDeletePendingReqStream(id) {
-		const reqStream = this.pendingReqStreams.get(id);
-		this.pendingReqStreams.delete(id);
-		const pass = reqStream ? reqStream.stream : undefined;
-
-		if (pass) {
-			this._destroyStreamIfPossible(pass);
-		}
-	}
-
-	/**
-	 * Internal method to delete a pending request stream from `pendingReqStreams`
 	 * and destroy it (if not already ended) with error.
 	 *
 	 * @param {String} id ID of the stream in `pendingReqStreams`
@@ -1116,8 +1083,8 @@ class Transit {
 	 */
 	_deletePendingReqStream(id, origin) {
 		const reqStream = this.pendingReqStreams.get(id);
-		this.pendingReqStreams.delete(id);
 		const pass = reqStream ? reqStream.stream : undefined;
+		this.pendingReqStreams.delete(id);
 
 		if (pass) {
 			this._destroyStreamIfPossible(pass, `Stream closed by ${origin}`);
@@ -1134,11 +1101,7 @@ class Transit {
 	 */
 	_destroyStreamIfPossible(stream, errorMessage) {
 		if (!stream.destroyed && stream.destroy) {
-			if (errorMessage) {
-				stream.destroy(new Error(errorMessage));
-			} else {
-				stream.destroy();
-			}
+			stream.destroy(new Error(errorMessage));
 		}
 	}
 

--- a/src/transit.js
+++ b/src/transit.js
@@ -1062,6 +1062,7 @@ class Transit {
 	 *
 	 * @param {String} id ID of the stream in `pendingResStreams`
 	 * @param {String} origin NodeID of the origin of the destroy request
+	 *
 	 * @memberof Transit
 	 */
 	_deletePendingResStream(id, origin) {
@@ -1078,7 +1079,8 @@ class Transit {
 	 * and destroy it (if not already ended) with error.
 	 *
 	 * @param {String} id ID of the stream in `pendingReqStreams`
-	 * @param {String} origin Origin of the request
+	 * @param {String} origin NodeID of the origin of the destroy request
+	 *
 	 * @memberof Transit
 	 */
 	_deletePendingReqStream(id, origin) {
@@ -1095,8 +1097,8 @@ class Transit {
 	 * Internal method to destroy a stream if it is not already destroyed.
 	 *
 	 * @param {DuplexStream} stream - The stream to be destroyed.
-	 * @param {String} [errorMessage] - The error message to be used when destroying.
-	 *                                  If not provided, the stream will be destroyed without an error.
+	 * @param {String} errorMessage - The error message to be used when destroying.
+	 *
 	 * @memberof Transit
 	 */
 	_destroyStreamIfPossible(stream, errorMessage) {

--- a/src/transit.js
+++ b/src/transit.js
@@ -1065,9 +1065,9 @@ class Transit {
 	 */
 	_softDeletePendingResStream(id) {
 		const stream = this.pendingResStreams.get(id);
+		this.pendingResStreams.delete(id);
 
 		if (stream) {
-			this.pendingResStreams.delete(id);
 			this._closeStreamIfPossible(stream);
 		}
 	}
@@ -1082,9 +1082,9 @@ class Transit {
 	 */
 	_deletePendingResStream(id, origin) {
 		const stream = this.pendingResStreams.get(id);
+		this.pendingResStreams.delete(id);
 
 		if (stream) {
-			this.pendingResStreams.delete(id);
 			this._destroyStreamIfPossible(stream, origin);
 		}
 	}
@@ -1098,15 +1098,11 @@ class Transit {
 	 */
 	_softDeletePendingReqStream(id) {
 		const reqStream = this.pendingReqStreams.get(id);
+		this.pendingReqStreams.delete(id);
 		const pass = reqStream ? reqStream.stream : undefined;
 
 		if (pass) {
-			this.pendingReqStreams.delete(id);
 			this._closeStreamIfPossible(pass);
-
-			if (!pass.readableEnded) {
-				pass.push(null);
-			}
 		}
 	}
 
@@ -1120,10 +1116,10 @@ class Transit {
 	 */
 	_deletePendingReqStream(id, origin) {
 		const reqStream = this.pendingReqStreams.get(id);
+		this.pendingReqStreams.delete(id);
 		const pass = reqStream ? reqStream.stream : undefined;
 
 		if (pass) {
-			this.pendingReqStreams.delete(id);
 			this._destroyStreamIfPossible(pass, origin);
 		}
 	}
@@ -1136,7 +1132,7 @@ class Transit {
 	 * @memberof Transit
 	 */
 	_destroyStreamIfPossible(stream, origin) {
-		if (!stream.destroyed) {
+		if (!stream.destroyed && stream.destroy) {
 			const message = origin ? `Stream closed by ${origin}` : "Stream internal error";
 			stream.destroy(new Error(message));
 		}
@@ -1149,7 +1145,7 @@ class Transit {
 	 * @memberof Transit
 	 */
 	_closeStreamIfPossible(stream) {
-		if (!stream.readableEnded) {
+		if (!stream.readableEnded && stream.push) {
 			stream.push(null);
 		}
 	}


### PR DESCRIPTION
added clean and close this.pendingResStreams when node disconnected

## :memo: Description
Fixed memory leak when another microservice started stream with broker.call and then switched off (with reboot for example)

Create 3 services, api-gw, test-1, test-2
api-gw handle request -> test-1
test-1 make stream and send it to test-2
test-2 send answer stream to test-1
test-1 send stream to api-gw
terminate test-2 process


If microservice test-2 was terminated (in active stream process) in api-gw service src/transit.js this.pendingResStreams and this.pendingRequests was not released/deleted

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

It is for close issue 
https://github.com/moleculerjs/moleculer/issues/1296

Repo for reproduce this bug

https://github.com/JS-AK/moleculer-pr-1307-example
