### PR TITLE
fix: updated moleculer-timeout-middleware with streams

### DIFF
--- a/src/middlewares/timeout.js
+++ b/src/middlewares/timeout.js
@@ -6,6 +6,7 @@
 
 "use strict";
 
+const { Stream } = require("stream");
 const { RequestTimeoutError } = require("../errors");
 const { METRIC } = require("../metrics");
 
@@ -38,6 +39,11 @@ module.exports = function (broker) {
 							nodeID,
 							timeout: ctx.options.timeout
 						});
+
+						if (ctx.params instanceof Stream) {
+							ctx.params.emit('moleculer-timeout-middleware', ctx.options.timeout)
+						}
+
 						err = new RequestTimeoutError({ action: actionName, nodeID });
 
 						broker.metrics.increment(METRIC.MOLECULER_REQUEST_TIMEOUT_TOTAL, {

--- a/src/middlewares/timeout.js
+++ b/src/middlewares/timeout.js
@@ -7,6 +7,7 @@
 "use strict";
 
 const { Stream } = require("stream");
+
 const { RequestTimeoutError } = require("../errors");
 const { METRIC } = require("../metrics");
 

--- a/src/middlewares/timeout.js
+++ b/src/middlewares/timeout.js
@@ -42,7 +42,7 @@ module.exports = function (broker) {
 						});
 
 						if (ctx.params instanceof Stream) {
-							ctx.params.emit('moleculer-timeout-middleware', ctx.options.timeout)
+							ctx.params.emit("moleculer-timeout-middleware", ctx.options.timeout);
 						}
 
 						err = new RequestTimeoutError({ action: actionName, nodeID });

--- a/src/transit.js
+++ b/src/transit.js
@@ -551,10 +551,13 @@ class Transit {
 
 			this.pendingReqStreams.set(payload.id, { sender: payload.sender, stream: pass });
 
-			pass.on("moleculer-timeout-middleware", (timeout) => {
+			pass.on("moleculer-timeout-middleware", timeout => {
 				setTimeout(() => {
 					this.pendingReqStreams.delete(payload.id);
-					this._destroyStreamIfPossible(pass, `Pending request stream ${payload.id} have been closed by timeout ${timeout} ms`);
+					this._destroyStreamIfPossible(
+						pass,
+						`Pending request stream ${payload.id} have been closed by timeout ${timeout} ms`
+					);
 				}, 1000);
 			});
 		}
@@ -874,8 +877,11 @@ class Transit {
 		if (request.stream) {
 			const pass = request.ctx.params;
 
-			pass.on("moleculer-timeout-middleware", (timeout) => {
-				this._destroyStreamIfPossible(pass, `Request stream ${ctx.id} have been closed by timeout ${timeout} ms`);
+			pass.on("moleculer-timeout-middleware", timeout => {
+				this._destroyStreamIfPossible(
+					pass,
+					`Request stream ${ctx.id} have been closed by timeout ${timeout} ms`
+				);
 			});
 		}
 
@@ -1118,7 +1124,7 @@ class Transit {
 	 */
 	_destroyStreamIfPossible(stream, errorMessage) {
 		if (!stream.destroyed && stream.destroy) {
-			stream.on("error", (err) => this.logger.error(err.message));
+			stream.on("error", err => this.logger.error(err.message));
 			stream.destroy(new Error(errorMessage));
 		}
 	}

--- a/src/transit.js
+++ b/src/transit.js
@@ -551,12 +551,12 @@ class Transit {
 
 			this.pendingReqStreams.set(payload.id, { sender: payload.sender, stream: pass });
 
-			pass.on('moleculer-timeout-middleware', (timeout) => {
+			pass.on("moleculer-timeout-middleware", (timeout) => {
 				setTimeout(() => {
 					this.pendingReqStreams.delete(payload.id);
-					this._destroyStreamIfPossible(pass, `Pending request stream ${payload.id} have been closed by timeout ${timeout} ms`)
+					this._destroyStreamIfPossible(pass, `Pending request stream ${payload.id} have been closed by timeout ${timeout} ms`);
 				}, 1000);
-			})
+			});
 		}
 
 		if (payload.seq > pass.$prevSeq + 1) {
@@ -872,11 +872,11 @@ class Transit {
 		this.pendingRequests.set(ctx.id, request);
 
 		if (request.stream) {
-			const pass = request.ctx.params
+			const pass = request.ctx.params;
 
-			pass.on('moleculer-timeout-middleware', (timeout) => {
-				this._destroyStreamIfPossible(pass, `Request stream ${ctx.id} have been closed by timeout ${timeout} ms`)
-			})
+			pass.on("moleculer-timeout-middleware", (timeout) => {
+				this._destroyStreamIfPossible(pass, `Request stream ${ctx.id} have been closed by timeout ${timeout} ms`);
+			});
 		}
 
 		// Publish request
@@ -1118,7 +1118,7 @@ class Transit {
 	 */
 	_destroyStreamIfPossible(stream, errorMessage) {
 		if (!stream.destroyed && stream.destroy) {
-			stream.on('error', (err) => this.logger.error(err.message))
+			stream.on("error", (err) => this.logger.error(err.message));
 			stream.destroy(new Error(errorMessage));
 		}
 	}

--- a/src/transit.js
+++ b/src/transit.js
@@ -550,6 +550,13 @@ class Transit {
 			pass.$pool = new Map();
 
 			this.pendingReqStreams.set(payload.id, { sender: payload.sender, stream: pass });
+
+			pass.on('moleculer-timeout-middleware', (timeout) => {
+				setTimeout(() => {
+					this.pendingReqStreams.delete(payload.id);
+					this._destroyStreamIfPossible(pass, `Pending request stream ${payload.id} have been closed by timeout ${timeout} ms`)
+				}, 1000);
+			})
 		}
 
 		if (payload.seq > pass.$prevSeq + 1) {
@@ -864,6 +871,14 @@ class Transit {
 		// Add to pendings
 		this.pendingRequests.set(ctx.id, request);
 
+		if (request.stream) {
+			const pass = request.ctx.params
+
+			pass.on('moleculer-timeout-middleware', (timeout) => {
+				this._destroyStreamIfPossible(pass, `Request stream ${ctx.id} have been closed by timeout ${timeout} ms`)
+			})
+		}
+
 		// Publish request
 		return this.publish(packet)
 			.then(() => {
@@ -1103,6 +1118,7 @@ class Transit {
 	 */
 	_destroyStreamIfPossible(stream, errorMessage) {
 		if (!stream.destroyed && stream.destroy) {
+			stream.on('error', (err) => this.logger.error(err.message))
 			stream.destroy(new Error(errorMessage));
 		}
 	}


### PR DESCRIPTION
Added clean and close this.pendingReqStreams when request from another microservice was timeouted before sent answer

## :memo: Description
Fixed memory leak when another microservice started stream with broker.call and then timeouted

Create 3 services, api-gw, test-1, test-2
api-gw handle request -> test-1
test-1 make stream and send it to test-2
test-2 await time to handle timeout at test-1

If microservice test-2 handle timeot this.pendingRequests was not released/deleted

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Repo for reproduce this bug

https://github.com/JS-AK/moleculer-pr-1313-example
