### PR TITLE
Add new option for initial services dependencies

### DIFF
--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -86,7 +86,8 @@ export default class MoleculerRunner {
 			.option("env", "Load .env file from the current directory")
 			.option("envfile", "Load a specified .env file")
 			.option("instances", "Launch [number] instances node (load balanced)")
-			.option("mask", "Filemask for service loading");
+			.option("mask", "Filemask for service loading")
+			.option("dependencies", "List of global dependencies for all services");
 
 		this.flags = Args.parse(procArgs, {
 			mri: {
@@ -98,12 +99,17 @@ export default class MoleculerRunner {
 					e: "env",
 					E: "envfile",
 					i: "instances",
-					m: "mask"
+					m: "mask",
+					d: "dependencies"
 				},
 				boolean: ["repl", "silent", "hot", "env"],
-				string: ["config", "envfile", "mask"]
+				string: ["config", "envfile", "mask", "dependencies"]
 			}
 		});
+
+		if (this.flags.dependencies) {
+			this.flags.dependencies = this.flags.dependencies.split(",").map(dep => dep.trim());
+		}
 
 		this.servicePaths = Args.sub;
 	}

--- a/src/runner.js
+++ b/src/runner.js
@@ -83,7 +83,8 @@ class MoleculerRunner {
 			.option("env", "Load .env file from the current directory")
 			.option("envfile", "Load a specified .env file")
 			.option("instances", "Launch [number] instances node (load balanced)")
-			.option("mask", "Filemask for service loading");
+			.option("mask", "Filemask for service loading")
+			.option("dependencies", "List of global dependencies for all services");
 
 		this.flags = Args.parse(procArgs, {
 			mri: {
@@ -95,12 +96,17 @@ class MoleculerRunner {
 					e: "env",
 					E: "envfile",
 					i: "instances",
-					m: "mask"
+					m: "mask",
+					d: "dependencies"
 				},
 				boolean: ["repl", "silent", "hot", "env"],
-				string: ["config", "envfile", "mask"]
+				string: ["config", "envfile", "mask", "dependencies"]
 			}
 		});
+
+		if (this.flags.dependencies) {
+			this.flags.dependencies = this.flags.dependencies.split(",").map(dep => dep.trim());
+		}
 
 		this.servicePaths = Args.sub;
 	}
@@ -306,6 +312,8 @@ class MoleculerRunner {
 		if (this.flags.silent) this.config.logger = false;
 
 		if (this.flags.hot) this.config.hotReload = true;
+
+		if (this.flags.dependencies) this.config.initialDependencies = this.flags.dependencies;
 
 		// console.log("Merged configuration", this.config);
 	}

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -46,6 +46,8 @@ const defaultOptions = {
 
 	errorRegenerator: null,
 
+	initialDependencies: [],
+
 	requestTimeout: 0 * 1000,
 	retryPolicy: {
 		enabled: false,

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -166,6 +166,7 @@ describe("Test ServiceBroker constructor", () => {
 				enabled: true,
 				retries: 3
 			},
+			initialDependencies: [],
 			contextParamsCloning: true,
 			maxCallLevel: 10,
 			requestTimeout: 5000,
@@ -280,6 +281,7 @@ describe("Test ServiceBroker constructor", () => {
 				factor: 2,
 				check: expect.any(Function)
 			},
+			initialDependencies: [],
 			requestTimeout: 5000,
 			maxCallLevel: 10,
 			maxSafeObjectSize: null,


### PR DESCRIPTION
## :memo: Description

At the company where I work, we recently encountered a challenge with MoleculerJS. We needed to initialize a service responsible for managing database connections before all the other services we have built (which currently number in the hundreds). The solution we found was to add the dependencies field to the schema of every service, referencing the name of the service we wanted the others to wait for. This led to the development of an improvement where we can pass the --dependencies option in the runner, specifying the names of the services that all other services should wait for to load. Alternatively, we can simply add them to the initialDependencies array in the broker.

### :dart: Relevant issues
N/A

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
const broker = new ServiceBroker({
    initialDependencies: ['databases-service']
});
``` 

ts-node ./node_modules/moleculer/bin/moleculer-runner.js --hot --repl --config moleculer.config.ts services/**/*.services.ts --dependencies databases-service

## :vertical_traffic_light: How Has This Been Tested?

To test it, simply create two services and set one as a dependency. If you're using the runner, you can pass the --dependencies option. If you're manually instantiating the broker, you can use the initialDependencies option in the settings. Run the program and check if it waits for the dependent service to start before starting the other.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas
