### PR TITLE
middleware type enhancement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -661,12 +661,18 @@ declare namespace Moleculer {
 		params: any,
 		opts: CallingOptions
 	) => Promise<any>;
+	type MethodHandler = {
+		name: string;
+		service: Service;
+		handler: Function;
+		tracing?: boolean;
+	};
 	type Middleware = {
 		name?: string;
 		localAction?: ((this: ServiceBroker, next: ActionHandler, action: ActionSchema) => (...args : any[]) => ActionHandler);
 		remoteAction?: ((this: ServiceBroker, next: ActionHandler, action: ActionSchema) => (...args : any[]) => ActionHandler);
 		localEvent?: ((this: ServiceBroker, next: ActionHandler, event: ServiceEvent) => (...args : any[]) => ActionHandler);
-		localMethod?: ((this: ServiceBroker, next: ActionHandler, method: any) => (...args : any[]) => ActionHandler);
+		localMethod?: ((this: ServiceBroker, handler: MethodHandler['handler'], method: MethodHandler) => any);
 		createService?: ((this: ServiceBroker, next: ActionHandler) => (...args : any[]) => Function);
 		destroyService?: ((this: ServiceBroker, next: ActionHandler) => (...args : any[]) => Function);
 		call?: ((this: ServiceBroker, next: ActionHandler) => (...args : any[]) => Function);


### PR DESCRIPTION
fix: there was no **name** field in the middleware specification

https://moleculer.services/docs/0.15/middlewares

and doc issue:

https://moleculer.services/docs/0.15/middlewares#localMethod-next-method

`localMethod(next, method) {` => need replace by => `localMethod(**handler**, method) {`

( https://github.com/moleculerjs/moleculer/blob/master/src/service.js#L429 )