### PR TITLE
Remove context from tracking when handler throws an error

### DIFF
--- a/src/middlewares/context-tracker.js
+++ b/src/middlewares/context-tracker.js
@@ -44,7 +44,14 @@ module.exports = function ContextTrackerMiddleware(broker) {
 				addContext(ctx);
 
 				// Call the handler
-				let p = handler(ctx);
+				let p;
+				try{
+					p = handler(ctx);
+				} catch(error) {
+					removeContext(ctx);
+					throw error;
+				}
+				
 
 				p = p
 					.then(res => {


### PR DESCRIPTION
Prerequisites
Please answer the following questions for yourself before submitting an issue.


I am running the latest version

I checked the documentation and found no answer
[] I checked to make sure that this issue has not already been filed

I'm reporting the issue to the correct repository
Current Behavior
After the validation error, the context is not removed from tracking, and graceful shutdown can't be executed.

Expected Behavior
To be removed from tracking.

Failure Information
When an error is thrown on this line, the catch and then the promise are not defined:
https://github.com/moleculerjs/moleculer/blob/master/src/middlewares/context-tracker.js#L47

Steps to Reproduce
Run the API service, and the first one that is defined on the alias must have parameter validation.

When the API is triggered with incorrect parameters, the context is not removed.

There is a message: "Waiting for 2 running context(s)..."