### PR TITLE
fix(types): added 'TracerExporters' interface into 'TracerOptions' according to docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare namespace Moleculer {
 
 	interface TracerOptions {
 		enabled?: boolean;
-		exporter?: string | TracerExporterOptions | (TracerExporterOptions | string)[] | null;
+		exporter?: string | TracerExporterOptions | (TracerExporterOptions | string)[] | TracerExporters | TracerExporters[] | null;
 		sampling?: {
 			rate?: number | null;
 			tracesPerSecond?: number | null;


### PR DESCRIPTION
…

## :memo: Description

Added ability to declare custom TracerExporter instance using TypeScript according to docs: https://moleculer.services/docs/0.14/tracing.html#Customer-Exporter

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```ts
// moleculer.config.ts
import type { BrokerOptions } from "moleculer";
// instance of TracerExporters.Jaeger for example
import { MyTracingExporters } from "./my-tracing-exporter";

export default {
    tracing: {
        enabled: true,
        exporter: new MyTracingExporters() // or [ new MyTracingExporters() ]
    }
} as BrokerOptions;
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
