### PR TITLE
Forward termination signals to cluster workers in runner

### DIFF
--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -474,6 +474,11 @@ export default class MoleculerRunner {
 			process.on(signal, () => {
 				logger.info(`Got ${signal}, stopping workers...`);
 				stopping = true;
+				// Forward termination signals to workers so they can cleanup gracefully
+				for (const id in cluster.workers) {
+					logger.info(`Forwarding ${signal} to worker ${id}...`);
+					cluster.workers[id].process.kill(signal);
+				}
 				cluster.disconnect(function () {
 					logger.info("All workers stopped, exiting.");
 					process.exit(0);

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -474,10 +474,15 @@ export default class MoleculerRunner {
 			process.on(signal, () => {
 				logger.info(`Got ${signal}, stopping workers...`);
 				stopping = true;
-				// Forward termination signals to workers so they can cleanup gracefully
-				for (const id in cluster.workers) {
-					logger.info(`Forwarding ${signal} to worker ${id}...`);
-					cluster.workers[id].process.kill(signal);
+				// Forward termination signals to workers so they can cleanup gracefully.
+				// Skip on Windows: process.kill would terminate the workers immediately
+				// without running their signal handlers, and console events (Ctrl+C)
+				// reach the workers there anyway.
+				if (process.platform !== "win32") {
+					for (const id in cluster.workers) {
+						logger.info(`Forwarding ${signal} to worker ${id}...`);
+						cluster.workers[id].process.kill(signal);
+					}
 				}
 				cluster.disconnect(function () {
 					logger.info("All workers stopped, exiting.");

--- a/src/runner.js
+++ b/src/runner.js
@@ -473,6 +473,11 @@ class MoleculerRunner {
 			process.on(signal, () => {
 				logger.info(`Got ${signal}, stopping workers...`);
 				stopping = true;
+				// Forward termination signals to workers so they can cleanup gracefully
+				for (const id in cluster.workers) {
+					logger.info(`Forwarding ${signal} to worker ${id}...`);
+					cluster.workers[id].process.kill(signal);
+				}
 				cluster.disconnect(function () {
 					logger.info("All workers stopped, exiting.");
 					process.exit(0);

--- a/src/runner.js
+++ b/src/runner.js
@@ -473,10 +473,15 @@ class MoleculerRunner {
 			process.on(signal, () => {
 				logger.info(`Got ${signal}, stopping workers...`);
 				stopping = true;
-				// Forward termination signals to workers so they can cleanup gracefully
-				for (const id in cluster.workers) {
-					logger.info(`Forwarding ${signal} to worker ${id}...`);
-					cluster.workers[id].process.kill(signal);
+				// Forward termination signals to workers so they can cleanup gracefully.
+				// Skip on Windows: process.kill would terminate the workers immediately
+				// without running their signal handlers, and console events (Ctrl+C)
+				// reach the workers there anyway.
+				if (process.platform !== "win32") {
+					for (const id in cluster.workers) {
+						logger.info(`Forwarding ${signal} to worker ${id}...`);
+						cluster.workers[id].process.kill(signal);
+					}
 				}
 				cluster.disconnect(function () {
 					logger.info("All workers stopped, exiting.");


### PR DESCRIPTION
Problem: when running with --instances in Docker/K8s, cluster workers didn’t receive SIGTERM, so they skipped graceful shutdown.
Fix: on stop signals, forward the signal to each cluster.worker before cluster.disconnect in runner.js and runner-esm.mjs.
Scope: stop handling only; no other behavior changes.
