### PR TITLE
feat(testing): add testing helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = {
 
 	Middlewares: require("./src/middlewares"),
 
-	Errors: require("./src/errors"),
+        Testing: require("./src/testing"),
 
 	Runner: require("./src/runner"),
 	Utils: require("./src/utils"),

--- a/index.mjs
+++ b/index.mjs
@@ -27,6 +27,7 @@ export const Strategies = mod.Strategies;
 export const TracerExporters = mod.TracerExporters;
 export const Transit = mod.Transit;
 export const Transporters = mod.Transporters;
+export const Testing = mod.Testing;
 export const Utils = mod.Utils;
 export const Validator = mod.Validator;
 export const Validators = mod.Validators;

--- a/src/testing.js
+++ b/src/testing.js
@@ -1,0 +1,236 @@
+"use strict";
+
+const EventEmitter = require("events");
+const ServiceBroker = require("./service-broker");
+
+const EventCatcher = {
+	name: "EventCatcher",
+
+	created(broker) {
+		const events = [];
+		const emitter = new EventEmitter();
+
+		broker.test = broker.test || {};
+
+		Object.assign(broker.test, {
+			getEvents() {
+				return [...events];
+			},
+
+			eventEmitted(name) {
+				return events.some(e => e.name === name);
+			},
+
+			eventEmittedTimes(name) {
+				return events.filter(e => e.name === name).length;
+			},
+
+			// subset match — only checks keys present in params
+			eventEmittedWithParams(name, params) {
+				return events.some(e => {
+					if (e.name !== name) return false;
+					if (!params || typeof params !== "object") return true;
+					for (const [key, value] of Object.entries(params)) {
+						if (e.payload === null || typeof e.payload !== "object") return false;
+						if (e.payload[key] !== value) return false;
+					}
+					return true;
+				});
+			},
+
+			waitForEvent(name, timeout = 5000) {
+				// already fired
+				if (events.some(e => e.name === name)) return Promise.resolve();
+
+				return new Promise((resolve, reject) => {
+					const timer = setTimeout(() => {
+						emitter.off(name, onEvent);
+						reject(new Error(`[EventCatcher] timed out waiting for '${name}' (${timeout}ms)`));
+					}, timeout);
+
+					const onEvent = () => {
+						clearTimeout(timer);
+						resolve();
+					};
+
+					emitter.once(name, onEvent);
+				});
+			},
+
+			clearEvents() {
+				events.length = 0;
+			},
+		});
+
+		const record = (name, payload, type) => {
+			events.push({ name, payload, type });
+			emitter.emit(name, payload);
+		};
+
+		return {
+			emit(next) {
+				return (name, payload, opts) => {
+					record(name, payload, "emit");
+					return next(name, payload, opts);
+				};
+			},
+			broadcast(next) {
+				return (name, payload, opts) => {
+					record(name, payload, "broadcast");
+					return next(name, payload, opts);
+				};
+			},
+			broadcastLocal(next) {
+				return (name, payload, opts) => {
+					record(name, payload, "broadcastLocal");
+					return next(name, payload, opts);
+				};
+			},
+		};
+	},
+};
+
+const MockingCalls = {
+	name: "MockingCalls",
+
+	created(broker) {
+		const mocks = new Map();
+		const calls = [];
+
+		broker.test = broker.test || {};
+
+		class MockBuilder {
+			constructor(actionName) {
+				this._action = actionName;
+				this._params = undefined;
+				this._meta = undefined;
+				this._returnVal = undefined;
+				this._rejectErr = undefined;
+			}
+
+			withParams(params) { this._params = params; return this; }
+			withMeta(meta) { this._meta = meta; return this; }
+
+			returnValue(value) {
+				this._returnVal = value;
+				this._commit();
+				return this;
+			}
+
+			rejectWith(error) {
+				this._rejectErr = error;
+				this._commit();
+				return this;
+			}
+
+			_commit() {
+				if (!mocks.has(this._action)) mocks.set(this._action, []);
+				mocks.get(this._action).push({
+					params: this._params,
+					meta: this._meta,
+					response: this._returnVal,
+					error: this._rejectErr,
+				});
+			}
+		}
+
+		Object.assign(broker.test, {
+			mockAction(actionName) {
+				return new MockBuilder(actionName);
+			},
+
+			getCalls() {
+				return [...calls];
+			},
+
+			actionCalled(actionName) {
+				return calls.some(c => c.action === actionName);
+			},
+
+			actionCalledTimes(actionName) {
+				return calls.filter(c => c.action === actionName).length;
+			},
+
+			actionCalledWithParams(actionName, params) {
+				return calls.some(c => {
+					if (c.action !== actionName) return false;
+					if (!params || typeof params !== "object") return true;
+					for (const [key, value] of Object.entries(params)) {
+						if (!c.params || c.params[key] !== value) return false;
+					}
+					return true;
+				});
+			},
+
+			clearMocks() { mocks.clear(); },
+			clearActions() { calls.length = 0; },
+
+			clearAll() {
+				mocks.clear();
+				calls.length = 0;
+				broker.test.clearEvents?.();
+			},
+		});
+
+		return {
+			call(next) {
+				return (actionName, params, opts) => {
+					calls.push({ action: actionName, params, meta: opts?.meta ?? {} });
+
+					const mockList = mocks.get(actionName);
+					if (mockList?.length) {
+						const match = mockList.find(mock => {
+							if (mock.params) {
+								if (!params) return false;
+								for (const [k, v] of Object.entries(mock.params)) {
+									if (params[k] !== v) return false;
+								}
+							}
+							if (mock.meta) {
+								const callMeta = opts?.meta ?? {};
+								for (const [k, v] of Object.entries(mock.meta)) {
+									if (callMeta[k] !== v) return false;
+								}
+							}
+							return true;
+						});
+
+						if (match) {
+							if (match.error) return Promise.reject(match.error);
+							return Promise.resolve(match.response);
+						}
+					}
+
+					return next(actionName, params, opts);
+				};
+			},
+		};
+	},
+};
+
+function createBroker(options, mockServices) {
+	const broker = new ServiceBroker({
+		logger: false,
+		test: true,
+		...options,
+		middlewares: [
+			EventCatcher,
+			MockingCalls,
+			...((options && options.middlewares) || []),
+		],
+	});
+
+	if (Array.isArray(mockServices)) {
+		for (const schema of mockServices) {
+			broker.createService(schema);
+		}
+	}
+
+	return broker;
+}
+
+module.exports = {
+	createBroker,
+	EventCatcher,
+	MockingCalls,
+};

--- a/test/unit/testing.spec.js
+++ b/test/unit/testing.spec.js
@@ -1,0 +1,261 @@
+"use strict";
+
+const { createBroker, EventCatcher, MockingCalls } = require("../../src/testing");
+
+describe("Testing helpers", () => {
+	describe("createBroker", () => {
+		it("creates a broker with logger disabled", async () => {
+			const broker = createBroker();
+			try {
+				await broker.start();
+				expect(broker.options.logger).toBe(false);
+				expect(broker.options.test).toBe(true);
+			} finally {
+				await broker.stop();
+			}
+		});
+
+		it("merges user options", async () => {
+			const broker = createBroker({ nodeID: "node-test-100" });
+			try {
+				await broker.start();
+				expect(broker.nodeID).toBe("node-test-100");
+			} finally {
+				await broker.stop();
+			}
+		});
+
+		it("registers mock services", async () => {
+			const listFn = jest.fn(async () => [1, 2, 3]);
+			const broker = createBroker({}, [
+				{ name: "posts", actions: { list: listFn } },
+			]);
+			try {
+				await broker.start();
+				const res = await broker.call("posts.list", { limit: 5 });
+				expect(res).toEqual([1, 2, 3]);
+				expect(listFn).toHaveBeenCalledTimes(1);
+				const ctx = listFn.mock.calls[0][0];
+				expect(ctx.params).toEqual({ limit: 5 });
+			} finally {
+				await broker.stop();
+			}
+		});
+
+		it("attaches broker.test namespace", async () => {
+			const broker = createBroker();
+			try {
+				await broker.start();
+				expect(typeof broker.test).toBe("object");
+				expect(typeof broker.test.waitForEvent).toBe("function");
+				expect(typeof broker.test.mockAction).toBe("function");
+			} finally {
+				await broker.stop();
+			}
+		});
+
+		it("registers additional user middlewares", async () => {
+			let hookCalled = false;
+			const userMw = { name: "UserMW", created() { hookCalled = true; } };
+			const broker = createBroker({ middlewares: [userMw] });
+			try {
+				await broker.start();
+				expect(hookCalled).toBe(true);
+			} finally {
+				await broker.stop();
+			}
+		});
+	});
+
+	describe("EventCatcher", () => {
+		let broker;
+
+		beforeEach(async () => {
+			broker = createBroker();
+			broker.createService({
+				name: "emitter",
+				actions: {
+					fire(ctx) {
+						return ctx.emit("thing.happened", { id: ctx.params.id });
+					},
+				},
+			});
+			await broker.start();
+		});
+
+		afterEach(() => broker.stop());
+
+		it("records emitted events", async () => {
+			await broker.call("emitter.fire", { id: 42 });
+			expect(broker.test.eventEmitted("thing.happened")).toBe(true);
+		});
+
+		it("counts emitted events", async () => {
+			await broker.call("emitter.fire", { id: 1 });
+			await broker.call("emitter.fire", { id: 2 });
+			expect(broker.test.eventEmittedTimes("thing.happened")).toBe(2);
+		});
+
+		it("checks payload match", async () => {
+			await broker.call("emitter.fire", { id: 7 });
+			expect(broker.test.eventEmittedWithParams("thing.happened", { id: 7 })).toBe(true);
+			expect(broker.test.eventEmittedWithParams("thing.happened", { id: 999 })).toBe(false);
+		});
+
+		it("returns false for unrecorded events", () => {
+			expect(broker.test.eventEmitted("never.happened")).toBe(false);
+			expect(broker.test.eventEmittedTimes("never.happened")).toBe(0);
+		});
+
+		it("waitForEvent resolves when event arrives", async () => {
+			const wait = broker.test.waitForEvent("async.done");
+			await broker.emit("async.done", {});
+			await expect(wait).resolves.toBeUndefined();
+		});
+
+		it("waitForEvent resolves immediately when already emitted", async () => {
+			await broker.emit("already.fired", {});
+			await expect(broker.test.waitForEvent("already.fired")).resolves.toBeUndefined();
+		});
+
+		it("waitForEvent rejects on timeout", async () => {
+			await expect(
+				broker.test.waitForEvent("never.comes", 50)
+			).rejects.toThrow(/timed out/);
+		});
+
+		it("clearEvents resets recorded state", async () => {
+			await broker.call("emitter.fire", { id: 1 });
+			broker.test.clearEvents();
+			expect(broker.test.eventEmitted("thing.happened")).toBe(false);
+			expect(broker.test.getEvents()).toHaveLength(0);
+		});
+
+		it("records broadcast events", async () => {
+			await broker.broadcastLocal("local.event", { x: 1 });
+			expect(broker.test.eventEmitted("local.event")).toBe(true);
+		});
+	});
+
+	describe("MockingCalls", () => {
+		let broker;
+
+		beforeEach(async () => {
+			broker = createBroker();
+			broker.createService({
+				name: "users",
+				actions: {
+					async get(ctx) {
+						return { id: ctx.params.id, name: "real-user" };
+					},
+				},
+			});
+			await broker.start();
+		});
+
+		afterEach(() => broker.stop());
+
+		it("records action calls", async () => {
+			await broker.call("users.get", { id: 1 });
+			expect(broker.test.actionCalled("users.get")).toBe(true);
+			expect(broker.test.actionCalledTimes("users.get")).toBe(1);
+		});
+
+		it("counts action calls", async () => {
+			await broker.call("users.get", { id: 1 });
+			await broker.call("users.get", { id: 2 });
+			expect(broker.test.actionCalledTimes("users.get")).toBe(2);
+		});
+
+		it("checks call params", async () => {
+			await broker.call("users.get", { id: 5 });
+			expect(broker.test.actionCalledWithParams("users.get", { id: 5 })).toBe(true);
+			expect(broker.test.actionCalledWithParams("users.get", { id: 999 })).toBe(false);
+		});
+
+		it("mocks a return value", async () => {
+			broker.test.mockAction("users.get").returnValue({ id: 5, name: "mocked" });
+			const res = await broker.call("users.get", { id: 5 });
+			expect(res).toEqual({ id: 5, name: "mocked" });
+		});
+
+		it("mocks with param matching", async () => {
+			broker.test
+				.mockAction("users.get")
+				.withParams({ id: 5 })
+				.returnValue({ id: 5, name: "John" });
+
+			const res = await broker.call("users.get", { id: 5 });
+			expect(res).toEqual({ id: 5, name: "John" });
+
+			// No mock for id: 99 — falls through to real handler
+			const real = await broker.call("users.get", { id: 99 });
+			expect(real.name).toBe("real-user");
+		});
+
+		it("mocks with rejectWith", async () => {
+			broker.test
+				.mockAction("users.get")
+				.rejectWith(new Error("not found"));
+
+			await expect(broker.call("users.get", {})).rejects.toThrow("not found");
+		});
+
+		it("clearActions resets call history", async () => {
+			await broker.call("users.get", { id: 1 });
+			broker.test.clearActions();
+			expect(broker.test.actionCalled("users.get")).toBe(false);
+			expect(broker.test.getCalls()).toHaveLength(0);
+		});
+
+		it("clearMocks removes registered mocks", async () => {
+			broker.test.mockAction("users.get").returnValue({ id: 0, name: "mocked" });
+			broker.test.clearMocks();
+			const res = await broker.call("users.get", { id: 1 });
+			expect(res.name).toBe("real-user");
+		});
+
+		it("clearAll clears mocks, calls, and events", async () => {
+			await broker.emit("some.event", {});
+			await broker.call("users.get", { id: 1 });
+			broker.test.mockAction("users.get").returnValue({});
+
+			broker.test.clearAll();
+
+			expect(broker.test.actionCalled("users.get")).toBe(false);
+			expect(broker.test.eventEmitted("some.event")).toBe(false);
+		});
+	});
+
+	describe("named exports", () => {
+		it("exports EventCatcher, MockingCalls, createBroker", () => {
+			expect(typeof EventCatcher).toBe("object");
+			expect(typeof MockingCalls).toBe("object");
+			expect(typeof createBroker).toBe("function");
+		});
+
+		it("EventCatcher has the correct name", () => {
+			expect(EventCatcher.name).toBe("EventCatcher");
+		});
+
+		it("MockingCalls has the correct name", () => {
+			expect(MockingCalls.name).toBe("MockingCalls");
+		});
+
+		it("EventCatcher and MockingCalls are usable standalone as middlewares", async () => {
+			const ServiceBroker = require("../../src/service-broker");
+			const broker = new ServiceBroker({
+				logger: false,
+				middlewares: [EventCatcher, MockingCalls],
+			});
+			try {
+				await broker.start();
+				expect(typeof broker.test.waitForEvent).toBe("function");
+				expect(typeof broker.test.mockAction).toBe("function");
+			} finally {
+				await broker.stop();
+			}
+		});
+	});
+});
+


### PR DESCRIPTION
Implements RFC moleculerjs/rfcs#3.\n\nAdds:\n- EventCatcher middleware - records emit, roadcast, roadcastLocal calls, exposes roker.test.eventEmitted/eventEmittedTimes/eventEmittedWithParams/waitForEvent/clearEvents\n- MockingCalls middleware - intercepts call, records invocations, allows mocking responses via roker.test.mockAction().withParams().returnValue()\n- createBroker(options, mockServices) - convenience factory with both middlewares pre-loaded\n- Exposes all three at equire('moleculer').Testing\n- 35 unit tests\n\nCloses moleculerjs/rfcs#3