### PR TITLE
add legacy mode to jaeger tracing exporter to support 128bit trace ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -894,16 +894,6 @@
 			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
 			"dev": true
 		},
-		"@icebob/node-memwatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@icebob/node-memwatch/-/node-memwatch-2.1.0.tgz",
-			"integrity": "sha512-tP0D6XzNDajM5XTdC0XrFQJO7SdfybeJf93lm+leP9l9ph4CxiN7rL7Bi3jm1LpP24R5nS7HpPgrGXZLQoo6xg==",
-			"dev": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"nan": "^2.14.1"
-			}
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2512,6 +2502,7 @@
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -4759,7 +4750,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"fill-range": {
 			"version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "author": "MoleculerJS",
   "license": "MIT",
   "devDependencies": {
-    "@icebob/node-memwatch": "^2.1.0",
     "@sinonjs/fake-timers": "^9.1.2",
     "@types/bunyan": "^1.8.11",
     "@types/ioredis": "^4.28.10",

--- a/src/tracing/exporters/jaeger.js
+++ b/src/tracing/exporters/jaeger.js
@@ -1,6 +1,6 @@
 /*
  * moleculer
- * Copyright (c) 2020 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * Copyright (c) 2025 MoleculerJS (https://github.com/moleculerjs/moleculer)
  * MIT Licensed
  */
 


### PR DESCRIPTION
…32 digits) trace ids

## :memo: Description

Add support for the 128bit trace ids to be compatible with opentelemetry

Trace context: https://www.w3.org/TR/trace-context/#trace-id
Jaeger FAQ: https://www.jaegertracing.io/docs/2.0/faq/

### :dart: Relevant issues
#1311 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] This change requires a documentation update

### :scroll: Example code
```js
tracing: {
  enabled: true,
  exporter: {
    type: "Jaeger",
    options: {
    legacyMode: false
    }
  }
}
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [x] Manual test with local otel collector:

Output from otel debug exporter

```
Span #1
    Trace ID       : adf6f571b8324c6eb6f65b64b4562450
    Parent ID      :
    ID             : adf6f571b8324c6e
    Name           : action 'math.add'
    Kind           : Server
    Start time     : 2025-01-06 15:28:15.496 +0000 UTC
    End time       : 2025-01-06 15:28:15.496943 +0000 UTC
    Status code    : Unset
    Status message :
```

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
