### PR TITLE
fix: Allow to set false for actions without mixins

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -716,7 +716,7 @@ class Service {
 	 */
 	mergeSchemaActions(src, target) {
 		Object.keys(src).forEach(k => {
-			if (src[k] === false && target[k]) {
+			if (src[k] === false) {
 				delete target[k];
 				return;
 			}

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -1781,7 +1781,8 @@ describe("Test Service class", () => {
 					},
 					handler() {}
 				},
-				update: false
+				update: false,
+				customFind: false
 			};
 
 			const prev = {


### PR DESCRIPTION
## :memo: Description

This allows to easily have "conditional" actions defined in your service (cf. exemple).
The alternative is to wrap it with an object spread or have a "false" mixin handler.

### :dart: Relevant issues

I didn't find any issue about that, but I can create one if you prefer.

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code

```ts
export default {
	name: 'test',
	actions: {
		sum: !env.ENABLE_SUM && {
			handler(ctx) {
				return ctx.params.a + ctx.params.b
			}
		}
	}
}
```

## :vertical_traffic_light: How Has This Been Tested?

We got the issue on our side and found the `mergeSchemaActions` method that handles it. I then found a test case to
add this use case to see if I could repro it.
Once reproduced in unit tests, I fixed it in the code.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
