### PR TITLE
feat: add testing helpers (createBroker, EventCatcher, MockingCalls)

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = {
 
 	Runner: require("./src/runner"),
 	Utils: require("./src/utils"),
+	Testing: require("./src/testing"),
 
 	CIRCUIT_CLOSE,
 	CIRCUIT_HALF_OPEN,

--- a/index.mjs
+++ b/index.mjs
@@ -30,3 +30,4 @@ export const Transporters = mod.Transporters;
 export const Utils = mod.Utils;
 export const Validator = mod.Validator;
 export const Validators = mod.Validators;
+export const Testing = mod.Testing;

--- a/src/testing.d.ts
+++ b/src/testing.d.ts
@@ -1,0 +1,65 @@
+import type ServiceBroker = require("./service-broker");
+import type { ServiceSchema, BrokerOptions } from "./service-broker";
+
+export interface TestBrokerOptions extends BrokerOptions {
+	/** Service schemas to load when the broker is created. */
+	services?: ServiceSchema[];
+}
+
+export interface TestHelpers {
+	/** Returns true if the named event was emitted at least once. */
+	eventEmitted(name: string): boolean;
+	/** Returns how many times the named event was emitted. */
+	eventEmittedTimes(name: string): number;
+	/**
+	 * Returns true if the named event was emitted with params that include
+	 * all key/value pairs in `expected` (deep partial match).
+	 */
+	eventEmittedWithParams(name: string, params: Record<string, unknown>): boolean;
+	/** Clears all captured events. */
+	clearEvents(): void;
+
+	/** Register a static or factory mock response for an action. */
+	mockAction(name: string, response: unknown | ((params: unknown) => unknown)): void;
+	/** Returns true if the named action was called at least once. */
+	actionCalled(name: string): boolean;
+	/** Returns how many times the named action was called. */
+	actionCalledTimes(name: string): number;
+	/**
+	 * Returns true if the named action was called with params that include
+	 * all key/value pairs in `expected` (deep partial match).
+	 */
+	actionCalledWithParams(name: string, params: Record<string, unknown>): boolean;
+	/** Clears all mocks and call history. */
+	clearActions(): void;
+}
+
+export interface TestServiceBroker extends ServiceBroker {
+	test: TestHelpers;
+}
+
+/**
+ * Creates a ServiceBroker pre-configured for unit testing.
+ * Logger is disabled by default. EventCatcher and MockingCalls middlewares are
+ * installed automatically and exposed via broker.test.
+ */
+export declare function createBroker(options?: TestBrokerOptions): TestServiceBroker;
+
+/** Middleware that captures emitted events for assertion in tests. */
+export declare class EventCatcher {
+	middleware(): object;
+	emitted(name: string): boolean;
+	emittedTimes(name: string): number;
+	emittedWithParams(name: string, expected: Record<string, unknown>): boolean;
+	clear(): void;
+}
+
+/** Middleware that intercepts broker.call() for mocking and assertion in tests. */
+export declare class MockingCalls {
+	middleware(): object;
+	mock(name: string, response: unknown | ((params: unknown) => unknown)): void;
+	called(name: string): boolean;
+	calledTimes(name: string): number;
+	calledWithParams(name: string, expected: Record<string, unknown>): boolean;
+	clear(): void;
+}

--- a/src/testing.js
+++ b/src/testing.js
@@ -1,0 +1,181 @@
+/*
+ * moleculer
+ * Copyright (c) 2025 MoleculerJS (https://github.com/moleculerjs/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const ServiceBroker = require("./service-broker");
+
+/**
+ * Creates a ServiceBroker pre-configured for unit testing.
+ * Logger is disabled by default. EventCatcher and MockingCalls middlewares are
+ * installed automatically and exposed via broker.test.
+ *
+ * @param {Object} options - Broker options. Accepts an extra `services` array.
+ * @returns {ServiceBroker}
+ */
+const createBroker = (options = {}) => {
+	const { services = [], middlewares = [], ...rest } = options;
+
+	const eventCatcher = new EventCatcher();
+	const mockingCalls = new MockingCalls();
+
+	const broker = new ServiceBroker({
+		logger: false,
+		...rest,
+		middlewares: [eventCatcher.middleware(), mockingCalls.middleware(), ...middlewares],
+	});
+
+	broker.test = {
+		eventEmitted: (name) => eventCatcher.emitted(name),
+		eventEmittedTimes: (name) => eventCatcher.emittedTimes(name),
+		eventEmittedWithParams: (name, params) => eventCatcher.emittedWithParams(name, params),
+		clearEvents: () => eventCatcher.clear(),
+
+		mockAction: (name, response) => mockingCalls.mock(name, response),
+		actionCalled: (name) => mockingCalls.called(name),
+		actionCalledTimes: (name) => mockingCalls.calledTimes(name),
+		actionCalledWithParams: (name, params) => mockingCalls.calledWithParams(name, params),
+		clearActions: () => mockingCalls.clear(),
+	};
+
+	for (const svc of services) broker.createService(svc);
+
+	return broker;
+};
+
+/**
+ * Middleware that captures events emitted via broker.emit / broadcast / broadcastLocal.
+ * Used by createBroker to power the broker.test event assertion helpers.
+ */
+class EventCatcher {
+	constructor() {
+		this._events = [];
+	}
+
+	middleware() {
+		const self = this;
+		return {
+			name: "EventCatcher",
+			emit(next) {
+				return (eventName, payload, opts) => {
+					self._events.push({ name: eventName, params: payload });
+					return next(eventName, payload, opts);
+				};
+			},
+			broadcast(next) {
+				return (eventName, payload, opts) => {
+					self._events.push({ name: eventName, params: payload });
+					return next(eventName, payload, opts);
+				};
+			},
+			broadcastLocal(next) {
+				return (eventName, payload, opts) => {
+					self._events.push({ name: eventName, params: payload });
+					return next(eventName, payload, opts);
+				};
+			},
+		};
+	}
+
+	/** Returns true if the named event was emitted at least once. */
+	emitted(name) {
+		return this._events.some((e) => e.name === name);
+	}
+
+	/** Returns how many times the named event was emitted. */
+	emittedTimes(name) {
+		return this._events.filter((e) => e.name === name).length;
+	}
+
+	/**
+	 * Returns true if the named event was emitted with params that include
+	 * all key/value pairs in `expected` (deep partial match).
+	 */
+	emittedWithParams(name, expected) {
+		return this._events
+			.filter((e) => e.name === name)
+			.some((e) => deepPartialMatch(e.params, expected));
+	}
+
+	/** Clears all captured events. */
+	clear() {
+		this._events = [];
+	}
+}
+
+/**
+ * Middleware that intercepts broker.call() to enable response mocking and call assertions.
+ * Used by createBroker to power the broker.test action helpers.
+ */
+class MockingCalls {
+	constructor() {
+		this._mocks = new Map();
+		this._calls = [];
+	}
+
+	middleware() {
+		const self = this;
+		return {
+			name: "MockingCalls",
+			call(next) {
+				return (actionName, params, opts) => {
+					self._calls.push({ name: actionName, params });
+					if (self._mocks.has(actionName)) {
+						const response = self._mocks.get(actionName);
+						return Promise.resolve(
+							typeof response === "function" ? response(params) : response
+						);
+					}
+					return next(actionName, params, opts);
+				};
+			},
+		};
+	}
+
+	/** Register a static or factory mock response for an action. */
+	mock(name, response) {
+		this._mocks.set(name, response);
+	}
+
+	/** Returns true if the named action was called at least once. */
+	called(name) {
+		return this._calls.some((c) => c.name === name);
+	}
+
+	/** Returns how many times the named action was called. */
+	calledTimes(name) {
+		return this._calls.filter((c) => c.name === name).length;
+	}
+
+	/**
+	 * Returns true if the named action was called with params that include
+	 * all key/value pairs in `expected` (deep partial match).
+	 */
+	calledWithParams(name, expected) {
+		return this._calls
+			.filter((c) => c.name === name)
+			.some((c) => deepPartialMatch(c.params, expected));
+	}
+
+	/** Clears all mocks and call history. */
+	clear() {
+		this._calls = [];
+		this._mocks.clear();
+	}
+}
+
+/**
+ * Deep partial match: returns true if all keys in `expected` exist in `actual`
+ * with equal values. Extra keys in `actual` are ignored.
+ */
+const deepPartialMatch = (actual, expected) => {
+	if (actual === expected) return true;
+	if (expected === null || typeof expected !== "object") return actual === expected;
+	if (actual === null || typeof actual !== "object") return false;
+	return Object.keys(expected).every((key) => deepPartialMatch(actual[key], expected[key]));
+};
+
+module.exports = { createBroker, EventCatcher, MockingCalls };

--- a/test/unit/testing.spec.js
+++ b/test/unit/testing.spec.js
@@ -1,0 +1,163 @@
+"use strict";
+
+const { createBroker, EventCatcher, MockingCalls } = require("../../src/testing");
+
+describe("Testing Helpers", () => {
+	describe("createBroker", () => {
+		it("should create a broker with a test namespace", async () => {
+			const broker = createBroker();
+			expect(broker).toBeDefined();
+			expect(broker.test).toBeDefined();
+			await broker.stop();
+		});
+
+		it("should disable logging by default", async () => {
+			const broker = createBroker();
+			expect(broker.options.logger).toBe(false);
+			await broker.stop();
+		});
+
+		it("should allow overriding broker options", async () => {
+			const broker = createBroker({ nodeID: "test-node" });
+			expect(broker.nodeID).toBe("test-node");
+			await broker.stop();
+		});
+
+		it("should load services passed via options", async () => {
+			const broker = createBroker({
+				services: [
+					{
+						name: "greeter",
+						actions: {
+							hello: () => "world",
+						},
+					},
+				],
+			});
+			await broker.start();
+			const res = await broker.call("greeter.hello");
+			expect(res).toBe("world");
+			await broker.stop();
+		});
+	});
+
+	describe("EventCatcher", () => {
+		let broker;
+
+		beforeEach(async () => {
+			broker = createBroker();
+			await broker.start();
+		});
+
+		afterEach(() => broker.stop());
+
+		it("should detect emitted events", () => {
+			broker.emit("user.created", { id: 1 });
+			expect(broker.test.eventEmitted("user.created")).toBe(true);
+			expect(broker.test.eventEmitted("user.deleted")).toBe(false);
+		});
+
+		it("should count emitted events", () => {
+			broker.emit("user.created", { id: 1 });
+			broker.emit("user.created", { id: 2 });
+			expect(broker.test.eventEmittedTimes("user.created")).toBe(2);
+			expect(broker.test.eventEmittedTimes("user.deleted")).toBe(0);
+		});
+
+		it("should match event params using deep partial matching", () => {
+			broker.emit("user.created", { id: 1, name: "Babacar", role: "admin" });
+			expect(broker.test.eventEmittedWithParams("user.created", { id: 1 })).toBe(true);
+			expect(broker.test.eventEmittedWithParams("user.created", { name: "Babacar" })).toBe(true);
+			expect(broker.test.eventEmittedWithParams("user.created", { id: 99 })).toBe(false);
+		});
+
+		it("should capture broadcast events", () => {
+			broker.broadcast("order.shipped", { orderId: 42 });
+			expect(broker.test.eventEmitted("order.shipped")).toBe(true);
+			expect(broker.test.eventEmittedWithParams("order.shipped", { orderId: 42 })).toBe(true);
+		});
+
+		it("should capture broadcastLocal events", () => {
+			broker.broadcastLocal("cache.cleared", { key: "users" });
+			expect(broker.test.eventEmitted("cache.cleared")).toBe(true);
+		});
+
+		it("should clear captured events", () => {
+			broker.emit("user.created", { id: 1 });
+			broker.test.clearEvents();
+			expect(broker.test.eventEmitted("user.created")).toBe(false);
+			expect(broker.test.eventEmittedTimes("user.created")).toBe(0);
+		});
+	});
+
+	describe("MockingCalls", () => {
+		let broker;
+
+		beforeEach(async () => {
+			broker = createBroker();
+			await broker.start();
+		});
+
+		afterEach(() => broker.stop());
+
+		it("should return a mocked static response", async () => {
+			broker.test.mockAction("users.get", { id: 1, name: "Babacar" });
+			const res = await broker.call("users.get", { id: 1 });
+			expect(res).toEqual({ id: 1, name: "Babacar" });
+		});
+
+		it("should support factory mocks", async () => {
+			broker.test.mockAction("users.get", (params) => ({ ...params, fetched: true }));
+			const res = await broker.call("users.get", { id: 42 });
+			expect(res).toEqual({ id: 42, fetched: true });
+		});
+
+		it("should detect called actions", async () => {
+			broker.test.mockAction("users.get", null);
+			await broker.call("users.get", { id: 1 });
+			expect(broker.test.actionCalled("users.get")).toBe(true);
+			expect(broker.test.actionCalled("users.delete")).toBe(false);
+		});
+
+		it("should count action calls", async () => {
+			broker.test.mockAction("users.get", null);
+			await broker.call("users.get", { id: 1 });
+			await broker.call("users.get", { id: 2 });
+			expect(broker.test.actionCalledTimes("users.get")).toBe(2);
+		});
+
+		it("should match call params using deep partial matching", async () => {
+			broker.test.mockAction("users.create", { id: 99 });
+			await broker.call("users.create", { name: "Babacar", role: "admin" });
+			expect(broker.test.actionCalledWithParams("users.create", { name: "Babacar" })).toBe(true);
+			expect(broker.test.actionCalledWithParams("users.create", { role: "admin" })).toBe(true);
+			expect(broker.test.actionCalledWithParams("users.create", { name: "Other" })).toBe(false);
+		});
+
+		it("should clear mocks and call history", async () => {
+			broker.test.mockAction("users.get", { id: 1 });
+			await broker.call("users.get", { id: 1 });
+			broker.test.clearActions();
+			expect(broker.test.actionCalled("users.get")).toBe(false);
+			expect(broker.test.actionCalledTimes("users.get")).toBe(0);
+		});
+	});
+
+	describe("EventCatcher class (standalone)", () => {
+		it("should work as a standalone middleware", () => {
+			const catcher = new EventCatcher();
+			const mw = catcher.middleware();
+			expect(mw.name).toBe("EventCatcher");
+			expect(typeof mw.emit).toBe("function");
+		});
+	});
+
+	describe("MockingCalls class (standalone)", () => {
+		it("should work as a standalone middleware", () => {
+			const mocker = new MockingCalls();
+			const mw = mocker.middleware();
+			expect(mw.name).toBe("MockingCalls");
+			expect(typeof mw.call).toBe("function");
+		});
+	});
+});


### PR DESCRIPTION
Implements the testing utilities proposed in RFC [moleculerjs/rfcs#3](https://github.com/moleculerjs/rfcs/issues/3).

What's added
createBroker(options)
Factory that returns a ServiceBroker pre-configured for unit tests — logger disabled, test middlewares auto-installed, and a broker.test namespace attached for all assertions. Accepts a services array to load schemas at creation time.

Files changed
src/testing.js — new module
src/testing.d.ts — TypeScript definitions
test/unit/testing.spec.js — 18 passing unit tests
index.js / index.mjs — exported as Testing