### PR TITLE
Fix BaseValidator constructor typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1503,7 +1503,7 @@ declare namespace Moleculer {
 	};
 
 	class BaseValidator {
-		constructor();
+		constructor(opts?: { paramName?: string });
 		init(broker: ServiceBroker): void;
 		compile(schema: GenericObject): Function;
 		validate(params: GenericObject, schema: GenericObject): boolean;


### PR DESCRIPTION
## :memo: Description

When looking at BaseValidator, the constructor accepts the name of the param to use for validation.
This was not reflected in the .d.ts

### :dart: Relevant issues

I did not open any issue for this.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

In the current version, this has a TS error.
With the fix, the TS error is gone
```
class MyValidator extends Validators.Base {
  constructor() {
    super({ paramName: 'schema' });
  }
  
  [...]
}
  ```

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
