### PR TITLE
Add stopDelay to BrokerRegistryOptions Typescript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -935,6 +935,7 @@ declare namespace Moleculer {
 		strategyOptions?: GenericObject;
 		preferLocal?: boolean;
 		discoverer?: RegistryDiscovererOptions | BaseDiscoverer | string;
+		stopDelay?: number;
 	}
 
 	interface RegistryDiscovererOptions {


### PR DESCRIPTION
## :memo: Description

This change adds `stopDelay` to the `BrokerRegistryOptions` Typescript type as an optional number. This allows Typescript users to override the `stopDelay` property on the broker to give other services more time to update their internal registries during a node shutdown.

### :dart: Relevant issues

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
const broker = new ServiceBroker({
	logger: true,
	registry: {
		stopDelay: 1000
	}
});


``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I built a Typescript service/broker with the `stopDelay` property set in the `registry` options. The project compiled without error.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
