### PR TITLE
feat(runner): add transitive hot-reload for ESM via custom loader

### DIFF
--- a/src/middlewares/hot-reload.js
+++ b/src/middlewares/hot-reload.js
@@ -23,18 +23,42 @@ module.exports = function HotReloadMiddleware(broker) {
 	let hotReloadModules = [];
 	let extraFiles = null;
 
+	/**
+	 * Resolve the active reload strategy.
+	 *
+	 * Defaults to a CommonJS strategy that uses Node's require cache and
+	 * the `module.children` tree to compute a service dependency graph.
+	 *
+	 * The runner can override this by exposing `broker.runner.reloadStrategy`
+	 * (e.g. the ESM runner provides an import()-based strategy without a
+	 * dependency graph).
+	 */
+	function getReloadStrategy() {
+		if (broker.runner && broker.runner.reloadStrategy) return broker.runner.reloadStrategy;
+
+		return {
+			usesNodeModuleTree: true,
+			loadService: filename => broker.loadService(filename),
+			reloadService: filename => broker.loadService(filename),
+			invalidate: filename => clearRequireCache(filename),
+			invalidateAll: () =>
+				Object.keys(require.cache).forEach(key => delete require.cache[key])
+		};
+	}
+
 	function hotReloadService(service) {
 		const relPath = path.relative(process.cwd(), service.__filename);
+		const strategy = getReloadStrategy();
 
 		broker.logger.info(`Hot reload '${service.name}' service...`, kleur.grey(relPath));
 
 		return broker.destroyService(service).then(() => {
 			if (fs.existsSync(service.__filename)) {
 				try {
-					return broker.loadService(service.__filename);
+					return strategy.reloadService(service.__filename);
 				} catch (err) {
 					broker.logger.error(`Failed to load service '${service.__filename}'`, err);
-					clearRequireCache(service.__filename);
+					strategy.invalidate(service.__filename);
 				}
 			}
 		});
@@ -44,18 +68,59 @@ module.exports = function HotReloadMiddleware(broker) {
 	 * Detect service dependency graph & watch all dependent files & services.
 	 *
 	 */
-	function watchProjectFiles() {
-		if (!broker.started || (!process.mainModule && !require.main)) return;
+	async function watchProjectFiles() {
+		if (!broker.started) return;
+
+		const strategy = getReloadStrategy();
+
+		// In CJS we walk the module tree to discover dependencies. In ESM
+		// (or any environment that does not expose a module graph) we only
+		// watch the service files we know about + any explicit `extraFiles`.
+		if (strategy.usesNodeModuleTree !== false && !process.mainModule && !require.main) return;
 
 		cache.clear();
 		prevProjectFiles = projectFiles;
 		projectFiles = new Map();
 
-		// Read the main module
-		const mainModule = process.mainModule || require.main;
+		if (strategy.usesNodeModuleTree !== false) {
+			// Read the main module
+			const mainModule = process.mainModule || require.main;
 
-		// Process the whole module tree
-		processModule(mainModule, null, 0, null);
+			// Process the whole module tree
+			processModule(mainModule, null, 0, null);
+		} else {
+			// No module graph available via Node primitives. Watch every
+			// loaded service file directly, and — if the strategy can
+			// expose a dependency graph itself (e.g. ESM loader) — also
+			// every transitively imported user file. For non-service
+			// files we mark `lookupImporters` so the change handler can
+			// resolve which services to reload at change time.
+			const serviceFiles = new Set();
+			broker.services.forEach(svc => {
+				if (!svc.__filename) return;
+				serviceFiles.add(svc.__filename);
+				const watchItem = getWatchItem(svc.__filename);
+				if (!watchItem.services.includes(svc.fullName)) {
+					watchItem.services.push(svc.fullName);
+				}
+			});
+
+			if (isFunction(strategy.getAllUserFiles)) {
+				try {
+					const allFiles = (await strategy.getAllUserFiles()) || [];
+					allFiles.forEach(f => {
+						if (serviceFiles.has(f)) return;
+						const watchItem = getWatchItem(f);
+						watchItem.lookupImporters = true;
+					});
+				} catch (err) {
+					broker.logger.warn(
+						"Hot-reload: failed to enumerate user files from loader.",
+						err
+					);
+				}
+			}
+		}
 
 		if (extraFiles != null) {
 			Object.entries(extraFiles).forEach(([fName, restartType]) => {
@@ -81,9 +146,10 @@ module.exports = function HotReloadMiddleware(broker) {
 				kleur.bgMagenta().white().bold(`Reload ${needToReloadDedup.length} service(s)`)
 			);
 
+			const loadStrategy = getReloadStrategy();
 			needToReloadDedup.forEach(svc => {
 				if (typeof svc == "string")
-					if (fs.existsSync(svc)) return broker.loadService(svc);
+					if (fs.existsSync(svc)) return loadStrategy.loadService(svc);
 					else return;
 
 				return hotReloadService(svc);
@@ -122,53 +188,110 @@ module.exports = function HotReloadMiddleware(broker) {
 				watchItem.others.forEach(filename =>
 					broker.logger.debug(kleur.grey(`    ${path.relative(process.cwd(), filename)}`))
 				);
-			}
-			// Create watcher
-			watchItem.watcher = fs.watch(fName, eventType => {
-				const relPath = path.relative(process.cwd(), fName);
-				broker.logger.info(
-					kleur.magenta().bold(`The '${relPath}' file is changed. (Event: ${eventType})`)
+			} else if (watchItem.lookupImporters)
+				broker.logger.debug(
+					`  ${relPath}:`,
+					kleur.grey("reload importing services on change.")
 				);
+			// Create watcher.
+			// `fs.watch` can fire multiple `change` events for a single
+			// edit (e.g. editors that save with truncate+write or
+			// write-tmp+rename). Debounce on the leading edge so we log &
+			// react once per burst.
+			watchItem.watcher = fs.watch(
+				fName,
+				_.debounce(
+					eventType => {
+						const relPath = path.relative(process.cwd(), fName);
+						broker.logger.info(
+							kleur
+								.magenta()
+								.bold(`The '${relPath}' file is changed. (Event: ${eventType})`)
+						);
 
-				// Clear from require cache
-				clearRequireCache(fName);
-				if (watchItem.others.length > 0) {
-					watchItem.others.forEach(f => clearRequireCache(f));
-				}
+						const watcherStrategy = getReloadStrategy();
 
-				if (
-					watchItem.brokerRestart &&
-					broker.runner &&
-					isFunction(broker.runner.restartBroker)
-				) {
-					broker.logger.info(kleur.bgMagenta().white().bold("Action: Restart broker..."));
-					stopAllFileWatcher(projectFiles);
-					// Clear the whole require cache
-					Object.keys(require.cache).forEach(key => delete require.cache[key]);
+						// Drop the file (and its known sibling deps) from the module cache
+						watcherStrategy.invalidate(fName);
+						if (watchItem.others.length > 0) {
+							watchItem.others.forEach(f => watcherStrategy.invalidate(f));
+						}
 
-					return broker.runner.restartBroker();
-				} else if (watchItem.allServices) {
-					// Reload all services
-					broker.services.forEach(svc => {
-						if (svc.__filename) needToReload.add(svc);
-					});
-					reloadServices();
-				} else if (watchItem.services.length > 0) {
-					// Reload certain services
-					broker.services.forEach(svc => {
-						if (watchItem.services.indexOf(svc.fullName) !== -1) needToReload.add(svc);
-					});
+						if (
+							watchItem.brokerRestart &&
+							broker.runner &&
+							isFunction(broker.runner.restartBroker)
+						) {
+							broker.logger.info(
+								kleur.bgMagenta().white().bold("Action: Restart broker...")
+							);
+							stopAllFileWatcher(projectFiles);
+							// Clear the whole module cache
+							watcherStrategy.invalidateAll();
 
-					if (needToReload.size === 0) {
-						// It means, it's a crashed reloaded service, so we
-						// didn't find it in the loaded services because
-						// the previous hot-reload failed. We should load it
-						// broker.loadService
-						needToReload.add(relPath);
-					}
-					reloadServices();
-				}
-			});
+							return broker.runner.restartBroker();
+						} else if (watchItem.allServices) {
+							// Reload all services
+							broker.services.forEach(svc => {
+								if (svc.__filename) needToReload.add(svc);
+							});
+							reloadServices();
+						} else if (watchItem.services.length > 0) {
+							// Reload certain services
+							broker.services.forEach(svc => {
+								if (watchItem.services.indexOf(svc.fullName) !== -1)
+									needToReload.add(svc);
+							});
+
+							if (needToReload.size === 0) {
+								// It means, it's a crashed reloaded service, so we
+								// didn't find it in the loaded services because
+								// the previous hot-reload failed. We should load it
+								// broker.loadService
+								needToReload.add(relPath);
+							}
+							reloadServices();
+						} else if (
+							watchItem.lookupImporters &&
+							isFunction(watcherStrategy.getImporters)
+						) {
+							// Transitive dep changed: ask the loader which
+							// user files import this one (transitively),
+							// then reload services among them. The loader
+							// already bumps `fName` + its importers on
+							// `invalidate`, so the next service import
+							// brings in the fresh dependency chain.
+							watcherStrategy
+								.getImporters(fName)
+								.then(importers => {
+									const set = new Set(importers || []);
+									let matched = 0;
+									broker.services.forEach(svc => {
+										if (svc.__filename && set.has(svc.__filename)) {
+											needToReload.add(svc);
+											matched++;
+										}
+									});
+									if (matched > 0) reloadServices();
+									else
+										broker.logger.debug(
+											kleur.grey(
+												`Hot-reload: '${relPath}' changed but no service imports it.`
+											)
+										);
+								})
+								.catch(err =>
+									broker.logger.warn(
+										"Hot-reload: failed to lookup importers.",
+										err
+									)
+								);
+						}
+					},
+					100,
+					{ leading: true, trailing: false }
+				)
+			);
 		});
 
 		if (projectFiles.size === 0) broker.logger.debug(kleur.grey("  No files."));
@@ -202,6 +325,7 @@ module.exports = function HotReloadMiddleware(broker) {
 			services: [],
 			allServices: false,
 			brokerRestart: false,
+			lookupImporters: false,
 			others: []
 		};
 		projectFiles.set(fName, watchItem);
@@ -287,16 +411,17 @@ module.exports = function HotReloadMiddleware(broker) {
 		// Debounced Service loader function
 		const needToLoad = new Set();
 		const loadServices = _.debounce(() => {
+			const strategy = getReloadStrategy();
 			broker.logger.info(
 				kleur.bgMagenta().white().bold(`Load ${needToLoad.size} service(s)...`)
 			);
 
 			needToLoad.forEach(filename => {
 				try {
-					broker.loadService(filename);
+					strategy.loadService(filename);
 				} catch (err) {
 					broker.logger.error(`Failed to load service '${filename}'`, err);
-					clearRequireCache(filename);
+					strategy.invalidate(filename);
 				}
 			});
 			needToLoad.clear();

--- a/src/runner-esm-loader.mjs
+++ b/src/runner-esm-loader.mjs
@@ -1,0 +1,164 @@
+/* moleculer
+ * Copyright (c) 2025 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+/**
+ * ESM loader hooks for Moleculer's hot-reload support.
+ *
+ * Registered by `runner-esm.mjs` via `module.register()`. Runs on a
+ * dedicated loader thread and communicates with the main runner over
+ * a `MessagePort`.
+ *
+ * Responsibilities:
+ *   - Track every resolved user file (anything outside `node_modules`)
+ *     and the parent → child import relationships seen in `resolve`.
+ *     This builds a reverse dependency graph (child → parents) used to
+ *     compute transitive importers when a file changes.
+ *   - Maintain a per-file "version" counter. When notified of a change,
+ *     bump the file AND all its transitive importers, so that the next
+ *     `resolve` of any of them returns a fresh `?v=<n>` URL and Node
+ *     re-evaluates the whole chain.
+ *
+ * Protocol (over `MessagePort`):
+ *   in:  { type: "invalidate",     path: string,    id: number }
+ *        { type: "invalidateAll",                   id: number }
+ *        { type: "sync",                            id: number }
+ *        { type: "getAllUserFiles",                 id: number }
+ *        { type: "getImporters",    path: string,   id: number }
+ *   out: { type: "ack", id: number, result?: any }
+ *
+ * The "sync" message is used by the runner to await delivery: because
+ * MessageChannel is FIFO, awaiting an ack for "sync" guarantees that
+ * any prior messages have already been processed.
+ */
+
+import { fileURLToPath } from "url";
+import { sep } from "path";
+
+let port = null;
+const versions = new Map();
+// child path -> Set<parent path>
+const importers = new Map();
+
+export function initialize(data) {
+	port = data.port;
+
+	port.on("message", msg => {
+		let result;
+		switch (msg && msg.type) {
+			case "invalidate":
+				bumpWithImporters(msg.path);
+				break;
+			case "invalidateAll":
+				for (const k of [...versions.keys()]) bump(k);
+				break;
+			case "sync":
+				// no-op, ack confirms prior messages were processed
+				break;
+			case "getAllUserFiles":
+				result = [...versions.keys()];
+				break;
+			case "getImporters":
+				result = [...collectImporters(msg.path)];
+				break;
+			default:
+				// Unknown message types are still acked so the caller's
+				// promise settles.
+				break;
+		}
+		port.postMessage({ type: "ack", id: msg.id, result });
+	});
+}
+
+function bump(path) {
+	versions.set(path, (versions.get(path) || 0) + 1);
+}
+
+/**
+ * Bump `path` and every file that transitively imports it. This is
+ * what enables a single edit (e.g. to a shared helper) to propagate
+ * fresh versions all the way up to the service files importing it
+ * via several intermediate modules.
+ */
+function bumpWithImporters(path) {
+	bump(path);
+	for (const importer of collectImporters(path)) bump(importer);
+}
+
+/**
+ * Compute the transitive closure of importers for `path` (BFS, cycle-safe).
+ * Does NOT include `path` itself.
+ */
+function collectImporters(path) {
+	const out = new Set();
+	const queue = [path];
+	while (queue.length > 0) {
+		const cur = queue.shift();
+		const parents = importers.get(cur);
+		if (!parents) continue;
+		for (const p of parents) {
+			if (out.has(p)) continue;
+			out.add(p);
+			queue.push(p);
+		}
+	}
+	return out;
+}
+
+export async function resolve(specifier, context, nextResolve) {
+	const result = await nextResolve(specifier, context);
+	if (!result || !result.url || !result.url.startsWith("file://")) return result;
+
+	// Strip any incoming query so we look up by the canonical filesystem path.
+	const baseUrl = result.url.split("?")[0].split("#")[0];
+
+	let absPath;
+	try {
+		absPath = fileURLToPath(baseUrl);
+	} catch {
+		return result;
+	}
+
+	// Track every resolved user file (default version 0). We skip
+	// `node_modules` to avoid re-importing huge dep trees on every
+	// broker restart.
+	const isUserFile = !absPath.includes(`${sep}node_modules${sep}`);
+	if (isUserFile) {
+		if (!versions.has(absPath)) versions.set(absPath, 0);
+
+		// Record parent → child relation (only for user-space imports).
+		if (context.parentURL && context.parentURL.startsWith("file://")) {
+			const parentBase = context.parentURL.split("?")[0].split("#")[0];
+			let parentPath;
+			try {
+				parentPath = fileURLToPath(parentBase);
+			} catch {
+				parentPath = null;
+			}
+			if (
+				parentPath &&
+				!parentPath.includes(`${sep}node_modules${sep}`) &&
+				parentPath !== absPath
+			) {
+				let set = importers.get(absPath);
+				if (!set) {
+					set = new Set();
+					importers.set(absPath, set);
+				}
+				set.add(parentPath);
+			}
+		}
+	}
+
+	const v = versions.get(absPath);
+	if (v && v > 0) {
+		const querySep = result.url.includes("?") ? "&" : "?";
+		return {
+			...result,
+			url: `${result.url}${querySep}v=${v}`,
+			shortCircuit: true
+		};
+	}
+	return result;
+}

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -7,7 +7,9 @@ import ServiceBroker from "./service-broker.js";
 import utils from "./utils.js";
 import fs from "fs";
 import path from "path";
-import { createRequire } from "module";
+import { createRequire, register } from "module";
+import { pathToFileURL } from "url";
+import { MessageChannel } from "worker_threads";
 import { globSync } from "glob";
 import { inspect } from "util";
 import _ from "lodash";
@@ -61,6 +63,119 @@ export default class MoleculerRunner {
 		this.servicePaths = null;
 		this.broker = null;
 		this.worker = null;
+
+		// Register the ESM hot-reload loader. The loader runs on a
+		// dedicated thread and rewrites resolved file:// URLs with
+		// `?v=<n>` for files whose version has been bumped. This is what
+		// allows transitive imports (e.g. a `shared.mjs` consumed by
+		// several services) to be picked up after a change.
+		this._installLoader();
+
+		// Reload strategy used by the HotReload middleware. ESM exposes
+		// no module graph to user code, so we rely on the loader (see
+		// `_installLoader`) to track imports and apply cache-busting
+		// `?v=<n>` URLs on the next resolve.
+		// Trade-offs:
+		//   - Old module versions stay in memory (acceptable in dev,
+		//     do NOT enable hot-reload in production).
+		//   - Files never imported by any loaded service are unknown to
+		//     the loader; declare them in `extraFiles` if you need them
+		//     watched (e.g. JSON configs, i18n catalogs).
+		this.reloadStrategy = {
+			usesNodeModuleTree: false,
+			loadService: filename => this.importAndCreateService(filename),
+			reloadService: filename => this.importAndCreateService(filename),
+			invalidate: filename => this._postLoaderMessage({ type: "invalidate", path: filename }),
+			invalidateAll: () => this._postLoaderMessage({ type: "invalidateAll" }),
+			getAllUserFiles: () => this._postLoaderMessage({ type: "getAllUserFiles" }),
+			getImporters: filename =>
+				this._postLoaderMessage({ type: "getImporters", path: filename })
+		};
+	}
+
+	/**
+	 * Set up the loader-side `MessagePort` and register the loader.
+	 * Called once from the constructor.
+	 */
+	_installLoader() {
+		const { port1, port2 } = new MessageChannel();
+		this._loaderPort = port1;
+		this._loaderMsgId = 0;
+		this._loaderAcks = new Map();
+
+		port1.on("message", msg => {
+			if (msg && msg.type === "ack") {
+				const cb = this._loaderAcks.get(msg.id);
+				if (cb) {
+					this._loaderAcks.delete(msg.id);
+					cb(msg.result);
+				}
+			}
+		});
+		// Note: do NOT `port1.unref()`. Keeping the port ref'd is what
+		// keeps the main thread alive while the broker is running; with
+		// `unref()` Node fires `beforeExit` early and the broker stops
+		// itself right after start.
+
+		try {
+			register("./runner-esm-loader.mjs", import.meta.url, {
+				data: { port: port2 },
+				transferList: [port2]
+			});
+			this._loaderEnabled = true;
+		} catch (err) {
+			// `module.register` is available on every supported Node
+			// version (>= 22). This branch only triggers if the user
+			// runs an unsupported runtime; degrade to "service file
+			// changes only" instead of crashing.
+			this._loaderEnabled = false;
+			logger.error(
+				new Error(
+					`ESM hot-reload loader could not be registered (${err.message}). ` +
+						"Transitive module changes won't be picked up."
+				)
+			);
+		}
+	}
+
+	/**
+	 * Send a message to the loader and resolve with the loader's `result`
+	 * payload (or `undefined`) once it has been processed. Used by the
+	 * reload strategy and by `importAndCreateService` to fence imports.
+	 *
+	 * @param {object} msg
+	 * @returns {Promise<any>}
+	 */
+	_postLoaderMessage(msg) {
+		if (!this._loaderEnabled) return Promise.resolve();
+		return new Promise(resolve => {
+			const id = ++this._loaderMsgId;
+			this._loaderAcks.set(id, resolve);
+			this._loaderPort.postMessage({ ...msg, id });
+		});
+	}
+
+	/**
+	 * Import a service file and register it on the broker. Used both
+	 * for initial loading and for hot-reload.
+	 *
+	 * Before importing, we round-trip a "sync" message through the
+	 * loader so that any pending invalidations have been applied. The
+	 * MessageChannel is FIFO, so awaiting the sync ack guarantees that
+	 * earlier invalidate messages have been processed first.
+	 *
+	 * @param {string} filename Absolute path to the service file
+	 * @returns {Promise<import('./service.js')>}
+	 */
+	async importAndCreateService(filename) {
+		await this._postLoaderMessage({ type: "sync" });
+		const url = pathToFileURL(filename).href;
+		const mod = await import(url);
+		const content = mod.default;
+
+		const svc = this.broker.createService(content);
+		svc.__filename = filename;
+		return svc;
 	}
 
 	/**
@@ -307,7 +422,9 @@ export default class MoleculerRunner {
 
 		if (this.flags.silent) this.config.logger = false;
 
-		if (this.flags.hot) this.config.hotReload = true;
+		// `--hot` only enables hot reload; do not clobber an object
+		// `hotReload: { extraFiles, modules }` provided via the config file.
+		if (this.flags.hot && !this.config.hotReload) this.config.hotReload = true;
 
 		// console.log("Merged configuration", this.config);
 	}
@@ -429,15 +546,7 @@ export default class MoleculerRunner {
 					}
 				});
 
-			await Promise.all(
-				utils.uniq(serviceFiles).map(async f => {
-					const mod = await import(f.startsWith("/") ? f : "/" + f);
-					const content = mod.default;
-
-					const svc = this.broker.createService(content);
-					svc.__filename = f;
-				})
-			);
+			await Promise.all(utils.uniq(serviceFiles).map(f => this.importAndCreateService(f)));
 		}
 	}
 

--- a/src/runner.d.ts
+++ b/src/runner.d.ts
@@ -5,6 +5,46 @@ import { Worker } from "cluster";
 
 declare namespace Runner {
 	/**
+	 * Pluggable strategy used by the HotReload middleware to load,
+	 * reload and invalidate service modules. Allows alternative module
+	 * systems (e.g. ESM) to plug their own loading mechanism.
+	 */
+	export interface ReloadStrategy {
+		/**
+		 * Whether the strategy relies on Node's CJS module tree
+		 * (`require.cache` / `module.children`) to discover service
+		 * dependencies. When `false` (e.g. ESM), the middleware uses
+		 * `getAllUserFiles` / `getImporters` instead.
+		 */
+		usesNodeModuleTree?: boolean;
+
+		/** Load a service file (used when a new file appears). */
+		loadService(filename: string): Service | Promise<Service>;
+
+		/** Reload a service file (called after destroyService). */
+		reloadService(filename: string): Service | Promise<Service>;
+
+		/** Drop a single file from the module cache (no-op if unsupported). */
+		invalidate(filename: string): void | Promise<void>;
+
+		/** Drop the whole module cache before a broker restart. */
+		invalidateAll(): void | Promise<void>;
+
+		/**
+		 * Optional. Return all user files known to the strategy. Used by
+		 * the HotReload middleware to discover transitive dependencies
+		 * when no native module graph is available.
+		 */
+		getAllUserFiles?(): Promise<string[]>;
+
+		/**
+		 * Optional. Return the transitive closure of files that import
+		 * `filename` (BFS, cycle-safe, excludes `filename` itself).
+		 */
+		getImporters?(filename: string): Promise<string[]>;
+	}
+
+	/**
 	 * Parsed CLI flags
 	 */
 	export interface RunnerFlags {
@@ -63,6 +103,12 @@ declare class Runner {
 	 * Watch folders for hot reload
 	 */
 	watchFolders: string[];
+
+	/**
+	 * Reload strategy used by the HotReload middleware (optional;
+	 * provided e.g. by the ESM runner).
+	 */
+	reloadStrategy?: Runner.ReloadStrategy;
 
 	/**
 	 * Parsed CLI flags

--- a/src/runner.js
+++ b/src/runner.js
@@ -319,7 +319,9 @@ class MoleculerRunner {
 
 		if (this.flags.silent) this.config.logger = false;
 
-		if (this.flags.hot) this.config.hotReload = true;
+		// `--hot` only enables hot reload; do not clobber an object
+		// `hotReload: { extraFiles, modules }` provided via the config file.
+		if (this.flags.hot && !this.config.hotReload) this.config.hotReload = true;
 
 		// console.log("Merged configuration", this.config);
 	}

--- a/test/e2e/scenarios/hot-reload-cjs/moleculer.config.js
+++ b/test/e2e/scenarios/hot-reload-cjs/moleculer.config.js
@@ -1,0 +1,22 @@
+// Configuration loaded by the moleculer-runner started from start.sh.
+// The runner picks up TRANSPORTER / NAMESPACE / SERIALIZER from env so
+// the e2e scenario.js can talk to it via the same TCP transporter.
+const path = require("path");
+
+let transporter = process.env.TRANSPORTER || "TCP";
+if (transporter == "Kafka") transporter = "kafka://localhost:9093";
+
+module.exports = {
+	namespace: process.env.NAMESPACE,
+	nodeID: "runner",
+	logLevel: process.env.LOGLEVEL || "warn",
+	transporter,
+	serializer: process.env.SERIALIZER || "JSON",
+	hotReload: true,
+
+	created(broker) {
+		// The e2e helper service listens for `$shutdown` events so the
+		// scenario can stop the runner cleanly.
+		broker.loadService(path.resolve(__dirname, "../../services/helper.service.js"));
+	}
+};

--- a/test/e2e/scenarios/hot-reload-cjs/scenario.js
+++ b/test/e2e/scenarios/hot-reload-cjs/scenario.js
@@ -1,0 +1,82 @@
+const { assert, createNode, executeScenarios, addScenario } = require("../../utils");
+const fs = require("fs");
+const path = require("path");
+
+const SERVICES_DIR = path.join(__dirname, "services");
+
+const FILES = {
+	greeter: path.join(SERVICES_DIR, "greeter.service.js"),
+	shared: path.join(SERVICES_DIR, "shared.js"),
+	chainA: path.join(SERVICES_DIR, "chain/A.js")
+};
+
+// Snapshot original contents and restore them when the test ends so a
+// failed run does not leave the working tree dirty.
+const SNAPSHOTS = Object.fromEntries(
+	Object.entries(FILES).map(([k, f]) => [k, fs.readFileSync(f, "utf8")])
+);
+
+function restoreAll() {
+	for (const [k, content] of Object.entries(SNAPSHOTS)) {
+		try {
+			fs.writeFileSync(FILES[k], content);
+		} catch (err) {
+			console.error(`Failed to restore ${FILES[k]}`, err);
+		}
+	}
+}
+process.on("exit", restoreAll);
+process.on("SIGINT", () => process.exit(2));
+
+const broker = createNode("supervisor");
+
+/**
+ * Poll an action until it returns `expected` or `timeout` ms elapses.
+ * The hot-reload middleware debounces reloads (~500 ms), so we need
+ * some slack.
+ */
+async function waitFor(actionName, expected, timeout = 10000) {
+	const start = Date.now();
+	let last;
+	while (Date.now() - start < timeout) {
+		try {
+			last = await broker.call(actionName);
+			if (last === expected) return;
+		} catch (err) {
+			last = err.message;
+		}
+		await broker.Promise.delay(200);
+	}
+	throw Object.assign(new Error("Timeout"), {
+		name: "AssertionError",
+		diff: `expected ${actionName} == ${JSON.stringify(expected)}, got ${JSON.stringify(last)}`
+	});
+}
+
+addScenario("reload service file", async () => {
+	await waitFor("greeter.hello", "Hello (v1)");
+	fs.writeFileSync(
+		FILES.greeter,
+		SNAPSHOTS.greeter.replace("return GREETING;", 'return "direct edit";')
+	);
+	await waitFor("greeter.hello", "direct edit");
+});
+
+addScenario("reload on transitive dep change (1 hop)", async () => {
+	// First restore greeter so it returns GREETING again.
+	fs.writeFileSync(FILES.greeter, SNAPSHOTS.greeter);
+	await waitFor("greeter.hello", "Hello (v1)");
+
+	fs.writeFileSync(FILES.shared, 'module.exports = "Hello (v2)";\n');
+	await waitFor("greeter.hello", "Hello (v2)");
+});
+
+addScenario("reload on transitive dep change (3 hops: A>B>C>service)", async () => {
+	const baseline = await broker.call("chained.say");
+	assert(baseline, "C wraps: [B says color is blue]");
+
+	fs.writeFileSync(FILES.chainA, 'module.exports = "red";\n');
+	await waitFor("chained.say", "C wraps: [B says color is red]");
+});
+
+executeScenarios(broker, ["greeter", "chained"]);

--- a/test/e2e/scenarios/hot-reload-cjs/services/chain/A.js
+++ b/test/e2e/scenarios/hot-reload-cjs/services/chain/A.js
@@ -1,0 +1,2 @@
+// Bottom of A→B→C→service chain.
+module.exports = "blue";

--- a/test/e2e/scenarios/hot-reload-cjs/services/chain/B.js
+++ b/test/e2e/scenarios/hot-reload-cjs/services/chain/B.js
@@ -1,0 +1,5 @@
+const COLOR = require("./A");
+
+module.exports = function describe() {
+	return `B says color is ${COLOR}`;
+};

--- a/test/e2e/scenarios/hot-reload-cjs/services/chain/C.js
+++ b/test/e2e/scenarios/hot-reload-cjs/services/chain/C.js
@@ -1,0 +1,5 @@
+const describe = require("./B");
+
+module.exports = function tell() {
+	return `C wraps: [${describe()}]`;
+};

--- a/test/e2e/scenarios/hot-reload-cjs/services/chained.service.js
+++ b/test/e2e/scenarios/hot-reload-cjs/services/chained.service.js
@@ -1,0 +1,11 @@
+const tell = require("./chain/C");
+
+module.exports = {
+	name: "chained",
+
+	actions: {
+		say() {
+			return tell();
+		}
+	}
+};

--- a/test/e2e/scenarios/hot-reload-cjs/services/greeter.service.js
+++ b/test/e2e/scenarios/hot-reload-cjs/services/greeter.service.js
@@ -1,0 +1,11 @@
+const GREETING = require("./shared");
+
+module.exports = {
+	name: "greeter",
+
+	actions: {
+		hello() {
+			return GREETING;
+		}
+	}
+};

--- a/test/e2e/scenarios/hot-reload-cjs/services/shared.js
+++ b/test/e2e/scenarios/hot-reload-cjs/services/shared.js
@@ -1,0 +1,1 @@
+module.exports = "Hello (v1)";

--- a/test/e2e/scenarios/hot-reload-cjs/start.sh
+++ b/test/e2e/scenarios/hot-reload-cjs/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Start hot-reload-cjs scenario...";
+echo "Transporter: $TRANSPORTER";
+echo "Serializer: $SERIALIZER";
+echo "Discoverer: $DISCOVERER";
+
+export NAMESPACE=hot-reload-cjs;
+node ../../../../bin/moleculer-runner.js --hot --config moleculer.config.js services & \
+node scenario.js

--- a/test/e2e/scenarios/hot-reload-esm/moleculer.config.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/moleculer.config.mjs
@@ -1,0 +1,25 @@
+// Configuration loaded by the moleculer-runner-mjs started from start.sh.
+// The runner picks up TRANSPORTER / NAMESPACE / SERIALIZER from env so
+// the e2e scenario.js can talk to it via the same TCP transporter.
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let transporter = process.env.TRANSPORTER || "TCP";
+if (transporter == "Kafka") transporter = "kafka://localhost:9093";
+
+export default {
+	namespace: process.env.NAMESPACE,
+	nodeID: "runner",
+	logLevel: process.env.LOGLEVEL || "warn",
+	transporter,
+	serializer: process.env.SERIALIZER || "JSON",
+	hotReload: true,
+
+	created(broker) {
+		// The e2e helper service listens for `$shutdown` events so the
+		// scenario can stop the runner cleanly.
+		broker.loadService(path.resolve(__dirname, "../../services/helper.service.js"));
+	}
+};

--- a/test/e2e/scenarios/hot-reload-esm/scenario.js
+++ b/test/e2e/scenarios/hot-reload-esm/scenario.js
@@ -1,0 +1,82 @@
+const { assert, createNode, executeScenarios, addScenario } = require("../../utils");
+const fs = require("fs");
+const path = require("path");
+
+const SERVICES_DIR = path.join(__dirname, "services");
+
+const FILES = {
+	greeter: path.join(SERVICES_DIR, "greeter.service.mjs"),
+	shared: path.join(SERVICES_DIR, "shared.mjs"),
+	chainA: path.join(SERVICES_DIR, "chain/A.mjs")
+};
+
+// Snapshot original contents and restore them when the test ends so a
+// failed run does not leave the working tree dirty.
+const SNAPSHOTS = Object.fromEntries(
+	Object.entries(FILES).map(([k, f]) => [k, fs.readFileSync(f, "utf8")])
+);
+
+function restoreAll() {
+	for (const [k, content] of Object.entries(SNAPSHOTS)) {
+		try {
+			fs.writeFileSync(FILES[k], content);
+		} catch (err) {
+			console.error(`Failed to restore ${FILES[k]}`, err);
+		}
+	}
+}
+process.on("exit", restoreAll);
+process.on("SIGINT", () => process.exit(2));
+
+const broker = createNode("supervisor");
+
+/**
+ * Poll an action until it returns `expected` or `timeout` ms elapses.
+ * The hot-reload middleware debounces reloads (~500 ms), so we need
+ * some slack.
+ */
+async function waitFor(actionName, expected, timeout = 10000) {
+	const start = Date.now();
+	let last;
+	while (Date.now() - start < timeout) {
+		try {
+			last = await broker.call(actionName);
+			if (last === expected) return;
+		} catch (err) {
+			last = err.message;
+		}
+		await broker.Promise.delay(200);
+	}
+	throw Object.assign(new Error("Timeout"), {
+		name: "AssertionError",
+		diff: `expected ${actionName} == ${JSON.stringify(expected)}, got ${JSON.stringify(last)}`
+	});
+}
+
+addScenario("reload service file", async () => {
+	await waitFor("greeter.hello", "Hello (v1)");
+	fs.writeFileSync(
+		FILES.greeter,
+		SNAPSHOTS.greeter.replace("return GREETING;", 'return "direct edit";')
+	);
+	await waitFor("greeter.hello", "direct edit");
+});
+
+addScenario("reload on transitive dep change (1 hop)", async () => {
+	// First restore greeter so it returns GREETING again.
+	fs.writeFileSync(FILES.greeter, SNAPSHOTS.greeter);
+	await waitFor("greeter.hello", "Hello (v1)");
+
+	fs.writeFileSync(FILES.shared, 'export const GREETING = "Hello (v2)";\n');
+	await waitFor("greeter.hello", "Hello (v2)");
+});
+
+addScenario("reload on transitive dep change (3 hops: A>B>C>service)", async () => {
+	const baseline = await broker.call("chained.say");
+	assert(baseline, "C wraps: [B says color is blue]");
+
+	fs.writeFileSync(FILES.chainA, 'export const COLOR = "red";\n');
+	await waitFor("chained.say", "C wraps: [B says color is red]");
+});
+
+executeScenarios(broker, ["greeter", "chained"]);

--- a/test/e2e/scenarios/hot-reload-esm/services/chain/A.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/services/chain/A.mjs
@@ -1,0 +1,2 @@
+// Bottom of A→B→C→service chain.
+export const COLOR = "blue";

--- a/test/e2e/scenarios/hot-reload-esm/services/chain/B.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/services/chain/B.mjs
@@ -1,0 +1,5 @@
+import { COLOR } from "./A.mjs";
+
+export function describe() {
+	return `B says color is ${COLOR}`;
+}

--- a/test/e2e/scenarios/hot-reload-esm/services/chain/C.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/services/chain/C.mjs
@@ -1,0 +1,5 @@
+import { describe } from "./B.mjs";
+
+export function tell() {
+	return `C wraps: [${describe()}]`;
+}

--- a/test/e2e/scenarios/hot-reload-esm/services/chained.service.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/services/chained.service.mjs
@@ -1,0 +1,11 @@
+import { tell } from "./chain/C.mjs";
+
+export default {
+	name: "chained",
+
+	actions: {
+		say() {
+			return tell();
+		}
+	}
+};

--- a/test/e2e/scenarios/hot-reload-esm/services/greeter.service.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/services/greeter.service.mjs
@@ -1,0 +1,11 @@
+import { GREETING } from "./shared.mjs";
+
+export default {
+	name: "greeter",
+
+	actions: {
+		hello() {
+			return GREETING;
+		}
+	}
+};

--- a/test/e2e/scenarios/hot-reload-esm/services/shared.mjs
+++ b/test/e2e/scenarios/hot-reload-esm/services/shared.mjs
@@ -1,0 +1,1 @@
+export const GREETING = "Hello (v1)";

--- a/test/e2e/scenarios/hot-reload-esm/start.sh
+++ b/test/e2e/scenarios/hot-reload-esm/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Start hot-reload-esm scenario...";
+echo "Transporter: $TRANSPORTER";
+echo "Serializer: $SERIALIZER";
+echo "Discoverer: $DISCOVERER";
+
+export NAMESPACE=hot-reload-esm;
+node ../../../../bin/moleculer-runner.mjs --hot \
+    --config moleculer.config.mjs \
+    --mask "**/*.service.mjs" \
+    services & \
+node scenario.js


### PR DESCRIPTION
## :memo: Description

Adds hot-reload support to the ESM runner with auto-detection of transitive dependency changes (parity with the CJS runner).

The ESM runner now registers a dedicated loader
(`src/runner-esm-loader.mjs`) via `module.register()`. The loader tracks every resolved user file and the parent → child import relationships seen in its `resolve` hook, building a reverse dependency graph. When a file changes, the loader bumps a per-file version counter for that file and every transitive importer; the next `import()` produces a fresh `?v=<n>` URL so Node re-evaluates the whole chain.

The HotReload middleware was extended to support pluggable strategies (CJS keeps the existing `require.cache` / `module.children` walker; ESM uses the loader). When the runner exposes a non-Node module graph, the middleware enumerates user files via `getAllUserFiles()` and, on change, resolves which services to reload via `getImporters()` — only the affected services are reloaded.

Other changes:
- `--hot` no longer clobbers a `hotReload: { ... }` config object (CJS and ESM runners).
- HotReload watcher callback debounced (leading edge, 100ms) to dedupe the multiple `change` events `fs.watch` fires per save on Linux.
- `runner.d.ts`: new `ReloadStrategy` interface.
- `test/e2e/scenarios/hot-reload-{cjs,esm}/`: new e2e scenarios validating service-file reload, 1-hop transitive dep reload, and 3-hop chain (`A → B → C → service`) reload for both module systems.

### :dart: Relevant issues

- Should fix #1319 

### :gem: Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

- [X] `npm test` and `npm run test:e2e` have been run without errors.
- [X] HMR tests have been added to the E2E test suite.

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] **I have added tests that prove my fix is effective or that my feature works**
- [X] **New and existing unit tests pass locally with my changes**
- [X] I have commented my code, particularly in hard-to-understand areas

This was made with the help of AI through GitHub Copilot.