### PR TITLE
Update mergeOptions signature

### DIFF
--- a/src/runner.d.ts
+++ b/src/runner.d.ts
@@ -114,7 +114,7 @@ declare class Runner {
 	/**
 	 * Merge broker options from config file & env variables
 	 */
-	mergeOptions(): void;
+	mergeOptions(configFromFile: Partial<BrokerOptions>): void;
 
 	/**
 	 * Check if a path is a directory


### PR DESCRIPTION
This fixes the type definition of `mergeOptions` to match what's in the code:

https://github.com/moleculerjs/moleculer/blob/master/src/runner.js#L315

> **Note:** originally this patched `index.d.ts`. Since then the typings were split out into separate `src/*.d.ts` files, so the change now applies to [`src/runner.d.ts`](https://github.com/moleculerjs/moleculer/blob/master/src/runner.d.ts#L117). Rebased onto `master` by a maintainer; the fix itself is unchanged.
