### PR TITLE
test(e2e): fix flaky 'emit event' scenario on Kafka + Local discoverer

### DIFF
--- a/test/e2e/utils.js
+++ b/test/e2e/utils.js
@@ -26,6 +26,28 @@ async function executeScenarios(broker, waitForServices, waitForNodeIDs) {
 		await broker.waitForServices(waitForServices, 30 * 1000);
 	}
 
+	// Registry sync is one-directional: waitForNodes/waitForServices only
+	// guarantee that THIS node sees the remote nodes. With slow transporters
+	// (e.g. Kafka, where INFO propagation takes seconds) the remote nodes may
+	// not know about this node yet, and events they emit towards it in the
+	// meantime are silently dropped. Wait until every remote node reports this
+	// node as available in its own registry.
+	const remoteNodeIDs = broker.registry.nodes
+		.list({ onlyAvailable: true })
+		.map(node => node.id)
+		.filter(nodeID => nodeID !== broker.nodeID);
+	for (const nodeID of remoteNodeIDs) {
+		broker.logger.info(`Waiting for node '${nodeID}' to see this node...`);
+		const nodes = await waitForResult(
+			() => broker.call("$node.list", { onlyAvailable: true }, { nodeID }).catch(() => []),
+			res => res.some(node => node.id === broker.nodeID && node.available),
+			30 * 1000
+		);
+		if (!nodes.some(node => node.id === broker.nodeID && node.available)) {
+			broker.logger.warn(`Node '${nodeID}' still does not see this node.`);
+		}
+	}
+
 	if (
 		!process.env.TRANSPORTER ||
 		process.env.TRANSPORTER == "TCP" ||


### PR DESCRIPTION
## Problem

The `emit event` scenario in the basic E2E suite fails intermittently (~40%) on **Kafka + Local discoverer** combinations — see the failed jobs on #1366 and past master runs. The failure is always the same: `getEmittedEvents` returns `0` even after the 10s `waitForResult` polling.

## Root cause

Not a Kafka transporter bug — a one-directional discovery race in the test harness:

- `executeScenarios()` uses `broker.waitForServices(...)`, which only guarantees that the **supervisor sees node1's services**. Nothing guarantees the reverse: that **node1 already knows about the supervisor**.
- With Kafka, INFO packet propagation takes ~1–1.5s (consumer fetch cycles). Every other transporter delivers it in milliseconds, which is why only Kafka is affected.
- In the failing runs the debug log shows node1 registering the supervisor ~1s **after** the scenario emitted `sample.event`. Node1 receives the event, but when it emits the `$scenario.event.emitted` reply, its registry has no subscriber for it → the event is silently dropped. Since the emit happens exactly once, the 10s polling added earlier cannot recover it.
- Only `Kafka + Local` fails because for non-Local discoverers `executeScenarios()` already sleeps an extra 10s before running scenarios.

Failing run (node1 never logs `Node 'supervisor' connected` before the emit):

```
09:09:31.486 supervisor/BROKER: Emit 'sample.event' event.
09:09:31.496 node1/TRANSIT: Event 'sample.event' received from 'supervisor' node
09:09:31.497 node1/BROKER: Broadcast '$scenario.event.emitted' event.   <-- no remote subscriber, dropped
09:09:32.470 node1/REGISTRY: Node 'supervisor' connected.               <-- 1s too late
```

## Fix

After `waitForNodes`/`waitForServices`, wait until every remote node reports the supervisor as available in its **own** registry (targeted `$node.list` calls) before starting the scenarios. Test-only change, no core code touched.

## Verification

- Reproduced locally with fresh `MOL-basic.*` topics per run (matching a fresh CI job): unfixed version failed on iteration 2 with the exact CI failure signature.
- With the fix: **20/20 consecutive runs green** (Kafka + JSON + Local, fresh topics each iteration).
- The extra wait costs ~1s on Kafka and is a no-op for transporters where the reverse INFO has already arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)