### PR TITLE
fix(runner): create the ESM runner's `require` lazily so the ESM entry point can be bundled

### DIFF
--- a/src/runner-esm.mjs
+++ b/src/runner-esm.mjs
@@ -18,7 +18,14 @@ import kleur from "kleur";
 
 // import.meta.resolve requires --experimental-import-meta-resolve flag: https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaresolvespecifier-parent
 // createRequire is a workaround to allow require.resolve in esm modules: https://stackoverflow.com/a/62499498
-const require = createRequire(import.meta.url);
+// It is created lazily, because `import.meta.url` is not available in every ESM host
+// (e.g. bundled edge runtimes), and calling it at module scope would break the whole
+// `moleculer` ESM entry point, which re-exports this file as `Runner`.
+let _require;
+function getRequire() {
+	if (!_require) _require = createRequire(import.meta.url);
+	return _require;
+}
 
 const stopSignals = [
 	"SIGHUP",
@@ -216,7 +223,7 @@ export default class MoleculerRunner {
 		}
 
 		try {
-			return require.resolve(configPath, resolveOptions);
+			return getRequire().resolve(configPath, resolveOptions);
 		} catch {
 			return null;
 		}


### PR DESCRIPTION
## Problem

`src/runner-esm.mjs` creates its `require` helper at module scope:

```js
const require = createRequire(import.meta.url);
```

That module is not opt-in: `index.mjs` re-exports it as the public `Runner`,

```js
import RunnerESM from "./src/runner-esm.mjs";   // index.mjs:2
export const Runner = RunnerESM;                // index.mjs:22
```

so **every** ESM `import ... from "moleculer"` eagerly evaluates the CLI runner,
including the `createRequire(import.meta.url)` call.

In any ESM host where `import.meta.url` is undefined — notably bundled edge
runtimes — this throws before a single line of user code runs:

```
Uncaught TypeError: The argument 'path' must be a file URL object,
a file URL string, or an absolute path string. Received 'undefined'
  at createRequire (node:module:34:15)
```

### Repro

A Cloudflare Worker that only does `import { ServiceBroker } from "moleculer"`
fails to start with the error above. Today the only workaround is to bypass the
ESM entry point entirely, e.g. in `wrangler.jsonc`:

```jsonc
"alias": { "moleculer": "./node_modules/moleculer/index.js" }
```

which is unpleasant to discover and pins users to the CJS build.

## Fix

`require` is used in exactly one place — `tryConfigPath()` — so it can be created
lazily. Behaviour on Node is unchanged; the module simply becomes importable in
hosts that do not provide `import.meta.url`.

```js
let _require;
function getRequire() {
	if (!_require) _require = createRequire(import.meta.url);
	return _require;
}
```

Nine lines, no API change, no change to the runner's semantics.

## Verification

- `npm run test:esm` passes. This is the meaningful regression test here: it runs
  `bin/moleculer-runner.mjs -c test/esm/moleculer.config.mjs`, and resolving that
  `-c` path goes through `tryConfigPath()` → the lazy `require`. Broker starts,
  `greeter.welcome` returns `Welcome, ESM!`, broker stops cleanly.
- `npx eslint src/runner-esm.mjs` clean.
- Smoke-checked `tryConfigPath()` directly for both the hit and miss branches
  (returns the resolved absolute path / `null`).
- With this patch a Moleculer 0.15.1 `ServiceBroker` boots inside workerd with no
  `alias` workaround — 4 services, 13 middlewares, nested `ctx.call` chains,
  `ctx.emit` and `fastest-validator` all working:

  ```
  INFO BROKER: Moleculer v0.15.1 is starting...
  INFO BROKER: Validator: FastestValidator
  INFO BROKER: Registered 13 middleware(s).
  INFO BROKER: ✔ ServiceBroker with 4 service(s) started successfully
  ```

## Possible follow-up (not in this PR)

Even with this fix, importing `moleculer` still pulls `glob`, `args`, `os` and
`cluster` into the bundle through `Runner`. Moving the runner to its own export
path (`moleculer/runner`) would drop those for everyone who bundles, but that is
a breaking change and deserves its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
