### PR TITLE
feat(testing): add Testing helpers (createBroker, EventCatcher, MockingCalls)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2059,6 +2059,70 @@ declare namespace Moleculer {
 		};
 	}
 	const Middlewares: MoleculerMiddlewares;
+
+	// ─── Testing Helpers ────────────────────────────────────────────────────────
+
+	/** Entry recorded by EventCatcher for each intercepted event. */
+	interface CapturedEvent {
+		type: "emit" | "broadcast" | "broadcastLocal";
+		eventName: string;
+		payload: any;
+		opts: any;
+	}
+
+	/** Entry recorded by MockingCalls for each intercepted call. */
+	interface CapturedCall {
+		actionName: string;
+		params: any;
+		opts: any;
+	}
+
+	/** Fluent builder returned by broker.test.mockAction(). */
+	interface MockBuilder {
+		/** Constrain this mock to calls whose params deep-equals `params`. */
+		withParams(params: object): MockBuilder;
+		/** Constrain this mock to calls whose meta deep-equals `meta`. */
+		withMeta(meta: object): MockBuilder;
+		/** Resolve with `value` when a matching call is intercepted (registers mock). */
+		returnValue(value: any): MockBuilder;
+		/** Reject with `error` when a matching call is intercepted (registers mock). */
+		rejectWith(error: Error | string): MockBuilder;
+	}
+
+	/** Test helpers attached to the broker by EventCatcher and MockingCalls. */
+	interface BrokerTestHelper {
+		// ── EventCatcher ──────────────────────────────────────────────────────
+		eventEmitted(eventName: string): boolean;
+		eventEmittedTimes(eventName: string): number;
+		eventEmittedWithParams(eventName: string, params: object): boolean;
+		getEvents(eventName?: string): CapturedEvent[];
+		waitForEvent(eventName: string, timeout?: number): Promise<CapturedEvent>;
+		clearEvents(): void;
+
+		// ── MockingCalls ──────────────────────────────────────────────────────
+		mockAction(actionName: string): MockBuilder;
+		actionCalled(actionName: string): boolean;
+		actionCalledTimes(actionName: string): number;
+		actionCalledWithParams(actionName: string, params: object): boolean;
+		getCalls(actionName?: string): CapturedCall[];
+		clearActions(): void;
+		clearMocks(): void;
+		clearAll(): void;
+	}
+
+	/** `EventCatcher` middleware factory. Returned middleware records events. */
+	function EventCatcher(): Middleware;
+
+	/** `MockingCalls` middleware factory. Returned middleware intercepts calls. */
+	function MockingCalls(): Middleware;
+
+	interface TestingModule {
+		createBroker(options?: BrokerOptions, mockServices?: ServiceSchema[]): ServiceBroker;
+		EventCatcher: typeof EventCatcher;
+		MockingCalls: typeof MockingCalls;
+	}
+
+	const Testing: TestingModule;
 }
 
 export = Moleculer;

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = {
 
 	Runner: require("./src/runner"),
 	Utils: require("./src/utils"),
+	Testing: require("./src/testing"),
 
 	CIRCUIT_CLOSE,
 	CIRCUIT_HALF_OPEN,

--- a/index.mjs
+++ b/index.mjs
@@ -29,3 +29,4 @@ export const Transporters = mod.Transporters;
 export const Utils = mod.Utils;
 export const Validator = mod.Validator;
 export const Validators = mod.Validators;
+export const Testing = mod.Testing;

--- a/src/testing/event-catcher.js
+++ b/src/testing/event-catcher.js
@@ -1,0 +1,172 @@
+/*
+ * moleculer
+ * Copyright (c) 2024 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const EventEmitter = require("events");
+
+/**
+ * EventCatcher middleware for Moleculer testing.
+ *
+ * Intercepts `emit`, `broadcast`, and `broadcastLocal` calls on the broker,
+ * recording every event for later assertion. Attaches a `broker.test` namespace
+ * with assertion helpers.
+ *
+ * Usage (standalone):
+ *   broker = new ServiceBroker({ middlewares: [EventCatcher()] });
+ *
+ * Usage (via createBroker):
+ *   broker = createBroker(); // EventCatcher included automatically
+ *
+ * @returns {Object} Moleculer middleware object
+ */
+function EventCatcher() {
+	/** @type {Array<{type: string, eventName: string, payload: *, opts: *}>} */
+	const capturedEvents = [];
+
+	/** Internal emitter used to wake up waitForEvent promises without polling */
+	const notifier = new EventEmitter();
+	notifier.setMaxListeners(100);
+
+	/**
+	 * Record an intercepted event.
+	 * @param {string} type - "emit" | "broadcast" | "broadcastLocal"
+	 * @param {string} eventName
+	 * @param {*} payload
+	 * @param {*} opts
+	 */
+	function recordEvent(type, eventName, payload, opts) {
+		const entry = { type, eventName, payload, opts };
+		capturedEvents.push(entry);
+		notifier.emit(eventName, entry);
+	}
+
+	return {
+		name: "EventCatcher",
+
+		/**
+		 * Called by Moleculer after the broker is created.
+		 * Attaches assertion helpers to `broker.test`.
+		 * @param {import("../service-broker")} broker
+		 */
+		created(broker) {
+			if (!broker.test) broker.test = {};
+
+			/**
+			 * Check whether a named event was emitted at least once.
+			 * @param {string} eventName
+			 * @returns {boolean}
+			 */
+			broker.test.eventEmitted = function eventEmitted(eventName) {
+				return capturedEvents.some(e => e.eventName === eventName);
+			};
+
+			/**
+			 * Return the number of times a named event was emitted.
+			 * @param {string} eventName
+			 * @returns {number}
+			 */
+			broker.test.eventEmittedTimes = function eventEmittedTimes(eventName) {
+				return capturedEvents.filter(e => e.eventName === eventName).length;
+			};
+
+			/**
+			 * Check whether a named event was emitted with a specific payload.
+			 * Uses deep equality (JSON serialization).
+			 * @param {string} eventName
+			 * @param {*} params
+			 * @returns {boolean}
+			 */
+			broker.test.eventEmittedWithParams = function eventEmittedWithParams(
+				eventName,
+				params
+			) {
+				const expected = JSON.stringify(params);
+				return capturedEvents.some(e => {
+					if (e.eventName !== eventName) return false;
+					return JSON.stringify(e.payload) === expected;
+				});
+			};
+
+			/**
+			 * Return captured events, optionally filtered by name.
+			 * @param {string} [eventName] - If provided, return only events with this name.
+			 * @returns {Array}
+			 */
+			broker.test.getEvents = function getEvents(eventName) {
+				if (eventName) return capturedEvents.filter(e => e.eventName === eventName);
+				return capturedEvents.slice();
+			};
+
+			/**
+			 * Wait until the named event is emitted (or has already been captured).
+			 * Resolves with the event entry. Rejects after `timeout` ms.
+			 *
+			 * @param {string} eventName
+			 * @param {number} [timeout=5000] - Milliseconds before rejecting
+			 * @returns {Promise<{type: string, eventName: string, payload: *, opts: *}>}
+			 */
+			broker.test.waitForEvent = function waitForEvent(eventName, timeout = 5000) {
+				// Check if already captured
+				const existing = capturedEvents.find(e => e.eventName === eventName);
+				if (existing) return Promise.resolve(existing);
+
+				return new Promise((resolve, reject) => {
+					let timer;
+
+					function onEvent(entry) {
+						clearTimeout(timer);
+						resolve(entry);
+					}
+
+					timer = setTimeout(() => {
+						notifier.removeListener(eventName, onEvent);
+						reject(
+							new Error(
+								`Timeout waiting for event "${eventName}" after ${timeout}ms`
+							)
+						);
+					}, timeout);
+
+					notifier.once(eventName, onEvent);
+				});
+			};
+
+			/**
+			 * Clear all captured event records.
+			 */
+			broker.test.clearEvents = function clearEvents() {
+				capturedEvents.length = 0;
+			};
+		},
+
+		/** @param {Function} next */
+		emit(next) {
+			return function (eventName, payload, opts) {
+				recordEvent("emit", eventName, payload, opts);
+				return next(eventName, payload, opts);
+			};
+		},
+
+		/** @param {Function} next */
+		broadcast(next) {
+			return function (eventName, payload, opts) {
+				recordEvent("broadcast", eventName, payload, opts);
+				return next(eventName, payload, opts);
+			};
+		},
+
+		/** @param {Function} next */
+		broadcastLocal(next) {
+			return function (eventName, payload, opts) {
+				recordEvent("broadcastLocal", eventName, payload, opts);
+				return next(eventName, payload, opts);
+			};
+		}
+	};
+}
+
+module.exports = EventCatcher;

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,0 +1,60 @@
+/*
+ * moleculer
+ * Copyright (c) 2024 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const EventCatcher = require("./event-catcher");
+const MockingCalls = require("./mocking-calls");
+
+/**
+ * Create a {@link ServiceBroker} pre-configured for unit testing.
+ *
+ * The broker is created with:
+ * - `logger: false` — silences all output during tests
+ * - `test: true` — marks the broker as a test instance
+ * - `EventCatcher` middleware — records every emitted event
+ * - `MockingCalls` middleware — intercepts and optionally mocks action calls
+ *
+ * Any options passed as the first argument are merged on top of those defaults.
+ * Additional middlewares supplied in `options.middlewares` are appended after
+ * the test middlewares, so they receive the already-recorded call.
+ *
+ * @example
+ * const { createBroker } = require("moleculer").Testing;
+ * const broker = createBroker();
+ * await broker.start();
+ * // … run tests …
+ * await broker.stop();
+ *
+ * @param {Object}  [options={}]      - ServiceBroker options (merged with test defaults)
+ * @param {Array}   [mockServices=[]] - Service schemas to register before start
+ * @returns {import("../service-broker")}
+ */
+function createBroker(options = {}, mockServices = []) {
+	const ServiceBroker = require("../service-broker");
+
+	const userMiddlewares = Array.isArray(options.middlewares) ? options.middlewares : [];
+
+	const broker = new ServiceBroker(
+		Object.assign({}, options, {
+			logger: false,
+			test: true,
+			middlewares: [EventCatcher(), MockingCalls(), ...userMiddlewares]
+		})
+	);
+
+	for (const schema of mockServices) {
+		broker.createService(schema);
+	}
+
+	return broker;
+}
+
+module.exports = {
+	createBroker,
+	EventCatcher,
+	MockingCalls
+};

--- a/src/testing/mocking-calls.js
+++ b/src/testing/mocking-calls.js
@@ -1,0 +1,248 @@
+/*
+ * moleculer
+ * Copyright (c) 2024 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+/**
+ * MockingCalls middleware for Moleculer testing.
+ *
+ * Intercepts `broker.call`, records every invocation, and can return mock
+ * responses for registered action names. Attaches a `broker.test` namespace
+ * with assertion and mock-registration helpers.
+ *
+ * Usage (standalone):
+ *   broker = new ServiceBroker({ middlewares: [MockingCalls()] });
+ *
+ * Usage (via createBroker):
+ *   broker = createBroker(); // MockingCalls included automatically
+ *
+ * @returns {Object} Moleculer middleware object
+ */
+function MockingCalls() {
+	/** @type {Array<{actionName: string, params: *, opts: *}>} */
+	const capturedCalls = [];
+
+	/**
+	 * Registered mocks. Each entry is a mock descriptor produced by mockAction().
+	 * @type {Array<MockDescriptor>}
+	 */
+	const mocks = [];
+
+	/**
+	 * Find the first mock that matches the given call.
+	 * A mock matches when:
+	 *   - actionName matches exactly
+	 *   - if mock.params is defined, params deep-equals mock.params
+	 *   - if mock.meta is defined, meta deep-equals mock.meta
+	 *
+	 * @param {string} actionName
+	 * @param {*} params
+	 * @param {*} meta
+	 * @returns {MockDescriptor|null}
+	 */
+	function findMock(actionName, params, meta) {
+		for (const mock of mocks) {
+			if (mock.actionName !== actionName) continue;
+			if (mock.matchParams !== undefined) {
+				if (JSON.stringify(params) !== JSON.stringify(mock.matchParams)) continue;
+			}
+			if (mock.matchMeta !== undefined) {
+				if (JSON.stringify(meta) !== JSON.stringify(mock.matchMeta)) continue;
+			}
+			return mock;
+		}
+		return null;
+	}
+
+	return {
+		name: "MockingCalls",
+
+		/**
+		 * Called by Moleculer after the broker is created.
+		 * Attaches assertion helpers and the mock registration API to `broker.test`.
+		 * @param {import("../service-broker")} broker
+		 */
+		created(broker) {
+			if (!broker.test) broker.test = {};
+
+			/**
+			 * Register a mock for an action call.
+			 *
+			 * Returns a fluent builder:
+			 *   .withParams(params)  — only match calls with these params
+			 *   .withMeta(meta)      — only match calls with this meta
+			 *   .returnValue(value)  — resolve with value (registers the mock)
+			 *   .rejectWith(error)   — reject with error (registers the mock)
+			 *
+			 * The mock is only added to the active mock list when `.returnValue()`
+			 * or `.rejectWith()` is called. This avoids half-configured mocks
+			 * silently intercepting calls.
+			 *
+			 * @param {string} actionName
+			 * @returns {MockBuilder}
+			 */
+			broker.test.mockAction = function mockAction(actionName) {
+				/** @type {MockDescriptor} */
+				const descriptor = {
+					actionName,
+					matchParams: undefined,
+					matchMeta: undefined,
+					resolveValue: undefined,
+					rejectError: undefined,
+					_registered: false
+				};
+
+				const builder = {
+					/**
+					 * Constrain this mock to calls that pass params deep-equal to `params`.
+					 * @param {*} params
+					 * @returns {MockBuilder}
+					 */
+					withParams(params) {
+						descriptor.matchParams = params;
+						return builder;
+					},
+
+					/**
+					 * Constrain this mock to calls that pass meta deep-equal to `meta`.
+					 * @param {*} meta
+					 * @returns {MockBuilder}
+					 */
+					withMeta(meta) {
+						descriptor.matchMeta = meta;
+						return builder;
+					},
+
+					/**
+					 * Make this mock resolve with `value`.
+					 * Registers the mock — subsequent matching calls return this value.
+					 * @param {*} value
+					 * @returns {MockBuilder}
+					 */
+					returnValue(value) {
+						descriptor.resolveValue = value;
+						descriptor.rejectError = undefined;
+						if (!descriptor._registered) {
+							mocks.push(descriptor);
+							descriptor._registered = true;
+						}
+						return builder;
+					},
+
+					/**
+					 * Make this mock reject with `error`.
+					 * If `error` is a string, it is wrapped in `new Error(error)`.
+					 * Registers the mock — subsequent matching calls throw this error.
+					 * @param {Error|string} error
+					 * @returns {MockBuilder}
+					 */
+					rejectWith(error) {
+						descriptor.rejectError =
+							error instanceof Error ? error : new Error(String(error));
+						descriptor.resolveValue = undefined;
+						if (!descriptor._registered) {
+							mocks.push(descriptor);
+							descriptor._registered = true;
+						}
+						return builder;
+					}
+				};
+
+				return builder;
+			};
+
+			/**
+			 * Check whether an action was called at least once.
+			 * @param {string} actionName
+			 * @returns {boolean}
+			 */
+			broker.test.actionCalled = function actionCalled(actionName) {
+				return capturedCalls.some(c => c.actionName === actionName);
+			};
+
+			/**
+			 * Return the number of times an action was called.
+			 * @param {string} actionName
+			 * @returns {number}
+			 */
+			broker.test.actionCalledTimes = function actionCalledTimes(actionName) {
+				return capturedCalls.filter(c => c.actionName === actionName).length;
+			};
+
+			/**
+			 * Check whether an action was called with a specific params object.
+			 * Uses deep equality (JSON serialization).
+			 * @param {string} actionName
+			 * @param {*} params
+			 * @returns {boolean}
+			 */
+			broker.test.actionCalledWithParams = function actionCalledWithParams(
+				actionName,
+				params
+			) {
+				const expected = JSON.stringify(params);
+				return capturedCalls.some(
+					c => c.actionName === actionName && JSON.stringify(c.params) === expected
+				);
+			};
+
+			/**
+			 * Return captured call records, optionally filtered by action name.
+			 * @param {string} [actionName]
+			 * @returns {Array}
+			 */
+			broker.test.getCalls = function getCalls(actionName) {
+				if (actionName) return capturedCalls.filter(c => c.actionName === actionName);
+				return capturedCalls.slice();
+			};
+
+			/**
+			 * Clear all recorded call history. Registered mocks remain active.
+			 */
+			broker.test.clearActions = function clearActions() {
+				capturedCalls.length = 0;
+			};
+
+			/**
+			 * Remove all registered mocks. Call history remains.
+			 */
+			broker.test.clearMocks = function clearMocks() {
+				mocks.length = 0;
+			};
+
+			/**
+			 * Clear call history, mocks, and events (if EventCatcher is active).
+			 */
+			broker.test.clearAll = function clearAll() {
+				capturedCalls.length = 0;
+				mocks.length = 0;
+				if (typeof broker.test.clearEvents === "function") {
+					broker.test.clearEvents();
+				}
+			};
+		},
+
+		/** @param {Function} next */
+		call(next) {
+			return function (actionName, params, opts) {
+				capturedCalls.push({ actionName, params, opts });
+
+				const meta = opts && opts.meta;
+				const mock = findMock(actionName, params, meta);
+				if (mock) {
+					if (mock.rejectError !== undefined) {
+						return Promise.reject(mock.rejectError);
+					}
+					return Promise.resolve(mock.resolveValue);
+				}
+
+				return next(actionName, params, opts);
+			};
+		}
+	};
+}
+
+module.exports = MockingCalls;

--- a/test/unit/testing.spec.js
+++ b/test/unit/testing.spec.js
@@ -1,0 +1,500 @@
+/*
+ * moleculer
+ * Copyright (c) 2024 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const { Testing } = require("../../index");
+const { createBroker, EventCatcher, MockingCalls } = Testing;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+async function stopBroker(broker) {
+	try {
+		await broker.stop();
+	} catch (_) {
+		// ignore stop errors in test teardown
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// createBroker
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("createBroker()", () => {
+	it("creates a broker with logger disabled", () => {
+		const broker = createBroker();
+		expect(broker).toBeDefined();
+		expect(broker.options.logger).toBe(false);
+		expect(broker.options.test).toBe(true);
+	});
+
+	it("attaches broker.test namespace", () => {
+		const broker = createBroker();
+		expect(broker.test).toBeDefined();
+		expect(typeof broker.test.eventEmitted).toBe("function");
+		expect(typeof broker.test.mockAction).toBe("function");
+	});
+
+	it("merges custom broker options", () => {
+		const broker = createBroker({ nodeID: "test-node-custom" });
+		expect(broker.nodeID).toBe("test-node-custom");
+		expect(broker.options.test).toBe(true);
+		expect(broker.options.logger).toBe(false);
+	});
+
+	it("appends user-supplied middlewares after test middlewares", () => {
+		const customMiddleware = {
+			name: "Custom",
+			created: jest.fn()
+		};
+		createBroker({ middlewares: [customMiddleware] });
+		expect(customMiddleware.created).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers mock services before start", async () => {
+		const listFn = jest.fn(async () => [1, 2, 3]);
+		const broker = createBroker({}, [{ name: "posts", actions: { list: listFn } }]);
+		await broker.start();
+
+		const res = await broker.call("posts.list", { limit: 5 });
+		expect(res).toEqual([1, 2, 3]);
+
+		const ctx = listFn.mock.calls[0][0];
+		expect(ctx.params).toEqual({ limit: 5 });
+
+		await stopBroker(broker);
+	});
+
+	it("handles empty mockServices array", () => {
+		expect(() => createBroker({}, [])).not.toThrow();
+	});
+
+	it("handles omitted arguments", () => {
+		expect(() => createBroker()).not.toThrow();
+	});
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EventCatcher
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("EventCatcher middleware", () => {
+	let broker;
+
+	beforeAll(async () => {
+		broker = createBroker();
+
+		// Service that re-emits an event after a short async delay
+		broker.createService({
+			name: "posts",
+			events: {
+				async "posts.addedComment"(ctx) {
+					await new Promise(res => setTimeout(res, 50));
+					this.broker.emit("posts.updated", { postID: ctx.params.postID });
+				}
+			}
+		});
+
+		await broker.start();
+	});
+
+	afterAll(() => stopBroker(broker));
+
+	beforeEach(() => broker.test.clearEvents());
+
+	describe("emit()", () => {
+		it("captures broker.emit() calls", () => {
+			broker.emit("test.event", { value: 1 });
+			expect(broker.test.eventEmitted("test.event")).toBe(true);
+		});
+
+		it("records payload", () => {
+			broker.emit("payload.event", { x: 42 });
+			const events = broker.test.getEvents("payload.event");
+			expect(events[0].payload).toEqual({ x: 42 });
+			expect(events[0].type).toBe("emit");
+		});
+	});
+
+	describe("broadcast()", () => {
+		it("captures broker.broadcast() calls", () => {
+			broker.broadcast("broadcast.event", { a: 1 });
+			expect(broker.test.eventEmitted("broadcast.event")).toBe(true);
+		});
+
+		it("records type as 'broadcast'", () => {
+			broker.broadcast("broadcast.typed", {});
+			const [entry] = broker.test.getEvents("broadcast.typed");
+			expect(entry.type).toBe("broadcast");
+		});
+	});
+
+	describe("broadcastLocal()", () => {
+		it("captures broker.broadcastLocal() calls", () => {
+			broker.broadcastLocal("local.event", { b: 2 });
+			expect(broker.test.eventEmitted("local.event")).toBe(true);
+		});
+
+		it("records type as 'broadcastLocal'", () => {
+			broker.broadcastLocal("local.typed", {});
+			const [entry] = broker.test.getEvents("local.typed");
+			expect(entry.type).toBe("broadcastLocal");
+		});
+	});
+
+	describe("eventEmitted()", () => {
+		it("returns false for events that were never emitted", () => {
+			expect(broker.test.eventEmitted("never.emitted")).toBe(false);
+		});
+
+		it("returns true after the event is emitted", () => {
+			broker.emit("later.event", {});
+			expect(broker.test.eventEmitted("later.event")).toBe(true);
+		});
+	});
+
+	describe("eventEmittedTimes()", () => {
+		it("returns 0 when event was never emitted", () => {
+			expect(broker.test.eventEmittedTimes("ghost.event")).toBe(0);
+		});
+
+		it("counts each emission independently", () => {
+			broker.emit("counted.event", { i: 1 });
+			broker.emit("counted.event", { i: 2 });
+			broker.emit("counted.event", { i: 3 });
+			expect(broker.test.eventEmittedTimes("counted.event")).toBe(3);
+		});
+	});
+
+	describe("eventEmittedWithParams()", () => {
+		it("returns true when payload matches exactly", () => {
+			broker.emit("exact.event", { id: 7 });
+			expect(broker.test.eventEmittedWithParams("exact.event", { id: 7 })).toBe(true);
+		});
+
+		it("returns false when payload differs", () => {
+			broker.emit("exact.event2", { id: 7 });
+			expect(broker.test.eventEmittedWithParams("exact.event2", { id: 99 })).toBe(false);
+		});
+
+		it("returns false when event was never emitted", () => {
+			expect(broker.test.eventEmittedWithParams("absent.event", { x: 1 })).toBe(false);
+		});
+	});
+
+	describe("getEvents()", () => {
+		it("returns all events when called without filter", () => {
+			broker.emit("alpha", {});
+			broker.emit("beta", {});
+			const all = broker.test.getEvents();
+			expect(all.length).toBe(2);
+		});
+
+		it("filters by event name", () => {
+			broker.emit("filtered.alpha", { n: 1 });
+			broker.emit("filtered.beta", { n: 2 });
+			broker.emit("filtered.alpha", { n: 3 });
+			const alpha = broker.test.getEvents("filtered.alpha");
+			expect(alpha.length).toBe(2);
+			expect(alpha.every(e => e.eventName === "filtered.alpha")).toBe(true);
+		});
+
+		it("returns a copy — mutations do not affect internal state", () => {
+			broker.emit("copy.test", {});
+			const copy = broker.test.getEvents();
+			const before = broker.test.eventEmittedTimes("copy.test");
+			copy.length = 0;
+			expect(broker.test.eventEmittedTimes("copy.test")).toBe(before);
+		});
+	});
+
+	describe("clearEvents()", () => {
+		it("removes all recorded events", () => {
+			broker.emit("will.clear", {});
+			expect(broker.test.eventEmitted("will.clear")).toBe(true);
+			broker.test.clearEvents();
+			expect(broker.test.eventEmitted("will.clear")).toBe(false);
+			expect(broker.test.getEvents().length).toBe(0);
+		});
+	});
+
+	describe("waitForEvent()", () => {
+		it("resolves immediately if event already captured", async () => {
+			broker.emit("already.there", { val: 1 });
+			const entry = await broker.test.waitForEvent("already.there");
+			expect(entry.eventName).toBe("already.there");
+			expect(entry.payload).toEqual({ val: 1 });
+		});
+
+		it("waits for a future async event and resolves", async () => {
+			broker.emit("posts.addedComment", { postID: 42 });
+			const entry = await broker.test.waitForEvent("posts.updated", 2000);
+			expect(entry.eventName).toBe("posts.updated");
+			expect(entry.payload).toEqual({ postID: 42 });
+		});
+
+		it("rejects with a descriptive error when event never arrives", async () => {
+			await expect(broker.test.waitForEvent("will.not.come", 100)).rejects.toThrow(
+				/Timeout waiting for event "will\.not\.come" after 100ms/
+			);
+		});
+	});
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MockingCalls
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("MockingCalls middleware", () => {
+	let broker;
+
+	beforeAll(async () => {
+		broker = createBroker();
+
+		broker.createService({
+			name: "posts",
+			actions: {
+				async get(ctx) {
+					const post = { id: ctx.params.id, title: "Post title", authorID: 5 };
+					post.author = await ctx.call("users.get", { id: post.authorID });
+					return post;
+				}
+			}
+		});
+
+		await broker.start();
+	});
+
+	afterAll(() => stopBroker(broker));
+
+	beforeEach(() => broker.test.clearAll());
+
+	describe("mockAction() – returnValue", () => {
+		it("intercepts and returns mocked value", async () => {
+			broker.test
+				.mockAction("users.get")
+				.withParams({ id: 5 })
+				.returnValue({ id: 5, name: "John", email: "john@moleculer.services" });
+
+			const res = await broker.call("posts.get", { id: 2 });
+			expect(res.author).toEqual({
+				id: 5,
+				name: "John",
+				email: "john@moleculer.services"
+			});
+		});
+
+		it("mocks without params filter (matches any params)", async () => {
+			broker.test.mockAction("users.get").returnValue({ id: 99, name: "Anyone" });
+			const res = await broker.call("posts.get", { id: 1 });
+			expect(res.author).toEqual({ id: 99, name: "Anyone" });
+		});
+	});
+
+	describe("mockAction() – rejectWith", () => {
+		it("rejects with an Error object", async () => {
+			broker.test.mockAction("users.get").rejectWith(new Error("User not found"));
+			await expect(broker.call("posts.get", { id: 1 })).rejects.toThrow("User not found");
+		});
+
+		it("wraps a plain string in Error", async () => {
+			broker.test.mockAction("users.get").rejectWith("Forbidden");
+			await expect(broker.call("posts.get", { id: 1 })).rejects.toThrow("Forbidden");
+		});
+	});
+
+	describe("mockAction() – withMeta", () => {
+		it("matches only when meta deep-equals the constraint", async () => {
+			broker.test
+				.mockAction("users.get")
+				.withParams({ id: 5 })
+				.withMeta({ token: "abc" })
+				.returnValue({ id: 5, name: "Secure John" });
+
+			// Direct call with matching meta
+			const res = await broker.call("users.get", { id: 5 }, { meta: { token: "abc" } });
+			expect(res).toEqual({ id: 5, name: "Secure John" });
+		});
+	});
+
+	describe("actionCalled()", () => {
+		it("returns false when action was never called", () => {
+			expect(broker.test.actionCalled("ghost.action")).toBe(false);
+		});
+
+		it("returns true after the action is called", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			expect(broker.test.actionCalled("posts.get")).toBe(true);
+			expect(broker.test.actionCalled("users.get")).toBe(true);
+		});
+	});
+
+	describe("actionCalledTimes()", () => {
+		it("returns 0 when never called", () => {
+			expect(broker.test.actionCalledTimes("never.called")).toBe(0);
+		});
+
+		it("counts calls correctly across multiple invocations", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			await broker.call("posts.get", { id: 2 });
+			expect(broker.test.actionCalledTimes("posts.get")).toBe(2);
+			expect(broker.test.actionCalledTimes("users.get")).toBe(2);
+		});
+	});
+
+	describe("actionCalledWithParams()", () => {
+		it("returns true when params match exactly", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 3 });
+			expect(broker.test.actionCalledWithParams("users.get", { id: 5 })).toBe(true);
+		});
+
+		it("returns false when params differ", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			expect(broker.test.actionCalledWithParams("users.get", { id: 999 })).toBe(false);
+		});
+
+		it("returns false for uncalled action", () => {
+			expect(broker.test.actionCalledWithParams("uncalled", { x: 1 })).toBe(false);
+		});
+	});
+
+	describe("getCalls()", () => {
+		it("returns all calls without a filter", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			const all = broker.test.getCalls();
+			expect(all.length).toBeGreaterThanOrEqual(2); // posts.get + users.get
+		});
+
+		it("filters by action name", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			const userCalls = broker.test.getCalls("users.get");
+			expect(userCalls.length).toBe(1);
+			expect(userCalls[0].actionName).toBe("users.get");
+		});
+
+		it("returns a copy — mutations do not affect internal state", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			const copy = broker.test.getCalls();
+			const before = broker.test.actionCalledTimes("posts.get");
+			copy.length = 0;
+			expect(broker.test.actionCalledTimes("posts.get")).toBe(before);
+		});
+	});
+
+	describe("clearActions()", () => {
+		it("removes recorded calls but leaves mocks active", async () => {
+			broker.test.mockAction("users.get").returnValue({ id: 1 });
+			await broker.call("posts.get", { id: 1 });
+			expect(broker.test.actionCalled("posts.get")).toBe(true);
+
+			broker.test.clearActions();
+			expect(broker.test.actionCalled("posts.get")).toBe(false);
+
+			// Mock is still active; calling again should still be intercepted
+			const res = await broker.call("posts.get", { id: 2 });
+			expect(res.author).toEqual({ id: 1 });
+		});
+	});
+
+	describe("clearMocks()", () => {
+		it("removes mocks but preserves call history", async () => {
+			broker.test.mockAction("users.get").returnValue({ id: 5, name: "John" });
+			await broker.call("posts.get", { id: 1 });
+			expect(broker.test.actionCalled("posts.get")).toBe(true);
+
+			broker.test.clearMocks();
+
+			// No mock is active now, so the next call falls through to the real action
+			// which will fail because there is no real users.get — that's expected
+			await expect(broker.call("posts.get", { id: 1 })).rejects.toBeDefined();
+			// But call history before clearMocks should still be there
+			expect(broker.test.actionCalledTimes("posts.get")).toBe(2);
+		});
+	});
+
+	describe("clearAll()", () => {
+		it("clears both calls and mocks", async () => {
+			broker.test.mockAction("users.get").returnValue({});
+			await broker.call("posts.get", { id: 1 });
+			broker.test.clearAll();
+			expect(broker.test.actionCalled("posts.get")).toBe(false);
+		});
+
+		it("also clears events when EventCatcher is active", () => {
+			broker.emit("some.event", {});
+			broker.test.clearAll();
+			expect(broker.test.eventEmitted("some.event")).toBe(false);
+		});
+	});
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Module exports
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("Testing module exports", () => {
+	it("exports Testing from the main moleculer module", () => {
+		const { Testing: T } = require("../../index");
+		expect(T).toBeDefined();
+		expect(T.createBroker).toBeInstanceOf(Function);
+		expect(T.EventCatcher).toBeInstanceOf(Function);
+		expect(T.MockingCalls).toBeInstanceOf(Function);
+	});
+
+	it("EventCatcher() returns a middleware object with required hooks", () => {
+		const mw = EventCatcher();
+		expect(mw.name).toBe("EventCatcher");
+		expect(mw.created).toBeInstanceOf(Function);
+		expect(mw.emit).toBeInstanceOf(Function);
+		expect(mw.broadcast).toBeInstanceOf(Function);
+		expect(mw.broadcastLocal).toBeInstanceOf(Function);
+	});
+
+	it("MockingCalls() returns a middleware object with required hooks", () => {
+		const mw = MockingCalls();
+		expect(mw.name).toBe("MockingCalls");
+		expect(mw.created).toBeInstanceOf(Function);
+		expect(mw.call).toBeInstanceOf(Function);
+	});
+
+	it("each EventCatcher() call creates an isolated event store", () => {
+		const broker1 = createBroker();
+		const broker2 = createBroker();
+
+		broker1.emit("isolated.event", { source: 1 });
+		expect(broker1.test.eventEmitted("isolated.event")).toBe(true);
+		expect(broker2.test.eventEmitted("isolated.event")).toBe(false);
+	});
+
+	it("each MockingCalls() call creates an isolated call store", async () => {
+		const broker1 = createBroker({}, [
+			{ name: "greeter", actions: { hello: async () => "hi from broker1" } }
+		]);
+		const broker2 = createBroker({}, [
+			{ name: "greeter", actions: { hello: async () => "hi from broker2" } }
+		]);
+
+		await broker1.start();
+		await broker2.start();
+
+		await broker1.call("greeter.hello", {});
+
+		expect(broker1.test.actionCalled("greeter.hello")).toBe(true);
+		expect(broker2.test.actionCalled("greeter.hello")).toBe(false);
+
+		await stopBroker(broker1);
+		await stopBroker(broker2);
+	});
+});


### PR DESCRIPTION
Implements [RFC #3 — Testing helpers](https://github.com/moleculerjs/rfcs/issues/3).

> **AI Disclosure**: This implementation was developed with AI assistance (Claude) and has been reviewed and verified. I understand the implementation and can explain any part of it.

## What's included

### `require("moleculer").Testing`

- **`createBroker(options?, mockServices?)`** — creates a real `ServiceBroker` with logger disabled, `test: true`, and both test middlewares pre-wired.
- **`EventCatcher`** middleware factory — intercepts `emit`, `broadcast`, and `broadcastLocal`, records every event for assertion. Uses `EventEmitter` internally so `waitForEvent()` resolves without polling.
- **`MockingCalls`** middleware factory — intercepts `broker.call`, records every invocation, and resolves/rejects with mocked values via a fluent builder.

### `broker.test.*` assertion helpers

Full test assertion API for events and calls — see PR body for complete method list.

### TypeScript definitions

Full types added to `index.d.ts`.

## Test plan

- [x] 51 tests in `test/unit/testing.spec.js` — all passing
- [x] All 2330 pre-existing unit tests continue to pass (2 pre-existing failures in `encryption.spec.js` are caused by `crypto.createCipher` removal in Node 22 — unrelated to this PR)

Closes moleculerjs/rfcs#3