### PR TITLE
Fixed loss of "this" identifier inside callMiddlewareInterceptor.

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -394,8 +394,10 @@ class ServiceBroker {
 	 * It is necessary to keep the context of the call when using call middleware.
 	 */
 	interceptCallMiddleware(createMiddleware) {
+		// We need to use ordinary function here, so "this" identifier can be bound to it later via call method.
 		return function (next) {
 			let result = null;
+			// Preserve "this" identifier inside intercepted middleware.
 			const call = createMiddleware.call(this, (...args) => (result = next(...args)));
 			return (...args) => {
 				const promise = call(...args);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -394,9 +394,9 @@ class ServiceBroker {
 	 * It is necessary to keep the context of the call when using call middleware.
 	 */
 	interceptCallMiddleware(createMiddleware) {
-		return next => {
+		return function (next) {
 			let result = null;
-			const call = createMiddleware((...args) => (result = next(...args)));
+			const call = createMiddleware.call(this, (...args) => (result = next(...args)));
 			return (...args) => {
 				const promise = call(...args);
 				if (result) promise.ctx = result.ctx;

--- a/test/integration/middlewares.spec.js
+++ b/test/integration/middlewares.spec.js
@@ -11,6 +11,18 @@ describe("Test middleware system", () => {
 			middlewares: [
 				{
 					call(next) {
+						return (...args) => {
+							if (this.nodeID !== broker.nodeID) {
+								throw new Error(
+									"This identifier inside call middleware is incorrect."
+								);
+							}
+							return next(...args);
+						};
+					}
+				},
+				{
+					call(next) {
 						return (actionName, params, opts) => {
 							return next(actionName, params, opts).then(res => {
 								return res;
@@ -56,7 +68,7 @@ describe("Test middleware system", () => {
 		beforeAll(() => broker.start());
 		afterAll(() => broker.stop());
 
-		it("The context is passed through the call middlware.", async () => {
+		it("The context is passed through the call middleware.", async () => {
 			const p = broker.call("test.testAction");
 			await expect(p).resolves.toBe("testmeta!");
 			expect(p.ctx).toBeDefined();

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -543,6 +543,24 @@ describe("Test broker.interceptCallMiddleware", () => {
 		expect(result.ctx).toEqual({ test: "test" });
 		await expect(result).resolves.toBe("middleware-result");
 	});
+
+	it("call interceptor should preserve this identifier", async () => {
+		const testThis = "test-this";
+
+		const createTestMiddleware = function (next) {
+			return async (...args) => {
+				await next(...args);
+				// This must be equal to testThis.
+				return this;
+			};
+		};
+
+		const createInterceptedMiddleware = broker.interceptCallMiddleware(createTestMiddleware);
+
+		const result = createInterceptedMiddleware.call(testThis, () => Promise.resolve())();
+
+		await expect(result).resolves.toBe(testThis);
+	});
 });
 
 describe("Test broker.start", () => {


### PR DESCRIPTION
## :memo: Description

When adding a solution for the problem of losing context when using call middleware in pull request https://github.com/moleculerjs/moleculer/pull/1270, a bug was made that leads to the loss of the "this" identifier inside the middleware wrapped by interceptors. To solve this problem, the code of the interceptCallMiddleware method was reworked so that it returns a ordinary function instead of an arrow function, which will later allow it to be correctly executed from call methods to preserve the "this" identifier.

The necessary tests were added.

### :dart: Relevant issues
#1317 

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration middlware test "Test hook middleware interceptors".
- [x] Unit service broker test "Test broker.interceptCallMiddleware".

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas

Two unit tests failed for me locally both before and after my changes:
- Test EncryptionMiddleware › should decrypt data with IV
- Test EncryptionMiddleware › should encrypt the data