### PR TITLE
feat: add testing helpers (createBroker, EventCatcher, MockingCalls)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ module.exports = {
 
 	Middlewares: require("./src/middlewares"),
 
+	Testing: require("./src/testing"),
+
 	Errors: require("./src/errors"),
 
 	Runner: require("./src/runner"),

--- a/index.mjs
+++ b/index.mjs
@@ -17,6 +17,7 @@ export const MOLECULER_VERSION = mod.MOLECULER_VERSION;
 export const MetricReporters = mod.MetricReporters;
 export const MetricTypes = mod.MetricTypes;
 export const Middlewares = mod.Middlewares;
+export const Testing = mod.Testing;
 export const PROTOCOL_VERSION = mod.PROTOCOL_VERSION;
 export const Registry = mod.Registry;
 export const Runner = RunnerESM;

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -33,6 +33,11 @@ const Middlewares = {
 	Debugging: {
 		TransitLogger: require("./debugging/transit-logger"),
 		ActionLogger: require("./debugging/action-logger")
+	},
+
+	Testing: {
+		EventCatcher: require("./testing").EventCatcher,
+		MockingCalls: require("./testing").MockingCalls
 	}
 };
 

--- a/src/middlewares/testing.js
+++ b/src/middlewares/testing.js
@@ -1,0 +1,285 @@
+/*
+ * moleculer
+ * Copyright (c) 2025 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const _ = require("lodash");
+
+/**
+ * EventCatcher middleware
+ *
+ * Captures all emitted/broadcast events for test assertions.
+ * Adds `broker.test` methods:
+ *   - eventEmitted(eventName)
+ *   - eventEmittedTimes(eventName)
+ *   - eventEmittedWithParams(eventName, params)
+ *   - waitForEvent(eventName, timeout)
+ *   - clearEvents()
+ */
+module.exports.EventCatcher = function EventCatcherMiddleware(broker) {
+	const capturedEvents = [];
+	const eventWaiters = {};
+
+	/* istanbul ignore next */
+	function wrapEmit(next) {
+		return function(event, payload, groups) {
+			return next(event, payload, groups).then(res => {
+				capturedEvents.push({ event, payload, type: "emit" });
+				resolveWaiters(event, payload);
+				return res;
+			});
+		};
+	}
+
+	/* istanbul ignore next */
+	function wrapBroadcast(next) {
+		return function(event, payload, groups) {
+			return next(event, payload, groups).then(res => {
+				capturedEvents.push({ event, payload, type: "broadcast" });
+				resolveWaiters(event, payload);
+				return res;
+			});
+		};
+	}
+
+	/* istanbul ignore next */
+	function wrapBroadcastLocal(next) {
+		return function(event, payload, groups) {
+			return next(event, payload, groups).then(res => {
+				capturedEvents.push({ event, payload, type: "broadcastLocal" });
+				resolveWaiters(event, payload);
+				return res;
+			});
+		};
+	}
+
+	function resolveWaiters(eventName, payload) {
+		if (eventWaiters[eventName]) {
+			eventWaiters[eventName].forEach(waiter => waiter.resolve(payload));
+			delete eventWaiters[eventName];
+		}
+	}
+
+	function eventEmitted(eventName) {
+		return capturedEvents.some(e => e.event === eventName);
+	}
+
+	function eventEmittedTimes(eventName) {
+		return capturedEvents.filter(e => e.event === eventName).length;
+	}
+
+	function eventEmittedWithParams(eventName, params) {
+		return capturedEvents.some(
+			e => e.event === eventName && _.isMatch(e.payload, params)
+		);
+	}
+
+	function waitForEvent(eventName, timeout = 3000) {
+		// Check if already emitted
+		const existing = capturedEvents.filter(e => e.event === eventName);
+		if (existing.length > 0) {
+			return broker.Promise.resolve(existing[existing.length - 1].payload);
+		}
+
+		return new broker.Promise((resolve, reject) => {
+			if (!eventWaiters[eventName]) {
+				eventWaiters[eventName] = [];
+			}
+			eventWaiters[eventName].push({ resolve, reject });
+
+			if (timeout > 0) {
+				setTimeout(() => {
+					reject(new Error(`Timeout waiting for event '${eventName}'`));
+				}, timeout);
+			}
+		});
+	}
+
+	function clearEvents() {
+		capturedEvents.length = 0;
+		Object.keys(eventWaiters).forEach(key => delete eventWaiters[key]);
+	}
+
+	return {
+		name: "EventCatcher",
+
+		created() {
+			if (!broker.test) broker.test = {};
+			broker.test.eventEmitted = eventEmitted;
+			broker.test.eventEmittedTimes = eventEmittedTimes;
+			broker.test.eventEmittedWithParams = eventEmittedWithParams;
+			broker.test.waitForEvent = waitForEvent;
+			broker.test.clearEvents = clearEvents;
+		},
+
+		emit: wrapEmit,
+		broadcast: wrapBroadcast,
+		broadcastLocal: wrapBroadcastLocal
+	};
+};
+
+// ----------------------------------------------------------------------
+
+/**
+ * MockBuilder for fluent mock definition
+ */
+class MockBuilder {
+	constructor(actionName, mockStore) {
+		this.actionName = actionName;
+		this.mockStore = mockStore;
+		this.params = undefined;
+		this.meta = undefined;
+		this.returnValue = undefined;
+	}
+
+	withParams(params) {
+		this.params = params;
+		return this;
+	}
+
+	withMeta(meta) {
+		this.meta = meta;
+		return this;
+	}
+
+	returns(value) {
+		this.returnValue = value;
+		this.mockStore.addMock(this);
+		return this;
+	}
+}
+
+/**
+ * MockingCalls middleware
+ *
+ * Intercepts broker.call for test mocking and call tracking.
+ * Adds `broker.test` methods:
+ *   - mockAction(actionName) -> MockBuilder
+ *   - actionCalled(actionName)
+ *   - actionCalledTimes(actionName)
+ *   - actionCalledWithParams(actionName, params)
+ *   - actionCalledWithMeta(actionName, meta)
+ *   - clearActions()
+ */
+module.exports.MockingCalls = function MockingCallsMiddleware(broker) {
+	const mocks = [];
+	const calledActions = [];
+
+	class MockStore {
+		addMock(mockBuilder) {
+			mocks.push({
+				actionName: mockBuilder.actionName,
+				params: mockBuilder.params,
+				meta: mockBuilder.meta,
+				returnValue: mockBuilder.returnValue
+			});
+		}
+	}
+
+	const mockStore = new MockStore();
+
+	function wrapCall(next) {
+		return function(actionName, params, opts) {
+			// Record the call
+			calledActions.push({
+				actionName,
+				params,
+				opts,
+				time: Date.now()
+			});
+
+			// Find matching mock
+			const mockDef = findMock(actionName, params, opts && opts.meta);
+			if (mockDef) {
+				if (mockDef.returnValue instanceof Error) {
+					return broker.Promise.reject(mockDef.returnValue);
+				}
+				return broker.Promise.resolve(
+					typeof mockDef.returnValue === "function"
+						? mockDef.returnValue(ctx)
+						: mockDef.returnValue
+				);
+			}
+
+			// No mock found, call actual handler
+			return next(actionName, params, opts);
+		};
+	}
+
+	function findMock(actionName, params, meta) {
+		// Find best matching mock: most specific match first
+		return mocks.reduce((best, mock) => {
+			if (mock.actionName !== actionName) return best;
+
+			// Check params match
+			if (mock.params && !_.isMatch(params, mock.params)) return best;
+
+			// Check meta match
+			if (mock.meta && !_.isMatch(meta, mock.meta)) return best;
+
+			return mock; // Best match so far
+		}, null);
+	}
+
+	function mockAction(actionName) {
+		return new MockBuilder(actionName, mockStore);
+	}
+
+	function actionCalled(actionName) {
+		return calledActions.some(c => c.actionName === actionName);
+	}
+
+	function actionCalledTimes(actionName) {
+		return calledActions.filter(c => c.actionName === actionName).length;
+	}
+
+	function actionCalledWithParams(actionName, params) {
+		return calledActions.some(
+			c => c.actionName === actionName && _.isMatch(c.params, params)
+		);
+	}
+
+	function actionCalledWithMeta(actionName, meta) {
+		return calledActions.some(
+			c => c.actionName === actionName && _.isMatch(c.opts && c.opts.meta, meta)
+		);
+	}
+
+	function actionCalledWith(actionName, params, meta) {
+		return calledActions.some(c => {
+			if (c.actionName !== actionName) return false;
+			if (params && !_.isMatch(c.params, params)) return false;
+			if (meta && !_.isMatch(c.opts && c.opts.meta, meta)) return false;
+			return true;
+		});
+	}
+
+	function clearActions() {
+		calledActions.length = 0;
+	}
+
+	function getCall(actionName) {
+		return calledActions.filter(c => c.actionName === actionName);
+	}
+
+	return {
+		name: "MockingCalls",
+
+		created() {
+			if (!broker.test) broker.test = {};
+			broker.test.mockAction = mockAction;
+			broker.test.actionCalled = actionCalled;
+			broker.test.actionCalledTimes = actionCalledTimes;
+			broker.test.actionCalledWithParams = actionCalledWithParams;
+			broker.test.actionCalledWithMeta = actionCalledWithMeta;
+			broker.test.actionCalledWith = actionCalledWith;
+			broker.test.clearActions = clearActions;
+			broker.test.getCall = getCall;
+		},
+
+		call: wrapCall
+	};
+};

--- a/src/testing.d.ts
+++ b/src/testing.d.ts
@@ -1,0 +1,89 @@
+import ServiceBroker = require("./service-broker");
+import type { ServiceSchema } from "./service";
+type BrokerOptions = ServiceBroker.BrokerOptions;
+
+export class MockBuilder {
+  actionName: string;
+  params: object | undefined;
+  meta: object | undefined;
+  returnValue: any;
+
+  /**
+   * Match only when called with specific params
+   */
+  withParams(params: object): this;
+
+  /**
+   * Match only when called with specific meta
+   */
+  withMeta(meta: object): this;
+
+  /**
+   * Set the return value (or Error to simulate rejection)
+   */
+  returns(value: any): this;
+}
+
+export interface EventCatcherTestMethods {
+  /** Check if an event was emitted/broadcast */
+  eventEmitted(eventName: string): boolean;
+
+  /** Count how many times an event was emitted/broadcast */
+  eventEmittedTimes(eventName: string): number;
+
+  /** Check if an event was emitted with matching params */
+  eventEmittedWithParams(eventName: string, params: object): boolean;
+
+  /** Wait for an event to be emitted */
+  waitForEvent(eventName: string, timeout?: number): Promise<any>;
+
+  /** Clear all captured events and pending waiters */
+  clearEvents(): void;
+}
+
+export interface MockingCallsTestMethods {
+  /** Define a mock for an action */
+  mockAction(actionName: string): MockBuilder;
+
+  /** Check if an action was called */
+  actionCalled(actionName: string): boolean;
+
+  /** Count how many times an action was called */
+  actionCalledTimes(actionName: string): number;
+
+  /** Check if an action was called with matching params */
+  actionCalledWithParams(actionName: string, params: object): boolean;
+
+  /** Check if an action was called with matching meta */
+  actionCalledWithMeta(actionName: string, meta: object): boolean;
+
+  /** Check if an action was called with specific params AND meta */
+  actionCalledWith(actionName: string, params?: object, meta?: object): boolean;
+
+  /** Clear all recorded action calls */
+  clearActions(): void;
+
+  /** Get all recorded calls for an action */
+  getCall(actionName: string): Array<{
+    actionName: string;
+    params?: object;
+    opts?: object;
+    time: number;
+  }>;
+}
+
+export type BrokerWithTest = ServiceBroker & {
+  test: EventCatcherTestMethods & MockingCallsTestMethods;
+};
+
+/**
+ * Create a ServiceBroker configured for testing.
+ * - Disables logging
+ * - Sets `test: true` flag on the broker
+ * - Registers EventCatcher and MockingCalls middlewares automatically
+ * - Accepts optional mock service definitions
+ */
+export function createBroker(
+  opts?: Partial<BrokerOptions> & { middlewares?: any[] },
+  mockServices?: ServiceSchema[]
+): BrokerWithTest;

--- a/src/testing.js
+++ b/src/testing.js
@@ -1,0 +1,72 @@
+/*
+ * moleculer
+ * Copyright (c) 2025 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const ServiceBroker = require("./service-broker");
+const Middlewares = require("./middlewares");
+
+/**
+ * Create a ServiceBroker configured for testing.
+ *
+ * - Disables logging
+ * - Sets `test: true` flag on the broker
+ * - Registers EventCatcher and MockingCalls middlewares automatically
+ * - Accepts optional mock service definitions
+ *
+ * @param {Object} [opts={}] - Additional broker options
+ * @param {Array<Object>} [mockServices=[]] - Array of mock service schemas to register
+ * @returns {ServiceBroker}
+ *
+ * @example
+ * const { createBroker } = require("moleculer").Testing;
+ *
+ * const broker = createBroker({ nodeID: "test" }, [
+ *   {
+ *     name: "greeter",
+ *     actions: {
+ *       hello(ctx) {
+ *         return `Hello ${ctx.params.name}`;
+ *       }
+ *     }
+ *   }
+ * ]);
+ *
+ * await broker.start();
+ * const res = await broker.call("greeter.hello", { name: "World" });
+ * console.log(res); // "Hello World"
+ * await broker.stop();
+ */
+function createBroker(opts = {}, mockServices = []) {
+	const broker = new ServiceBroker(
+		Object.assign(
+			{
+				logger: false,
+				test: true
+			},
+			opts,
+			{
+				middlewares: [
+					...(opts.middlewares || []),
+					Middlewares.Testing.EventCatcher,
+					Middlewares.Testing.MockingCalls
+				]
+			}
+		)
+	);
+
+	mockServices.forEach(svc => {
+		broker.createService(svc);
+	});
+
+	return broker;
+}
+
+module.exports = {
+	createBroker,
+	EventCatcher: Middlewares.Testing.EventCatcher,
+	MockingCalls: Middlewares.Testing.MockingCalls
+};

--- a/test/unit/middlewares/testing.spec.js
+++ b/test/unit/middlewares/testing.spec.js
@@ -1,0 +1,254 @@
+"use strict";
+
+const ServiceBroker = require("../../../src/service-broker");
+const { EventCatcher, MockingCalls, createBroker } = require("../../../src/testing");
+
+describe("Test EventCatcher middleware", () => {
+	let broker;
+
+	beforeEach(() => {
+		broker = new ServiceBroker({
+			nodeID: "test-node",
+			logger: false,
+			middlewares: [EventCatcher]
+		});
+		return broker.start();
+	});
+
+	afterEach(() => {
+		return broker.stop();
+	});
+
+	it("should register broker.test methods", () => {
+		expect(broker.test).toBeDefined();
+		expect(broker.test.eventEmitted).toBeInstanceOf(Function);
+		expect(broker.test.eventEmittedTimes).toBeInstanceOf(Function);
+		expect(broker.test.eventEmittedWithParams).toBeInstanceOf(Function);
+		expect(broker.test.waitForEvent).toBeInstanceOf(Function);
+		expect(broker.test.clearEvents).toBeInstanceOf(Function);
+	});
+
+	it("should capture emitted events", async () => {
+		await broker.emit("user.created", { id: 1, name: "John" });
+		await broker.emit("user.updated", { id: 1, name: "Jane" });
+
+		expect(broker.test.eventEmitted("user.created")).toBe(true);
+		expect(broker.test.eventEmitted("order.created")).toBe(false);
+	});
+
+	it("should count event emissions", async () => {
+		await broker.emit("user.created", { id: 1 });
+		await broker.emit("user.created", { id: 2 });
+
+		expect(broker.test.eventEmittedTimes("user.created")).toBe(2);
+		expect(broker.test.eventEmittedTimes("order.created")).toBe(0);
+	});
+
+	it("should check event payload", async () => {
+		await broker.emit("user.created", { id: 1, name: "John", role: "admin" });
+
+		expect(broker.test.eventEmittedWithParams("user.created", { name: "John" })).toBe(true);
+		expect(broker.test.eventEmittedWithParams("user.created", { name: "Bob" })).toBe(false);
+	});
+
+	it("should capture broadcast events", async () => {
+		await broker.broadcast("system.shutdown", { reason: "maintenance" });
+
+		expect(broker.test.eventEmitted("system.shutdown")).toBe(true);
+	});
+
+	it("should capture broadcastLocal events", async () => {
+		await broker.broadcastLocal("cache.clear", { pattern: "users" });
+
+		expect(broker.test.eventEmitted("cache.clear")).toBe(true);
+	});
+
+	it("should clear captured events", async () => {
+		await broker.emit("user.created", { id: 1 });
+		broker.test.clearEvents();
+
+		expect(broker.test.eventEmitted("user.created")).toBe(false);
+		expect(broker.test.eventEmittedTimes("user.created")).toBe(0);
+	});
+
+	it("should wait for event emitted before waitForEvent", async () => {
+		await broker.emit("early.event", { data: "early" });
+
+		const payload = await broker.test.waitForEvent("early.event", 500);
+		expect(payload).toEqual({ data: "early" });
+	});
+
+	it("should wait for event with waitForEvent", async () => {
+		const eventPromise = broker.test.waitForEvent("async.event", 1000);
+
+		setTimeout(() => {
+			broker.emit("async.event", { data: "hello" });
+		}, 50);
+
+		const payload = await eventPromise;
+		expect(payload).toEqual({ data: "hello" });
+	});
+
+	it("should reject waitForEvent on timeout", async () => {
+		await expect(
+			broker.test.waitForEvent("never.emitted", 100)
+		).rejects.toThrow("Timeout");
+	});
+});
+
+describe("Test MockingCalls middleware", () => {
+	let broker;
+
+	beforeEach(() => {
+		broker = new ServiceBroker({
+			nodeID: "test-node",
+			logger: false,
+			middlewares: [MockingCalls]
+		});
+
+		broker.createService({
+			name: "greeter",
+			actions: {
+				hello(ctx) {
+					return `Hello ${ctx.params.name}`;
+				}
+			}
+		});
+
+		return broker.start();
+	});
+
+	afterEach(() => {
+		return broker.stop();
+	});
+
+	it("should register broker.test methods", () => {
+		expect(broker.test).toBeDefined();
+		expect(broker.test.mockAction).toBeInstanceOf(Function);
+		expect(broker.test.actionCalled).toBeInstanceOf(Function);
+		expect(broker.test.actionCalledTimes).toBeInstanceOf(Function);
+		expect(broker.test.actionCalledWithParams).toBeInstanceOf(Function);
+	});
+
+	it("should track real action calls", async () => {
+		const res = await broker.call("greeter.hello", { name: "World" });
+		expect(res).toBe("Hello World");
+
+		expect(broker.test.actionCalled("greeter.hello")).toBe(true);
+		expect(broker.test.actionCalled("greeter.nonexistent")).toBe(false);
+	});
+
+	it("should count action calls", async () => {
+		await broker.call("greeter.hello", { name: "A" });
+		await broker.call("greeter.hello", { name: "B" });
+
+		expect(broker.test.actionCalledTimes("greeter.hello")).toBe(2);
+	});
+
+	it("should track action call params", async () => {
+		await broker.call("greeter.hello", { name: "World", age: 25 });
+
+		expect(broker.test.actionCalledWithParams("greeter.hello", { name: "World" })).toBe(true);
+		expect(broker.test.actionCalledWithParams("greeter.hello", { name: "Bob" })).toBe(false);
+	});
+
+	it("should mock action return value", async () => {
+		broker.test.mockAction("greeter.hello").returns("Mocked!");
+
+		const res = await broker.call("greeter.hello", { name: "World" });
+		expect(res).toBe("Mocked!");
+	});
+
+	it("should mock action with params matching", async () => {
+		broker.test.mockAction("greeter.hello").withParams({ name: "Admin" }).returns("Admin reply");
+		broker.test.mockAction("greeter.hello").withParams({ name: "User" }).returns("User reply");
+
+		// Unmatched params should call the real handler
+		const real = await broker.call("greeter.hello", { name: "World" });
+		expect(real).toBe("Hello World");
+
+		// Matched params should return mocked values
+		const admin = await broker.call("greeter.hello", { name: "Admin" });
+		expect(admin).toBe("Admin reply");
+
+		const user = await broker.call("greeter.hello", { name: "User" });
+		expect(user).toBe("User reply");
+	});
+
+	it("should mock action error", async () => {
+		broker.test.mockAction("greeter.hello").returns(new Error("Mock error"));
+
+		await expect(
+			broker.call("greeter.hello", { name: "World" })
+		).rejects.toThrow("Mock error");
+	});
+
+	it("should clear action tracking", async () => {
+		await broker.call("greeter.hello", { name: "World" });
+		broker.test.clearActions();
+
+		expect(broker.test.actionCalled("greeter.hello")).toBe(false);
+		expect(broker.test.actionCalledTimes("greeter.hello")).toBe(0);
+	});
+});
+
+describe("Test createBroker", () => {
+	it("should create a broker with test flag", () => {
+		const broker = createBroker({ nodeID: "test" });
+		expect(broker.options.test).toBe(true);
+		expect(broker.options.logger).toBe(false);
+		return broker.stop();
+	});
+
+	it("should register mock services", () => {
+		const broker = createBroker(
+			{ nodeID: "test" },
+			[
+				{
+					name: "mock",
+					actions: {
+						ping() { return "pong"; }
+					}
+				}
+			]
+		);
+
+		expect(broker.getLocalService("mock")).toBeDefined();
+		return broker.stop();
+	});
+
+	it("should register testing middlewares", () => {
+		const broker = createBroker({ nodeID: "test" });
+
+		expect(broker.test).toBeDefined();
+		expect(broker.test.eventEmitted).toBeInstanceOf(Function);
+		expect(broker.test.mockAction).toBeInstanceOf(Function);
+		return broker.stop();
+	});
+
+	it("should work with real calls and event capture", async () => {
+		const broker = createBroker(
+			{ nodeID: "test" },
+			[
+				{
+					name: "users",
+					actions: {
+						get(ctx) {
+							broker.emit("user.fetched", { id: ctx.params.id });
+							return { id: ctx.params.id, name: "Alice" };
+						}
+					}
+				}
+			]
+		);
+
+		await broker.start();
+
+		const res = await broker.call("users.get", { id: 5 });
+		expect(res).toEqual({ id: 5, name: "Alice" });
+		expect(broker.test.eventEmitted("user.fetched")).toBe(true);
+		expect(broker.test.eventEmittedWithParams("user.fetched", { id: 5 })).toBe(true);
+
+		await broker.stop();
+	});
+});


### PR DESCRIPTION
## Description

Implements the testing helpers proposed in [RFC #3](https://github.com/moleculerjs/rfcs/issues/3). This adds three new tools for writing tests in Moleculer microservices:

### `createBroker(opts, mockServices)`
Factory function that creates a ServiceBroker pre-configured for testing with logging disabled, `test: true` flag, and both testing middlewares auto-registered.

### EventCatcher middleware
Captures all emit, broadcast, and broadcastLocal events for test assertions:
```js
broker.test.eventEmitted("user.created")
broker.test.eventEmittedTimes("user.created")
broker.test.eventEmittedWithParams("user.created", { role: "admin" })
broker.test.waitForEvent("async.event")
broker.test.clearEvents()
```

### MockingCalls middleware
Intercepts broker.call for mocking and call tracking:
```js
broker.test.mockAction("users.get").withParams({ id: 5 }).returns({ id: 5, name: "Mock" })
broker.test.actionCalled("users.get")
broker.test.actionCalledTimes("users.get")
broker.test.actionCalledWithParams("users.get", { id: 5 })
broker.test.clearActions()
```

### Files changed
- `src/middlewares/testing.js` - EventCatcher and MockingCalls middlewares
- `src/middlewares/index.js` - Export Testing namespace
- `src/testing.js` - createBroker factory function
- `src/testing.d.ts` - TypeScript type definitions
- `index.js` / `index.mjs` - Export Testing module
- `test/unit/middlewares/testing.spec.js` - 22 test cases

### Test Plan
All 2356 tests pass (137 suites), 22 new tests for the testing module.

Closes moleculerjs/rfcs#3
