### PR TITLE
feat(runner): support worker node args and auto heap balance

### DIFF
--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -78,7 +78,6 @@ export default class MoleculerRunner {
 		-s, --silent     Silent mode. No logger (disabled by default)
 		-v, --version    Output the version number
 		-w, --worker-node-args  Node.js/V8 args for cluster workers only
-		    --auto-worker-heap-reserve  MB for primary; auto-split remaining available RAM equally across workers
 	*/
 	processFlags(procArgs) {
 		Args.option("config", "Load the configuration from a file")
@@ -92,10 +91,6 @@ export default class MoleculerRunner {
 			.option(
 				"worker-node-args",
 				"Node.js/V8 args passed to cluster workers only (also MOLECULER_WORKER_NODE_OPTIONS)"
-			)
-			.option(
-				"auto-worker-heap-reserve",
-				"Auto-balance worker heaps: MB reserved for primary; remaining available RAM is split equally as --max-old-space-size (also MOLECULER_AUTO_WORKER_HEAP_RESERVE)"
 			);
 
 		this.flags = Args.parse(procArgs, {
@@ -172,43 +167,6 @@ export default class MoleculerRunner {
 	}
 
 	/**
-	 * Resolve MB to reserve for the primary process (--auto-worker-heap-reserve).
-	 * Returns null when auto heap balancing is disabled.
-	 *
-	 * @returns {number|null}
-	 */
-	resolveAutoWorkerHeapReserve() {
-		const fromFlag = this.flags && this.flags.autoWorkerHeapReserve;
-		const raw =
-			fromFlag !== undefined && fromFlag !== null && fromFlag !== ""
-				? fromFlag
-				: process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
-
-		if (raw === undefined || raw === null || raw === "") return null;
-
-		const value = Number(raw);
-		if (!Number.isFinite(value) || value < 0) {
-			throw new Error(
-				`Invalid --auto-worker-heap-reserve / MOLECULER_AUTO_WORKER_HEAP_RESERVE value: ${raw}`
-			);
-		}
-
-		return Math.floor(value);
-	}
-
-	/**
-	 * Available memory in MB (cgroup/container limit when present).
-	 *
-	 * @returns {number}
-	 */
-	getAvailableMemoryMb() {
-		const constrained =
-			typeof process.constrainedMemory === "function" ? process.constrainedMemory() : 0;
-		const bytes = constrained > 0 ? constrained : os.totalmem();
-		return Math.floor(bytes / 1024 / 1024);
-	}
-
-	/**
 	 * Resolve Node.js/V8 args for cluster workers from env + CLI flag.
 	 * Applied only to forked instances, not to the primary process.
 	 *
@@ -218,43 +176,6 @@ export default class MoleculerRunner {
 		const fromEnv = this.parseNodeArgsString(process.env.MOLECULER_WORKER_NODE_OPTIONS);
 		const fromFlag = this.parseNodeArgsString(this.flags && this.flags.workerNodeArgs);
 		return [...fromEnv, ...fromFlag];
-	}
-
-	/**
-	 * Build final execArgv for cluster workers.
-	 * When --auto-worker-heap-reserve is set, remaining available RAM is split equally
-	 * and injected as --max-old-space-size (overrides any heap flags in worker-node-args).
-	 *
-	 * @param {number} workerCount
-	 * @returns {string[]}
-	 */
-	buildWorkerExecArgv(workerCount) {
-		let args = this.resolveWorkerNodeArgs();
-		const reserveMb = this.resolveAutoWorkerHeapReserve();
-
-		if (reserveMb == null) return args;
-
-		const availableMb = this.getAvailableMemoryMb();
-		const heapMb = Math.floor((availableMb - reserveMb) / workerCount);
-
-		if (heapMb <= 0) {
-			throw new Error(
-				`Cannot auto-balance worker heap: available=${availableMb} MB, reserve=${reserveMb} MB, workers=${workerCount}`
-			);
-		}
-
-		args = args.filter(
-			arg =>
-				!arg.startsWith("--max-old-space-size") &&
-				!arg.startsWith("--max-old-space-size-percentage")
-		);
-		args.push(`--max-old-space-size=${heapMb}`);
-
-		logger.info(
-			`Auto worker heap: ${heapMb} MB each (${availableMb} MB available, ${reserveMb} MB reserved for primary, ${workerCount} workers)`
-		);
-
-		return args;
 	}
 
 	/**
@@ -599,7 +520,7 @@ export default class MoleculerRunner {
 		const workerCount =
 			Number.isInteger(instances) && instances > 0 ? instances : os.cpus().length;
 
-		const workerNodeArgs = this.buildWorkerExecArgv(workerCount);
+		const workerNodeArgs = this.resolveWorkerNodeArgs();
 		if (workerNodeArgs.length > 0) {
 			cluster.setupPrimary({
 				execArgv: [...process.execArgv, ...workerNodeArgs]

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -77,6 +77,8 @@ export default class MoleculerRunner {
 		-r, --repl       Start REPL mode (disabled by default)
 		-s, --silent     Silent mode. No logger (disabled by default)
 		-v, --version    Output the version number
+		-w, --worker-node-args  Node.js/V8 args for cluster workers only
+		    --auto-worker-heap-reserve  MB for primary; auto-split remaining available RAM equally across workers
 	*/
 	processFlags(procArgs) {
 		Args.option("config", "Load the configuration from a file")
@@ -86,7 +88,15 @@ export default class MoleculerRunner {
 			.option("env", "Load .env file from the current directory")
 			.option("envfile", "Load a specified .env file")
 			.option("instances", "Launch [number] instances node (load balanced)")
-			.option("mask", "Filemask for service loading");
+			.option("mask", "Filemask for service loading")
+			.option(
+				"worker-node-args",
+				"Node.js/V8 args passed to cluster workers only (also MOLECULER_WORKER_NODE_OPTIONS)"
+			)
+			.option(
+				"auto-worker-heap-reserve",
+				"Auto-balance worker heaps: MB reserved for primary; remaining available RAM is split equally as --max-old-space-size (also MOLECULER_AUTO_WORKER_HEAP_RESERVE)"
+			);
 
 		this.flags = Args.parse(procArgs, {
 			mri: {
@@ -98,14 +108,133 @@ export default class MoleculerRunner {
 					e: "env",
 					E: "envfile",
 					i: "instances",
-					m: "mask"
+					m: "mask",
+					w: "worker-node-args"
 				},
 				boolean: ["repl", "silent", "hot", "env"],
-				string: ["config", "envfile", "mask"]
+				string: ["config", "envfile", "mask", "worker-node-args"]
 			}
 		});
 
 		this.servicePaths = Args.sub;
+	}
+
+	/**
+	 * Parse a Node.js CLI args string into an argv array.
+	 * Supports quoted tokens, same style as NODE_OPTIONS.
+	 *
+	 * @param {string|string[]|null|undefined} value
+	 * @returns {string[]}
+	 */
+	parseNodeArgsString(value) {
+		if (value == null || value === "") return [];
+		if (Array.isArray(value)) {
+			return value.flatMap(item => this.parseNodeArgsString(item));
+		}
+
+		const str = String(value).trim();
+		if (!str) return [];
+
+		const args = [];
+		const re = /(?:[^\s"']+|"[^"]*"|'[^']*')+/g;
+		let match;
+		while ((match = re.exec(str)) !== null) {
+			let token = match[0];
+			if (
+				(token.startsWith('"') && token.endsWith('"')) ||
+				(token.startsWith("'") && token.endsWith("'"))
+			) {
+				token = token.slice(1, -1);
+			}
+			if (token) args.push(token);
+		}
+		return args;
+	}
+
+	/**
+	 * Resolve MB to reserve for the primary process (--auto-worker-heap-reserve).
+	 * Returns null when auto heap balancing is disabled.
+	 *
+	 * @returns {number|null}
+	 */
+	resolveAutoWorkerHeapReserve() {
+		const fromFlag = this.flags && this.flags.autoWorkerHeapReserve;
+		const raw =
+			fromFlag !== undefined && fromFlag !== null && fromFlag !== ""
+				? fromFlag
+				: process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
+
+		if (raw === undefined || raw === null || raw === "") return null;
+
+		const value = Number(raw);
+		if (!Number.isFinite(value) || value < 0) {
+			throw new Error(
+				`Invalid --auto-worker-heap-reserve / MOLECULER_AUTO_WORKER_HEAP_RESERVE value: ${raw}`
+			);
+		}
+
+		return Math.floor(value);
+	}
+
+	/**
+	 * Available memory in MB (cgroup/container limit when present).
+	 *
+	 * @returns {number}
+	 */
+	getAvailableMemoryMb() {
+		const constrained =
+			typeof process.constrainedMemory === "function" ? process.constrainedMemory() : 0;
+		const bytes = constrained > 0 ? constrained : os.totalmem();
+		return Math.floor(bytes / 1024 / 1024);
+	}
+
+	/**
+	 * Resolve Node.js/V8 args for cluster workers from env + CLI flag.
+	 * Applied only to forked instances, not to the primary process.
+	 *
+	 * @returns {string[]}
+	 */
+	resolveWorkerNodeArgs() {
+		const fromEnv = this.parseNodeArgsString(process.env.MOLECULER_WORKER_NODE_OPTIONS);
+		const fromFlag = this.parseNodeArgsString(this.flags && this.flags.workerNodeArgs);
+		return [...fromEnv, ...fromFlag];
+	}
+
+	/**
+	 * Build final execArgv for cluster workers.
+	 * When --auto-worker-heap-reserve is set, remaining available RAM is split equally
+	 * and injected as --max-old-space-size (overrides any heap flags in worker-node-args).
+	 *
+	 * @param {number} workerCount
+	 * @returns {string[]}
+	 */
+	buildWorkerExecArgv(workerCount) {
+		let args = this.resolveWorkerNodeArgs();
+		const reserveMb = this.resolveAutoWorkerHeapReserve();
+
+		if (reserveMb == null) return args;
+
+		const availableMb = this.getAvailableMemoryMb();
+		const heapMb = Math.floor((availableMb - reserveMb) / workerCount);
+
+		if (heapMb <= 0) {
+			throw new Error(
+				`Cannot auto-balance worker heap: available=${availableMb} MB, reserve=${reserveMb} MB, workers=${workerCount}`
+			);
+		}
+
+		args = args.filter(
+			arg =>
+				!arg.startsWith("--max-old-space-size") &&
+				!arg.startsWith("--max-old-space-size-percentage")
+		);
+		args.push(`--max-old-space-size=${heapMb}`);
+
+		logger.info(
+			`Auto worker heap: ${heapMb} MB each (${availableMb} MB available, ${reserveMb} MB reserved for primary, ${workerCount} workers)`
+		);
+
+		return args;
 	}
 
 	/**
@@ -447,6 +576,17 @@ export default class MoleculerRunner {
 	startWorkers(instances) {
 		let stopping = false;
 
+		const workerCount =
+			Number.isInteger(instances) && instances > 0 ? instances : os.cpus().length;
+
+		const workerNodeArgs = this.buildWorkerExecArgv(workerCount);
+		if (workerNodeArgs.length > 0) {
+			cluster.setupPrimary({
+				execArgv: [...process.execArgv, ...workerNodeArgs]
+			});
+			logger.info(`Worker Node.js args: ${workerNodeArgs.join(" ")}`);
+		}
+
 		cluster.on("exit", function (worker, code) {
 			if (!stopping) {
 				// only restart the worker if the exit was by an error
@@ -460,9 +600,6 @@ export default class MoleculerRunner {
 				}
 			}
 		});
-
-		const workerCount =
-			Number.isInteger(instances) && instances > 0 ? instances : os.cpus().length;
 
 		logger.info(`Starting ${workerCount} workers...`);
 

--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -136,18 +136,38 @@ export default class MoleculerRunner {
 		if (!str) return [];
 
 		const args = [];
-		const re = /(?:[^\s"']+|"[^"]*"|'[^']*')+/g;
-		let match;
-		while ((match = re.exec(str)) !== null) {
-			let token = match[0];
-			if (
-				(token.startsWith('"') && token.endsWith('"')) ||
-				(token.startsWith("'") && token.endsWith("'"))
-			) {
-				token = token.slice(1, -1);
+		let current = "";
+		let quote = null;
+
+		for (let i = 0; i < str.length; i++) {
+			const ch = str[i];
+
+			if (quote) {
+				if (ch === quote) {
+					quote = null;
+				} else {
+					current += ch;
+				}
+				continue;
 			}
-			if (token) args.push(token);
+
+			if (ch === '"' || ch === "'") {
+				quote = ch;
+				continue;
+			}
+
+			if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+				if (current) {
+					args.push(current);
+					current = "";
+				}
+				continue;
+			}
+
+			current += ch;
 		}
+
+		if (current) args.push(current);
 		return args;
 	}
 

--- a/src/runner.d.ts
+++ b/src/runner.d.ts
@@ -54,13 +54,6 @@ declare namespace Runner {
 		 * Example: "--max-old-space-size=768 --trace-warnings"
 		 */
 		workerNodeArgs?: string;
-
-		/**
-		 * Auto-balance worker heaps: MB reserved for the primary process.
-		 * Remaining available RAM is split equally across workers as --max-old-space-size.
-		 * Also configurable with MOLECULER_AUTO_WORKER_HEAP_RESERVE env var.
-		 */
-		autoWorkerHeapReserve?: number;
 	}
 }
 
@@ -151,24 +144,9 @@ declare class Runner {
 	parseNodeArgsString(value: string | string[] | null | undefined): string[];
 
 	/**
-	 * Resolve MB to reserve for the primary process (--auto-worker-heap-reserve). Null when disabled.
-	 */
-	resolveAutoWorkerHeapReserve(): number | null;
-
-	/**
-	 * Available memory in MB (cgroup/container limit when present).
-	 */
-	getAvailableMemoryMb(): number;
-
-	/**
 	 * Resolve Node.js/V8 args for cluster workers from env + CLI flag
 	 */
 	resolveWorkerNodeArgs(): string[];
-
-	/**
-	 * Build final execArgv for cluster workers (applies --auto-worker-heap-reserve balancing).
-	 */
-	buildWorkerExecArgv(workerCount: number): string[];
 
 	/**
 	 * Start cluster workers
@@ -193,7 +171,7 @@ declare class Runner {
 	/**
 	 * Start runner
 	 */
-	start(args: string[]): Promise<void|ServiceBroker>;
+	start(args: string[]): Promise<void | ServiceBroker>;
 }
 
 export = Runner;

--- a/src/runner.d.ts
+++ b/src/runner.d.ts
@@ -47,6 +47,20 @@ declare namespace Runner {
 		 * File mask for loading services
 		 */
 		mask?: string;
+
+		/**
+		 * Node.js/V8 CLI args passed only to cluster workers via cluster.setupPrimary({ execArgv }).
+		 * Also configurable with MOLECULER_WORKER_NODE_OPTIONS env var.
+		 * Example: "--max-old-space-size=768 --trace-warnings"
+		 */
+		workerNodeArgs?: string;
+
+		/**
+		 * Auto-balance worker heaps: MB reserved for the primary process.
+		 * Remaining available RAM is split equally across workers as --max-old-space-size.
+		 * Also configurable with MOLECULER_AUTO_WORKER_HEAP_RESERVE env var.
+		 */
+		autoWorkerHeapReserve?: number;
 	}
 }
 
@@ -130,6 +144,31 @@ declare class Runner {
 	 * Load services from files or directories
 	 */
 	loadServices(): void;
+
+	/**
+	 * Parse a Node.js CLI args string into an argv array
+	 */
+	parseNodeArgsString(value: string | string[] | null | undefined): string[];
+
+	/**
+	 * Resolve MB to reserve for the primary process (--auto-worker-heap-reserve). Null when disabled.
+	 */
+	resolveAutoWorkerHeapReserve(): number | null;
+
+	/**
+	 * Available memory in MB (cgroup/container limit when present).
+	 */
+	getAvailableMemoryMb(): number;
+
+	/**
+	 * Resolve Node.js/V8 args for cluster workers from env + CLI flag
+	 */
+	resolveWorkerNodeArgs(): string[];
+
+	/**
+	 * Build final execArgv for cluster workers (applies --auto-worker-heap-reserve balancing).
+	 */
+	buildWorkerExecArgv(workerCount: number): string[];
 
 	/**
 	 * Start cluster workers

--- a/src/runner.js
+++ b/src/runner.js
@@ -88,7 +88,6 @@ class MoleculerRunner {
 		-s, --silent     Silent mode. No logger (disabled by default)
 		-v, --version    Output the version number
 		-w, --worker-node-args  Node.js/V8 args for cluster workers only
-		    --auto-worker-heap-reserve  MB for primary; auto-split remaining available RAM equally across workers
 	*/
 	processFlags(procArgs) {
 		Args.option("config", "Load the configuration from a file")
@@ -102,10 +101,6 @@ class MoleculerRunner {
 			.option(
 				"worker-node-args",
 				"Node.js/V8 args passed to cluster workers only (also MOLECULER_WORKER_NODE_OPTIONS)"
-			)
-			.option(
-				"auto-worker-heap-reserve",
-				"Auto-balance worker heaps: MB reserved for primary; remaining available RAM is split equally as --max-old-space-size (also MOLECULER_AUTO_WORKER_HEAP_RESERVE)"
 			);
 
 		this.flags = Args.parse(procArgs, {
@@ -182,43 +177,6 @@ class MoleculerRunner {
 	}
 
 	/**
-	 * Resolve MB to reserve for the primary process (--auto-worker-heap-reserve).
-	 * Returns null when auto heap balancing is disabled.
-	 *
-	 * @returns {number|null}
-	 */
-	resolveAutoWorkerHeapReserve() {
-		const fromFlag = this.flags && this.flags.autoWorkerHeapReserve;
-		const raw =
-			fromFlag !== undefined && fromFlag !== null && fromFlag !== ""
-				? fromFlag
-				: process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
-
-		if (raw === undefined || raw === null || raw === "") return null;
-
-		const value = Number(raw);
-		if (!Number.isFinite(value) || value < 0) {
-			throw new Error(
-				`Invalid --auto-worker-heap-reserve / MOLECULER_AUTO_WORKER_HEAP_RESERVE value: ${raw}`
-			);
-		}
-
-		return Math.floor(value);
-	}
-
-	/**
-	 * Available memory in MB (cgroup/container limit when present).
-	 *
-	 * @returns {number}
-	 */
-	getAvailableMemoryMb() {
-		const constrained =
-			typeof process.constrainedMemory === "function" ? process.constrainedMemory() : 0;
-		const bytes = constrained > 0 ? constrained : os.totalmem();
-		return Math.floor(bytes / 1024 / 1024);
-	}
-
-	/**
 	 * Resolve Node.js/V8 args for cluster workers from env + CLI flag.
 	 * Applied only to forked instances, not to the primary process.
 	 *
@@ -228,43 +186,6 @@ class MoleculerRunner {
 		const fromEnv = this.parseNodeArgsString(process.env.MOLECULER_WORKER_NODE_OPTIONS);
 		const fromFlag = this.parseNodeArgsString(this.flags && this.flags.workerNodeArgs);
 		return [...fromEnv, ...fromFlag];
-	}
-
-	/**
-	 * Build final execArgv for cluster workers.
-	 * When --auto-worker-heap-reserve is set, remaining available RAM is split equally
-	 * and injected as --max-old-space-size (overrides any heap flags in worker-node-args).
-	 *
-	 * @param {number} workerCount
-	 * @returns {string[]}
-	 */
-	buildWorkerExecArgv(workerCount) {
-		let args = this.resolveWorkerNodeArgs();
-		const reserveMb = this.resolveAutoWorkerHeapReserve();
-
-		if (reserveMb == null) return args;
-
-		const availableMb = this.getAvailableMemoryMb();
-		const heapMb = Math.floor((availableMb - reserveMb) / workerCount);
-
-		if (heapMb <= 0) {
-			throw new Error(
-				`Cannot auto-balance worker heap: available=${availableMb} MB, reserve=${reserveMb} MB, workers=${workerCount}`
-			);
-		}
-
-		args = args.filter(
-			arg =>
-				!arg.startsWith("--max-old-space-size") &&
-				!arg.startsWith("--max-old-space-size-percentage")
-		);
-		args.push(`--max-old-space-size=${heapMb}`);
-
-		logger.info(
-			`Auto worker heap: ${heapMb} MB each (${availableMb} MB available, ${reserveMb} MB reserved for primary, ${workerCount} workers)`
-		);
-
-		return args;
 	}
 
 	/**
@@ -612,7 +533,7 @@ class MoleculerRunner {
 		const workerCount =
 			Number.isInteger(instances) && instances > 0 ? instances : os.cpus().length;
 
-		const workerNodeArgs = this.buildWorkerExecArgv(workerCount);
+		const workerNodeArgs = this.resolveWorkerNodeArgs();
 		if (workerNodeArgs.length > 0) {
 			cluster.setupPrimary({
 				execArgv: [...process.execArgv, ...workerNodeArgs]

--- a/src/runner.js
+++ b/src/runner.js
@@ -87,6 +87,8 @@ class MoleculerRunner {
 		-r, --repl       Start REPL mode (disabled by default)
 		-s, --silent     Silent mode. No logger (disabled by default)
 		-v, --version    Output the version number
+		-w, --worker-node-args  Node.js/V8 args for cluster workers only
+		    --auto-worker-heap-reserve  MB for primary; auto-split remaining available RAM equally across workers
 	*/
 	processFlags(procArgs) {
 		Args.option("config", "Load the configuration from a file")
@@ -96,7 +98,15 @@ class MoleculerRunner {
 			.option("env", "Load .env file from the current directory")
 			.option("envfile", "Load a specified .env file")
 			.option("instances", "Launch [number] instances node (load balanced)")
-			.option("mask", "Filemask for service loading");
+			.option("mask", "Filemask for service loading")
+			.option(
+				"worker-node-args",
+				"Node.js/V8 args passed to cluster workers only (also MOLECULER_WORKER_NODE_OPTIONS)"
+			)
+			.option(
+				"auto-worker-heap-reserve",
+				"Auto-balance worker heaps: MB reserved for primary; remaining available RAM is split equally as --max-old-space-size (also MOLECULER_AUTO_WORKER_HEAP_RESERVE)"
+			);
 
 		this.flags = Args.parse(procArgs, {
 			mri: {
@@ -108,14 +118,133 @@ class MoleculerRunner {
 					e: "env",
 					E: "envfile",
 					i: "instances",
-					m: "mask"
+					m: "mask",
+					w: "worker-node-args"
 				},
 				boolean: ["repl", "silent", "hot", "env"],
-				string: ["config", "envfile", "mask"]
+				string: ["config", "envfile", "mask", "worker-node-args"]
 			}
 		});
 
 		this.servicePaths = Args.sub;
+	}
+
+	/**
+	 * Parse a Node.js CLI args string into an argv array.
+	 * Supports quoted tokens, same style as NODE_OPTIONS.
+	 *
+	 * @param {string|string[]|null|undefined} value
+	 * @returns {string[]}
+	 */
+	parseNodeArgsString(value) {
+		if (value == null || value === "") return [];
+		if (Array.isArray(value)) {
+			return value.flatMap(item => this.parseNodeArgsString(item));
+		}
+
+		const str = String(value).trim();
+		if (!str) return [];
+
+		const args = [];
+		const re = /(?:[^\s"']+|"[^"]*"|'[^']*')+/g;
+		let match;
+		while ((match = re.exec(str)) !== null) {
+			let token = match[0];
+			if (
+				(token.startsWith('"') && token.endsWith('"')) ||
+				(token.startsWith("'") && token.endsWith("'"))
+			) {
+				token = token.slice(1, -1);
+			}
+			if (token) args.push(token);
+		}
+		return args;
+	}
+
+	/**
+	 * Resolve MB to reserve for the primary process (--auto-worker-heap-reserve).
+	 * Returns null when auto heap balancing is disabled.
+	 *
+	 * @returns {number|null}
+	 */
+	resolveAutoWorkerHeapReserve() {
+		const fromFlag = this.flags && this.flags.autoWorkerHeapReserve;
+		const raw =
+			fromFlag !== undefined && fromFlag !== null && fromFlag !== ""
+				? fromFlag
+				: process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
+
+		if (raw === undefined || raw === null || raw === "") return null;
+
+		const value = Number(raw);
+		if (!Number.isFinite(value) || value < 0) {
+			throw new Error(
+				`Invalid --auto-worker-heap-reserve / MOLECULER_AUTO_WORKER_HEAP_RESERVE value: ${raw}`
+			);
+		}
+
+		return Math.floor(value);
+	}
+
+	/**
+	 * Available memory in MB (cgroup/container limit when present).
+	 *
+	 * @returns {number}
+	 */
+	getAvailableMemoryMb() {
+		const constrained =
+			typeof process.constrainedMemory === "function" ? process.constrainedMemory() : 0;
+		const bytes = constrained > 0 ? constrained : os.totalmem();
+		return Math.floor(bytes / 1024 / 1024);
+	}
+
+	/**
+	 * Resolve Node.js/V8 args for cluster workers from env + CLI flag.
+	 * Applied only to forked instances, not to the primary process.
+	 *
+	 * @returns {string[]}
+	 */
+	resolveWorkerNodeArgs() {
+		const fromEnv = this.parseNodeArgsString(process.env.MOLECULER_WORKER_NODE_OPTIONS);
+		const fromFlag = this.parseNodeArgsString(this.flags && this.flags.workerNodeArgs);
+		return [...fromEnv, ...fromFlag];
+	}
+
+	/**
+	 * Build final execArgv for cluster workers.
+	 * When --auto-worker-heap-reserve is set, remaining available RAM is split equally
+	 * and injected as --max-old-space-size (overrides any heap flags in worker-node-args).
+	 *
+	 * @param {number} workerCount
+	 * @returns {string[]}
+	 */
+	buildWorkerExecArgv(workerCount) {
+		let args = this.resolveWorkerNodeArgs();
+		const reserveMb = this.resolveAutoWorkerHeapReserve();
+
+		if (reserveMb == null) return args;
+
+		const availableMb = this.getAvailableMemoryMb();
+		const heapMb = Math.floor((availableMb - reserveMb) / workerCount);
+
+		if (heapMb <= 0) {
+			throw new Error(
+				`Cannot auto-balance worker heap: available=${availableMb} MB, reserve=${reserveMb} MB, workers=${workerCount}`
+			);
+		}
+
+		args = args.filter(
+			arg =>
+				!arg.startsWith("--max-old-space-size") &&
+				!arg.startsWith("--max-old-space-size-percentage")
+		);
+		args.push(`--max-old-space-size=${heapMb}`);
+
+		logger.info(
+			`Auto worker heap: ${heapMb} MB each (${availableMb} MB available, ${reserveMb} MB reserved for primary, ${workerCount} workers)`
+		);
+
+		return args;
 	}
 
 	/**
@@ -460,6 +589,17 @@ class MoleculerRunner {
 	startWorkers(instances) {
 		let stopping = false;
 
+		const workerCount =
+			Number.isInteger(instances) && instances > 0 ? instances : os.cpus().length;
+
+		const workerNodeArgs = this.buildWorkerExecArgv(workerCount);
+		if (workerNodeArgs.length > 0) {
+			cluster.setupPrimary({
+				execArgv: [...process.execArgv, ...workerNodeArgs]
+			});
+			logger.info(`Worker Node.js args: ${workerNodeArgs.join(" ")}`);
+		}
+
 		cluster.on("exit", function (worker, code) {
 			if (!stopping) {
 				// only restart the worker if the exit was by an error
@@ -473,9 +613,6 @@ class MoleculerRunner {
 				}
 			}
 		});
-
-		const workerCount =
-			Number.isInteger(instances) && instances > 0 ? instances : os.cpus().length;
 
 		logger.info(`Starting ${workerCount} workers...`);
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -146,18 +146,38 @@ class MoleculerRunner {
 		if (!str) return [];
 
 		const args = [];
-		const re = /(?:[^\s"']+|"[^"]*"|'[^']*')+/g;
-		let match;
-		while ((match = re.exec(str)) !== null) {
-			let token = match[0];
-			if (
-				(token.startsWith('"') && token.endsWith('"')) ||
-				(token.startsWith("'") && token.endsWith("'"))
-			) {
-				token = token.slice(1, -1);
+		let current = "";
+		let quote = null;
+
+		for (let i = 0; i < str.length; i++) {
+			const ch = str[i];
+
+			if (quote) {
+				if (ch === quote) {
+					quote = null;
+				} else {
+					current += ch;
+				}
+				continue;
 			}
-			if (token) args.push(token);
+
+			if (ch === '"' || ch === "'") {
+				quote = ch;
+				continue;
+			}
+
+			if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+				if (current) {
+					args.push(current);
+					current = "";
+				}
+				continue;
+			}
+
+			current += ch;
 		}
+
+		if (current) args.push(current);
 		return args;
 	}
 

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -1,0 +1,226 @@
+"use strict";
+
+jest.mock("cluster", () => ({
+	isPrimary: true,
+	isMaster: true,
+	fork: jest.fn(),
+	on: jest.fn(),
+	setupPrimary: jest.fn(),
+	disconnect: jest.fn(),
+	worker: null
+}));
+
+const cluster = require("cluster");
+const MoleculerRunner = require("../../src/runner");
+
+describe("Test MoleculerRunner worker node args", () => {
+	const originalNodeOptions = process.env.MOLECULER_WORKER_NODE_OPTIONS;
+	const originalReserveMb = process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
+
+	afterEach(() => {
+		delete process.env.MOLECULER_WORKER_NODE_OPTIONS;
+		delete process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
+		if (originalNodeOptions !== undefined) {
+			process.env.MOLECULER_WORKER_NODE_OPTIONS = originalNodeOptions;
+		}
+		if (originalReserveMb !== undefined) {
+			process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE = originalReserveMb;
+		}
+		jest.clearAllMocks();
+		jest.restoreAllMocks();
+	});
+
+	describe("parseNodeArgsString", () => {
+		const runner = new MoleculerRunner();
+
+		it("should return empty array for empty values", () => {
+			expect(runner.parseNodeArgsString()).toEqual([]);
+			expect(runner.parseNodeArgsString(null)).toEqual([]);
+			expect(runner.parseNodeArgsString("")).toEqual([]);
+			expect(runner.parseNodeArgsString("   ")).toEqual([]);
+		});
+
+		it("should split node args by whitespace", () => {
+			expect(
+				runner.parseNodeArgsString("--max-old-space-size=768 --trace-warnings")
+			).toEqual(["--max-old-space-size=768", "--trace-warnings"]);
+		});
+
+		it("should keep quoted tokens intact", () => {
+			expect(runner.parseNodeArgsString(`--require "./path with space.js"`)).toEqual([
+				"--require",
+				"./path with space.js"
+			]);
+			expect(runner.parseNodeArgsString(`--require './path with space.js'`)).toEqual([
+				"--require",
+				"./path with space.js"
+			]);
+		});
+
+		it("should flatten arrays", () => {
+			expect(
+				runner.parseNodeArgsString(["--max-old-space-size=256", "--trace-warnings"])
+			).toEqual(["--max-old-space-size=256", "--trace-warnings"]);
+		});
+	});
+
+	describe("resolveWorkerNodeArgs", () => {
+		it("should merge env and CLI flag args", () => {
+			process.env.MOLECULER_WORKER_NODE_OPTIONS = "--max-old-space-size=512";
+			const runner = new MoleculerRunner();
+			runner.flags = { workerNodeArgs: "--trace-warnings" };
+
+			expect(runner.resolveWorkerNodeArgs()).toEqual([
+				"--max-old-space-size=512",
+				"--trace-warnings"
+			]);
+		});
+
+		it("should return empty array when neither env nor flag is set", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = {};
+			expect(runner.resolveWorkerNodeArgs()).toEqual([]);
+		});
+	});
+
+	describe("processFlags", () => {
+		it("should parse --worker-node-args", () => {
+			const runner = new MoleculerRunner();
+			runner.processFlags([
+				"node",
+				"moleculer-runner",
+				"--worker-node-args=--max-old-space-size=768 --trace-warnings",
+				"services"
+			]);
+
+			expect(runner.flags.workerNodeArgs).toBe(
+				"--max-old-space-size=768 --trace-warnings"
+			);
+		});
+
+		it("should parse short -w alias", () => {
+			const runner = new MoleculerRunner();
+			runner.processFlags([
+				"node",
+				"moleculer-runner",
+				"-w=--max-old-space-size-percentage=25",
+				"services"
+			]);
+
+			expect(runner.flags.workerNodeArgs).toBe("--max-old-space-size-percentage=25");
+		});
+
+		it("should parse --auto-worker-heap-reserve", () => {
+			const runner = new MoleculerRunner();
+			runner.processFlags([
+				"node",
+				"moleculer-runner",
+				"--instances",
+				"3",
+				"--auto-worker-heap-reserve",
+				"1024",
+				"services"
+			]);
+
+			expect(runner.flags.autoWorkerHeapReserve).toBe(1024);
+		});
+	});
+
+	describe("buildWorkerExecArgv with --auto-worker-heap-reserve", () => {
+		it("should split remaining memory equally across workers", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = { autoWorkerHeapReserve: 1024 };
+			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
+
+			expect(runner.buildWorkerExecArgv(3)).toEqual(["--max-old-space-size=1024"]);
+		});
+
+		it("should override conflicting heap flags from worker-node-args", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = {
+				autoWorkerHeapReserve: 512,
+				workerNodeArgs: "--max-old-space-size=999 --trace-warnings"
+			};
+			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
+
+			expect(runner.buildWorkerExecArgv(2)).toEqual([
+				"--trace-warnings",
+				"--max-old-space-size=1792"
+			]);
+		});
+
+		it("should read reserve from MOLECULER_AUTO_WORKER_HEAP_RESERVE", () => {
+			process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE = "768";
+			const runner = new MoleculerRunner();
+			runner.flags = {};
+			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(3072);
+
+			expect(runner.buildWorkerExecArgv(3)).toEqual(["--max-old-space-size=768"]);
+		});
+
+		it("should throw when reserve leaves no heap for workers", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = { autoWorkerHeapReserve: 4096 };
+			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
+
+			expect(() => runner.buildWorkerExecArgv(3)).toThrow(
+				/Cannot auto-balance worker heap/
+			);
+		});
+	});
+
+	describe("startWorkers", () => {
+		it("should call setupPrimary with worker execArgv", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = { workerNodeArgs: "--max-old-space-size=768" };
+
+			runner.startWorkers(2);
+
+			expect(cluster.setupPrimary).toHaveBeenCalledTimes(1);
+			expect(cluster.setupPrimary).toHaveBeenCalledWith({
+				execArgv: [...process.execArgv, "--max-old-space-size=768"]
+			});
+			expect(cluster.fork).toHaveBeenCalledTimes(2);
+		});
+
+		it("should not call setupPrimary when no worker args are set", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = {};
+
+			runner.startWorkers(1);
+
+			expect(cluster.setupPrimary).not.toHaveBeenCalled();
+			expect(cluster.fork).toHaveBeenCalledTimes(1);
+		});
+
+		it("should apply MOLECULER_WORKER_NODE_OPTIONS via setupPrimary", () => {
+			process.env.MOLECULER_WORKER_NODE_OPTIONS =
+				"--max-old-space-size=256 --no-warnings";
+			const runner = new MoleculerRunner();
+			runner.flags = {};
+
+			runner.startWorkers(1);
+
+			expect(cluster.setupPrimary).toHaveBeenCalledWith({
+				execArgv: [
+					...process.execArgv,
+					"--max-old-space-size=256",
+					"--no-warnings"
+				]
+			});
+		});
+
+		it("should apply auto heap from --auto-worker-heap-reserve", () => {
+			const runner = new MoleculerRunner();
+			runner.flags = { autoWorkerHeapReserve: 1024 };
+			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
+
+			runner.startWorkers(3);
+
+			expect(cluster.setupPrimary).toHaveBeenCalledWith({
+				execArgv: [...process.execArgv, "--max-old-space-size=1024"]
+			});
+			expect(cluster.fork).toHaveBeenCalledTimes(3);
+		});
+	});
+});

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -41,9 +41,9 @@ describe("Test MoleculerRunner worker node args", () => {
 		});
 
 		it("should split node args by whitespace", () => {
-			expect(
-				runner.parseNodeArgsString("--max-old-space-size=768 --trace-warnings")
-			).toEqual(["--max-old-space-size=768", "--trace-warnings"]);
+			expect(runner.parseNodeArgsString("--max-old-space-size=768 --trace-warnings")).toEqual(
+				["--max-old-space-size=768", "--trace-warnings"]
+			);
 		});
 
 		it("should keep quoted tokens intact", () => {
@@ -93,9 +93,7 @@ describe("Test MoleculerRunner worker node args", () => {
 				"services"
 			]);
 
-			expect(runner.flags.workerNodeArgs).toBe(
-				"--max-old-space-size=768 --trace-warnings"
-			);
+			expect(runner.flags.workerNodeArgs).toBe("--max-old-space-size=768 --trace-warnings");
 		});
 
 		it("should parse short -w alias", () => {
@@ -163,9 +161,7 @@ describe("Test MoleculerRunner worker node args", () => {
 			runner.flags = { autoWorkerHeapReserve: 4096 };
 			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
 
-			expect(() => runner.buildWorkerExecArgv(3)).toThrow(
-				/Cannot auto-balance worker heap/
-			);
+			expect(() => runner.buildWorkerExecArgv(3)).toThrow(/Cannot auto-balance worker heap/);
 		});
 	});
 
@@ -194,19 +190,14 @@ describe("Test MoleculerRunner worker node args", () => {
 		});
 
 		it("should apply MOLECULER_WORKER_NODE_OPTIONS via setupPrimary", () => {
-			process.env.MOLECULER_WORKER_NODE_OPTIONS =
-				"--max-old-space-size=256 --no-warnings";
+			process.env.MOLECULER_WORKER_NODE_OPTIONS = "--max-old-space-size=256 --no-warnings";
 			const runner = new MoleculerRunner();
 			runner.flags = {};
 
 			runner.startWorkers(1);
 
 			expect(cluster.setupPrimary).toHaveBeenCalledWith({
-				execArgv: [
-					...process.execArgv,
-					"--max-old-space-size=256",
-					"--no-warnings"
-				]
+				execArgv: [...process.execArgv, "--max-old-space-size=256", "--no-warnings"]
 			});
 		});
 

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -15,16 +15,11 @@ const MoleculerRunner = require("../../src/runner");
 
 describe("Test MoleculerRunner worker node args", () => {
 	const originalNodeOptions = process.env.MOLECULER_WORKER_NODE_OPTIONS;
-	const originalReserveMb = process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
 
 	afterEach(() => {
 		delete process.env.MOLECULER_WORKER_NODE_OPTIONS;
-		delete process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE;
 		if (originalNodeOptions !== undefined) {
 			process.env.MOLECULER_WORKER_NODE_OPTIONS = originalNodeOptions;
-		}
-		if (originalReserveMb !== undefined) {
-			process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE = originalReserveMb;
 		}
 		jest.clearAllMocks();
 		jest.restoreAllMocks();
@@ -107,62 +102,6 @@ describe("Test MoleculerRunner worker node args", () => {
 
 			expect(runner.flags.workerNodeArgs).toBe("--max-old-space-size-percentage=25");
 		});
-
-		it("should parse --auto-worker-heap-reserve", () => {
-			const runner = new MoleculerRunner();
-			runner.processFlags([
-				"node",
-				"moleculer-runner",
-				"--instances",
-				"3",
-				"--auto-worker-heap-reserve",
-				"1024",
-				"services"
-			]);
-
-			expect(runner.flags.autoWorkerHeapReserve).toBe(1024);
-		});
-	});
-
-	describe("buildWorkerExecArgv with --auto-worker-heap-reserve", () => {
-		it("should split remaining memory equally across workers", () => {
-			const runner = new MoleculerRunner();
-			runner.flags = { autoWorkerHeapReserve: 1024 };
-			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
-
-			expect(runner.buildWorkerExecArgv(3)).toEqual(["--max-old-space-size=1024"]);
-		});
-
-		it("should override conflicting heap flags from worker-node-args", () => {
-			const runner = new MoleculerRunner();
-			runner.flags = {
-				autoWorkerHeapReserve: 512,
-				workerNodeArgs: "--max-old-space-size=999 --trace-warnings"
-			};
-			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
-
-			expect(runner.buildWorkerExecArgv(2)).toEqual([
-				"--trace-warnings",
-				"--max-old-space-size=1792"
-			]);
-		});
-
-		it("should read reserve from MOLECULER_AUTO_WORKER_HEAP_RESERVE", () => {
-			process.env.MOLECULER_AUTO_WORKER_HEAP_RESERVE = "768";
-			const runner = new MoleculerRunner();
-			runner.flags = {};
-			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(3072);
-
-			expect(runner.buildWorkerExecArgv(3)).toEqual(["--max-old-space-size=768"]);
-		});
-
-		it("should throw when reserve leaves no heap for workers", () => {
-			const runner = new MoleculerRunner();
-			runner.flags = { autoWorkerHeapReserve: 4096 };
-			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
-
-			expect(() => runner.buildWorkerExecArgv(3)).toThrow(/Cannot auto-balance worker heap/);
-		});
 	});
 
 	describe("startWorkers", () => {
@@ -199,19 +138,6 @@ describe("Test MoleculerRunner worker node args", () => {
 			expect(cluster.setupPrimary).toHaveBeenCalledWith({
 				execArgv: [...process.execArgv, "--max-old-space-size=256", "--no-warnings"]
 			});
-		});
-
-		it("should apply auto heap from --auto-worker-heap-reserve", () => {
-			const runner = new MoleculerRunner();
-			runner.flags = { autoWorkerHeapReserve: 1024 };
-			jest.spyOn(runner, "getAvailableMemoryMb").mockReturnValue(4096);
-
-			runner.startWorkers(3);
-
-			expect(cluster.setupPrimary).toHaveBeenCalledWith({
-				execArgv: [...process.execArgv, "--max-old-space-size=1024"]
-			});
-			expect(cluster.fork).toHaveBeenCalledTimes(3);
 		});
 	});
 });


### PR DESCRIPTION
## :memo: Description

Adds ~~two~~ Moleculer Runner option~~s~~ for cluster mode (`--instances`):

1. **`--worker-node-args`** / `MOLECULER_WORKER_NODE_OPTIONS`  
   Pass arbitrary Node.js/V8 CLI flags only to forked workers via `cluster.setupPrimary({ execArgv })`. The primary process is not affected. This avoids putting worker-only flags into global `NODE_OPTIONS`.

2. ~~**`--auto-worker-heap-reserve=<MB>`** / `MOLECULER_AUTO_WORKER_HEAP_RESERVE`  
   Reserve N MB for the primary (supervisor) process, detect available memory (`process.constrainedMemory()` in containers / cgroup, otherwise `os.totalmem()`), and split the remainder equally across workers as `--max-old-space-size`.~~

~~**Precedence:** when `--auto-worker-heap-reserve` is set, it overrides any `--max-old-space-size*` / `--max-old-space-size-percentage*` values from `--worker-node-args`. Other worker args are kept.~~

**Notes for reviewers:**
- With `--instances`, the primary does **not** start a broker — it only forks/restarts workers.
- ~~`--max-old-space-size` is a V8 heap limit, not a hard RSS/container limit.~~
- Same changes are applied to both CJS (`runner.js`) and ESM (`runner-esm.mjs`) runners.

### :dart: Relevant issues

N/A (feature request / enhancement)

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### :scroll: Example code

```bash
# Manual heap limit per worker
moleculer-runner -i 3 --worker-node-args="--max-old-space-size=768" services

# Via env
MOLECULER_WORKER_NODE_OPTIONS="--trace-warnings --max-old-space-size=768" moleculer-runner -i 3 services
```

~~Auto-balance (removed): reserve 1024 MB for primary, split the rest equally~~  
~~`moleculer-runner -i 3 --auto-worker-heap-reserve=1024 services`~~  
~~`MOLECULER_AUTO_WORKER_HEAP_RESERVE=1024 moleculer-runner -i 3 services`~~  
~~`MOLECULER_WORKER_NODE_OPTIONS="--trace-warnings" moleculer-runner -i 3 --auto-worker-heap-reserve=1024 services`~~

## :vertical_traffic_light: How Has This Been Tested?

- [x] **Unit — `test/unit/runner.spec.js`**: parse `--worker-node-args` / `-w`; merge env + CLI; `cluster.setupPrimary({ execArgv })` called for workers ~~; parse `--auto-worker-heap-reserve`; equal heap split; override of conflicting heap flags; invalid reserve error~~
- [x] Locally: `npx jest test/unit/runner.spec.js --coverage=false` (~~17~~ 11 tests passed)

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas