### PR TITLE
fix(registry): merge actions/events on grouping and emit servicesChanged on disconnect

### DIFF
--- a/src/registry/node-catalog.js
+++ b/src/registry/node-catalog.js
@@ -203,6 +203,8 @@ class NodeCatalog {
 
 			this.broker.broadcastLocal("$node.disconnected", { node, unexpected: !!isUnexpected });
 
+			this.broker.servicesChanged(false);
+
 			this.registry.updateMetrics();
 
 			if (isUnexpected) this.logger.warn(`Node '${node.id}' disconnected unexpectedly.`);

--- a/src/registry/service-catalog.js
+++ b/src/registry/service-catalog.js
@@ -159,6 +159,24 @@ class ServiceCatalog {
 				res.push(item);
 			} else {
 				if (item.nodes.indexOf(service.node.id) === -1) item.nodes.push(service.node.id);
+
+				// Merge actions from subsequent nodes so that autoAliases always
+				// sees the full union of actions across all nodes for this service.
+				// This prevents stale registry entries (e.g. a k8s zombie pod killed
+				// via SIGKILL) from shadowing newer actions of a replacement pod.
+				if (withActions && item.actions) {
+					_.forIn(service.actions, (action) => {
+						if (action.protected || item.actions[action.name]) return;
+						item.actions[action.name] = _.omit(action, ["handler", "remoteHandler", "service"]);
+					});
+				}
+
+				if (withEvents && item.events) {
+					_.forIn(service.events, (event) => {
+						if (/^\$/.test(event.name) || item.events[event.name]) return;
+						item.events[event.name] = _.omit(event, ["handler", "remoteHandler", "service"]);
+					});
+				}
 			}
 		});
 

--- a/src/registry/service-catalog.js
+++ b/src/registry/service-catalog.js
@@ -165,16 +165,24 @@ class ServiceCatalog {
 				// This prevents stale registry entries (e.g. a k8s zombie pod killed
 				// via SIGKILL) from shadowing newer actions of a replacement pod.
 				if (withActions && item.actions) {
-					_.forIn(service.actions, (action) => {
+					_.forIn(service.actions, action => {
 						if (action.protected || item.actions[action.name]) return;
-						item.actions[action.name] = _.omit(action, ["handler", "remoteHandler", "service"]);
+						item.actions[action.name] = _.omit(action, [
+							"handler",
+							"remoteHandler",
+							"service"
+						]);
 					});
 				}
 
 				if (withEvents && item.events) {
-					_.forIn(service.events, (event) => {
+					_.forIn(service.events, event => {
 						if (/^\$/.test(event.name) || item.events[event.name]) return;
-						item.events[event.name] = _.omit(event, ["handler", "remoteHandler", "service"]);
+						item.events[event.name] = _.omit(event, [
+							"handler",
+							"remoteHandler",
+							"service"
+						]);
 					});
 				}
 			}

--- a/test/integration/registry.spec.js
+++ b/test/integration/registry.spec.js
@@ -195,7 +195,9 @@ describe("Test service registry", () => {
 				expect(H.getEventNodes(master, "user.created")).toEqual(["node-1"]);
 				expect(H.getEventNodes(master, "user.paid")).toEqual([]);
 
-				expect(servicesChanged).toHaveBeenCalledTimes(1);
+				// 1st call: INFO packet sent by node2 while stopping its services
+				// 2nd call: DISCONNECT packet processed — node fully removed from registry
+				expect(servicesChanged).toHaveBeenCalledTimes(2);
 			});
 	});
 

--- a/test/unit/registry/node-catalog.spec.js
+++ b/test/unit/registry/node-catalog.spec.js
@@ -221,6 +221,7 @@ describe("Test NodeCatalog.disconnected", () => {
 		broker.broadcastLocal.mockClear();
 		broker.registry.unregisterServicesByNode.mockClear();
 		broker.registry.updateMetrics.mockClear();
+		broker.servicesChanged.mockClear();
 
 		catalog.disconnected("node-11", false);
 
@@ -269,8 +270,8 @@ describe("Test NodeCatalog.disconnected", () => {
 
 		expect(broker.registry.updateMetrics).toHaveBeenCalledTimes(1);
 
-		// expect(broker.servicesChanged).toHaveBeenCalledTimes(1);
-		// expect(broker.servicesChanged).toHaveBeenCalledWith(false);
+		expect(broker.servicesChanged).toHaveBeenCalledTimes(1);
+		expect(broker.servicesChanged).toHaveBeenCalledWith(false);
 
 		expect(broker.registry.unregisterServicesByNode).toHaveBeenCalledTimes(1);
 		expect(broker.registry.unregisterServicesByNode).toHaveBeenCalledWith(node.id);

--- a/test/unit/registry/service-catalog.spec.js
+++ b/test/unit/registry/service-catalog.spec.js
@@ -229,19 +229,34 @@ describe("Test ServiceCatalog methods", () => {
 		const zombieNode = { id: "pod-OLD", available: true };
 		const newNode = { id: "pod-NEW", available: true };
 
-		const zombieSvc = catalog.add(zombieNode, { name: "svc", fullName: "svc", settings: {}, metadata: {} });
+		const zombieSvc = catalog.add(zombieNode, {
+			name: "svc",
+			fullName: "svc",
+			settings: {},
+			metadata: {}
+		});
 		zombieSvc.addAction({ name: "svc.hello", rest: "GET /hello" });
 		zombieSvc.addAction({ name: "svc.world", rest: "GET /world" });
 		zombieSvc.addEvent({ name: "svc.started" });
 
-		const newSvc = catalog.add(newNode, { name: "svc", fullName: "svc", settings: {}, metadata: {} });
+		const newSvc = catalog.add(newNode, {
+			name: "svc",
+			fullName: "svc",
+			settings: {},
+			metadata: {}
+		});
 		newSvc.addAction({ name: "svc.hello", rest: "GET /hello" });
 		newSvc.addAction({ name: "svc.world", rest: "GET /world" });
 		newSvc.addAction({ name: "svc.newAction", rest: "GET /new" }); // only on new pod
 		newSvc.addEvent({ name: "svc.started" });
-		newSvc.addEvent({ name: "svc.newEvent" });                       // only on new pod
+		newSvc.addEvent({ name: "svc.newEvent" }); // only on new pod
 
-		const res = catalog.list({ skipInternal: true, withActions: true, withEvents: true, grouping: true });
+		const res = catalog.list({
+			skipInternal: true,
+			withActions: true,
+			withEvents: true,
+			grouping: true
+		});
 		const svcItem = res.find(r => r.fullName === "svc");
 
 		expect(svcItem).toBeDefined();
@@ -263,16 +278,31 @@ describe("Test ServiceCatalog methods", () => {
 		const nodeA = { id: "nodeA", available: true };
 		const nodeB = { id: "nodeB", available: true };
 
-		const svcA = catalog.add(nodeA, { name: "guarded", fullName: "guarded", settings: {}, metadata: {} });
+		const svcA = catalog.add(nodeA, {
+			name: "guarded",
+			fullName: "guarded",
+			settings: {},
+			metadata: {}
+		});
 		svcA.addAction({ name: "guarded.public" });
 
-		const svcB = catalog.add(nodeB, { name: "guarded", fullName: "guarded", settings: {}, metadata: {} });
+		const svcB = catalog.add(nodeB, {
+			name: "guarded",
+			fullName: "guarded",
+			settings: {},
+			metadata: {}
+		});
 		svcB.addAction({ name: "guarded.public" });
 		svcB.addAction({ name: "guarded.secret", protected: true }); // must not appear
-		svcB.addEvent({ name: "$internal.event" });                  // must not appear
+		svcB.addEvent({ name: "$internal.event" }); // must not appear
 		svcB.addEvent({ name: "guarded.visible" });
 
-		const res = catalog.list({ skipInternal: true, withActions: true, withEvents: true, grouping: true });
+		const res = catalog.list({
+			skipInternal: true,
+			withActions: true,
+			withEvents: true,
+			grouping: true
+		});
 		const item = res.find(r => r.fullName === "guarded");
 
 		expect(item).toBeDefined();
@@ -288,10 +318,20 @@ describe("Test ServiceCatalog methods", () => {
 		const nodeA = { id: "node-first", available: true };
 		const nodeB = { id: "node-second", available: true };
 
-		const svcA = catalog.add(nodeA, { name: "versioned", fullName: "versioned", settings: {}, metadata: {} });
+		const svcA = catalog.add(nodeA, {
+			name: "versioned",
+			fullName: "versioned",
+			settings: {},
+			metadata: {}
+		});
 		svcA.addAction({ name: "versioned.op", version: 1 });
 
-		const svcB = catalog.add(nodeB, { name: "versioned", fullName: "versioned", settings: {}, metadata: {} });
+		const svcB = catalog.add(nodeB, {
+			name: "versioned",
+			fullName: "versioned",
+			settings: {},
+			metadata: {}
+		});
 		svcB.addAction({ name: "versioned.op", version: 2 }); // same name, different version
 
 		const res = catalog.list({ skipInternal: true, withActions: true, grouping: true });

--- a/test/unit/registry/service-catalog.spec.js
+++ b/test/unit/registry/service-catalog.spec.js
@@ -259,6 +259,52 @@ describe("Test ServiceCatalog methods", () => {
 		catalog.removeAllByNodeID("pod-NEW");
 	});
 
+	it("should not merge protected actions or internal events when grouping", () => {
+		const nodeA = { id: "nodeA", available: true };
+		const nodeB = { id: "nodeB", available: true };
+
+		const svcA = catalog.add(nodeA, { name: "guarded", fullName: "guarded", settings: {}, metadata: {} });
+		svcA.addAction({ name: "guarded.public" });
+
+		const svcB = catalog.add(nodeB, { name: "guarded", fullName: "guarded", settings: {}, metadata: {} });
+		svcB.addAction({ name: "guarded.public" });
+		svcB.addAction({ name: "guarded.secret", protected: true }); // must not appear
+		svcB.addEvent({ name: "$internal.event" });                  // must not appear
+		svcB.addEvent({ name: "guarded.visible" });
+
+		const res = catalog.list({ skipInternal: true, withActions: true, withEvents: true, grouping: true });
+		const item = res.find(r => r.fullName === "guarded");
+
+		expect(item).toBeDefined();
+		expect(Object.keys(item.actions)).not.toContain("guarded.secret");
+		expect(Object.keys(item.events)).not.toContain("$internal.event");
+		expect(Object.keys(item.events)).toContain("guarded.visible");
+
+		catalog.removeAllByNodeID("nodeA");
+		catalog.removeAllByNodeID("nodeB");
+	});
+
+	it("should not overwrite first-node action with second-node version when grouping", () => {
+		const nodeA = { id: "node-first", available: true };
+		const nodeB = { id: "node-second", available: true };
+
+		const svcA = catalog.add(nodeA, { name: "versioned", fullName: "versioned", settings: {}, metadata: {} });
+		svcA.addAction({ name: "versioned.op", version: 1 });
+
+		const svcB = catalog.add(nodeB, { name: "versioned", fullName: "versioned", settings: {}, metadata: {} });
+		svcB.addAction({ name: "versioned.op", version: 2 }); // same name, different version
+
+		const res = catalog.list({ skipInternal: true, withActions: true, grouping: true });
+		const item = res.find(r => r.fullName === "versioned");
+
+		expect(item).toBeDefined();
+		// First node's action wins — version must not be overwritten
+		expect(item.actions["versioned.op"].version).toBe(1);
+
+		catalog.removeAllByNodeID("node-first");
+		catalog.removeAllByNodeID("node-second");
+	});
+
 	it("should return with service list for info", () => {
 		let node2 = { id: "server-2", available: true };
 		catalog.add(node2, { name: "$node", fullName: "$node" });

--- a/test/unit/registry/service-catalog.spec.js
+++ b/test/unit/registry/service-catalog.spec.js
@@ -225,6 +225,40 @@ describe("Test ServiceCatalog methods", () => {
 		]);
 	});
 
+	it("should merge actions/events when grouping multiple nodes for the same service", () => {
+		const zombieNode = { id: "pod-OLD", available: true };
+		const newNode = { id: "pod-NEW", available: true };
+
+		const zombieSvc = catalog.add(zombieNode, { name: "svc", fullName: "svc", settings: {}, metadata: {} });
+		zombieSvc.addAction({ name: "svc.hello", rest: "GET /hello" });
+		zombieSvc.addAction({ name: "svc.world", rest: "GET /world" });
+		zombieSvc.addEvent({ name: "svc.started" });
+
+		const newSvc = catalog.add(newNode, { name: "svc", fullName: "svc", settings: {}, metadata: {} });
+		newSvc.addAction({ name: "svc.hello", rest: "GET /hello" });
+		newSvc.addAction({ name: "svc.world", rest: "GET /world" });
+		newSvc.addAction({ name: "svc.newAction", rest: "GET /new" }); // only on new pod
+		newSvc.addEvent({ name: "svc.started" });
+		newSvc.addEvent({ name: "svc.newEvent" });                       // only on new pod
+
+		const res = catalog.list({ skipInternal: true, withActions: true, withEvents: true, grouping: true });
+		const svcItem = res.find(r => r.fullName === "svc");
+
+		expect(svcItem).toBeDefined();
+		expect(svcItem.nodes).toEqual(expect.arrayContaining(["pod-OLD", "pod-NEW"]));
+
+		expect(Object.keys(svcItem.actions)).toEqual(
+			expect.arrayContaining(["svc.hello", "svc.world", "svc.newAction"])
+		);
+
+		expect(Object.keys(svcItem.events)).toEqual(
+			expect.arrayContaining(["svc.started", "svc.newEvent"])
+		);
+
+		catalog.removeAllByNodeID("pod-OLD");
+		catalog.removeAllByNodeID("pod-NEW");
+	});
+
 	it("should return with service list for info", () => {
 		let node2 = { id: "server-2", available: true };
 		catalog.add(node2, { name: "$node", fullName: "$node" });


### PR DESCRIPTION
## :memo: Description

Two related bugs that cause API Gateway `autoAliases` to return 404 for actions that exist on a live node when a stale node (zombie) is still present in the registry (e.g. a Kubernetes pod killed via SIGKILL without SIGTERM):

**1. `ServiceCatalog.list({ grouping: true })` drops actions/events from non-first nodes**

When multiple nodes run the same service, `list()` with `grouping: true` only kept actions/events from the **first** `ServiceItem` found. Actions from all subsequent nodes were silently discarded.
This means if a zombie pod (killed via SIGKILL, still in registry) was processed first, any new actions added by a replacement pod were invisible to API Gateway — resulting in permanent 404s until full restart.

**Fixed by:** merging the union of actions/events from all nodes into the grouped result (first-node wins on conflict, protected actions and internal `$`-events are excluded).

**2. `NodeCatalog.disconnected()` never calls `broker.servicesChanged()`**

When a node disconnects (heartbeat timeout), services were removed from the catalog and `$node.disconnected` was emitted — but `broker.servicesChanged()` was never called. This meant API Gateway never regenerated its `autoAliases` route table after a disconnect, leaving stale 404 routes indefinitely.

**Fixed by:** adding `broker.servicesChanged(false)` after the disconnect is processed in `NodeCatalog.disconnected()`.

### :dart: Relevant issues

Related to any environment where pods/nodes can die via SIGKILL (no SIGTERM) — common in Kubernetes.

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code

```js
// Scenario: two nodes run the same service, zombie pod was registered first
// Before fix: API Gateway only saw actions from pod-OLD, svc.newAction → 404
// After fix: actions from all nodes are merged into the grouped result

const broker = new ServiceBroker({ nodeID: "gateway" });

broker.createService({
  name: "api",
  mixins: [ApiGateway],
  settings: {
    routes: [{ autoAliases: true }]
  }
});

// pod-OLD (zombie, still in registry after SIGKILL)
// pod-NEW (replacement, has extra action svc.newAction)
// After fix: GET /svc/new-action → 200 ✓
```

## :vertical_traffic_light: How Has This Been Tested?

- [x] **Unit — `service-catalog.spec.js`**: regression test for zombie pod scenario (merge of new actions/events from second node); edge-case tests for protected actions not merged, internal `$`-events not merged, first-node action not overwritten
- [x] **Unit — `node-catalog.spec.js`**: verified `broker.servicesChanged(false)` is called on both expected and unexpected disconnect
- [x] **Integration — `registry.spec.js`**: updated assertion to expect 2 `servicesChanged` calls after node stop (INFO packet + DISCONNECT packet)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
